### PR TITLE
Fixed an error in the documentation examples

### DIFF
--- a/docs/advanced/endpoint.md
+++ b/docs/advanced/endpoint.md
@@ -1,4 +1,3 @@
-
 # Advanced Use of EndpointCreator
 
 In FastCRUD, the `EndpointCreator` class simplifies the process of creating standard CRUD endpoints. However, for more advanced use cases, you might want to add custom routes that go beyond the basic CRUD operations. This can be achieved by extending the `EndpointCreator` class.
@@ -8,12 +7,13 @@ In FastCRUD, the `EndpointCreator` class simplifies the process of creating stan
 You can control which CRUD operations are exposed by using `included_methods` and `deleted_methods`. These parameters allow you to specify exactly which CRUD methods should be included or excluded when setting up the router.
 
 ### Using `included_methods`
+
 Using `included_methods` you may define exactly the methods you want to be included.
 
 ```python hl_lines="10"
 # Using crud_router with selective CRUD methods
 my_router = crud_router(
-    session=async_session,
+    session=get_session,
     model=MyModel,
     crud=FastCRUD(MyModel),
     create_schema=CreateMyModel,
@@ -27,12 +27,13 @@ app.include_router(my_router)
 ```
 
 ### Using `deleted_methods`
+
 Using `deleted_methods` you define the methods that will not be included.
 
 ```python hl_lines="10"
 # Using crud_router with selective CRUD methods
 my_router = crud_router(
-    session=async_session,
+    session=get_session,
     model=MyModel,
     crud=FastCRUD(MyModel),
     create_schema=CreateMyModel,
@@ -46,6 +47,7 @@ app.include_router(my_router)
 ```
 
 !!! WARNING
+
         If `included_methods` and `deleted_methods` are both provided, a ValueError will be raised.
 
 ## Extending EndpointCreator
@@ -151,7 +153,7 @@ class MyCustomEndpointCreator(EndpointCreator):
 
 # Use the custom EndpointCreator with crud_router
 my_router = crud_router(
-    session=async_session,
+    session=get_session,
     model=MyModel,
     crud=FastCRUD(MyModel),
     create_schema=CreateMyModel,

--- a/docs/sqlmodel.md
+++ b/docs/sqlmodel.md
@@ -1,4 +1,3 @@
-
 # Using FastCRUD with SQLModel
 
 Since SQLModel is just a combination of SQLAlchemy and Pydantic, the process simplifies as SQLModel combines the model and schema definitions.
@@ -22,7 +21,7 @@ class ItemCreateSchema(SQLModel):
 
 DATABASE_URL = "sqlite+aiosqlite:///./test.db"
 engine = create_async_engine(DATABASE_URL, echo=True)
-session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 ```
 
 Then your schemas
@@ -42,7 +41,7 @@ class ItemCreateSchema(SQLModel):
 
 DATABASE_URL = "sqlite+aiosqlite:///./test.db"
 engine = create_async_engine(DATABASE_URL, echo=True)
-session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 ```
 
 And, finally, your database connection
@@ -62,18 +61,30 @@ class ItemCreateSchema(SQLModel):
 
 DATABASE_URL = "sqlite+aiosqlite:///./test.db"
 engine = create_async_engine(DATABASE_URL, echo=True)
-session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 ```
 
 Use `crud_router` and include it in your `FastAPI` application
 
-```python title="main.py" hl_lines="5-13 15"
+```python title="main.py" hl_lines="17-25 27"
 from fastcrud import FastCRUD, crud_router
 
-app = FastAPI()
+# Database session dependency
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session() as session:
+        yield session
+
+# Create tables before the app start
+async def lifespan(app: FastAPI):
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+
+# FastAPI app
+app = FastAPI(lifespan=lifespan)
 
 item_router = crud_router(
-    session=session,
+    session=get_session,
     model=Item,
     crud=FastCRUD(Item),
     create_schema=ItemSchema,

--- a/docs/usage/crud.md
+++ b/docs/usage/crud.md
@@ -1,9 +1,9 @@
-
 # Using FastCRUD for Enhanced CRUD Operations
 
 FastCRUD is a versatile tool for handling CRUD (Create, Read, Update, Delete) operations in FastAPI applications with SQLAlchemy models. It leverages Pydantic schemas for data validation and serialization, offering a streamlined approach to database interactions.
 
 ## Key Features
+
 - Simplified CRUD operations with SQLAlchemy models.
 - Data validation and serialization using Pydantic.
 - Support for complex queries including joins and pagination.
@@ -11,6 +11,7 @@ FastCRUD is a versatile tool for handling CRUD (Create, Read, Update, Delete) op
 ## Getting Started
 
 ### Step 1: Define Models and Schemas
+
 Define your SQLAlchemy models and Pydantic schemas for data representation.
 
 ```python
@@ -18,6 +19,7 @@ Define your SQLAlchemy models and Pydantic schemas for data representation.
 ```
 
 ### Step 2: Initialize FastCRUD
+
 Create a FastCRUD instance for your model to handle CRUD operations.
 
 ```python
@@ -38,7 +40,8 @@ new_record = await my_model_crud.create(db_session, create_schema_instance)
 
 More on available methods below.
 
-___
+---
+
 ## Understanding FastCRUD Methods
 
 FastCRUD offers a comprehensive suite of methods for CRUD operations, each designed to handle different aspects of database interactions efficiently.
@@ -47,7 +50,7 @@ FastCRUD offers a comprehensive suite of methods for CRUD operations, each desig
 
 ```python
 create(
-    db: AsyncSession, 
+    db: AsyncSession,
     object: CreateSchemaType
 ) -> ModelType
 ```
@@ -63,7 +66,7 @@ new_item = await item_crud.create(db, ItemCreateSchema(name="New Item"))
 
 ```python
 get(
-    db: AsyncSession, 
+    db: AsyncSession,
     schema_to_select: Optional[type[BaseModel]] = None,
     **kwargs: Any
 ) -> Optional[dict]
@@ -80,7 +83,7 @@ item = await item_crud.get(db, id=item_id)
 
 ```python
 exists(
-    db: AsyncSession, 
+    db: AsyncSession,
     **kwargs: Any
 ) -> bool
 ```
@@ -96,7 +99,7 @@ exists = await item_crud.exists(db, name="Existing Item")
 
 ```python
 count(
-    db: AsyncSession, 
+    db: AsyncSession,
     **kwargs: Any
 ) -> int
 ```
@@ -112,15 +115,15 @@ count = await item_crud.count(db, category="Books")
 
 ```python
 get_multi(
-    db: AsyncSession, 
-    offset: int = 0, 
-    limit: int = 100, 
-    schema_to_select: Optional[type[BaseModel]] = None, 
-    sort_columns: Optional[Union[str, list[str]]] = None, 
-    sort_orders: Optional[Union[str, list[str]]] = None, 
-    return_as_model: bool = False, 
+    db: AsyncSession,
+    offset: int = 0,
+    limit: int = 100,
+    schema_to_select: Optional[type[BaseModel]] = None,
+    sort_columns: Optional[Union[str, list[str]]] = None,
+    sort_orders: Optional[Union[str, list[str]]] = None,
+    return_as_model: bool = False,
     **kwargs: Any
-) -> dict[str, Any]</
+) -> dict[str, Any]
 ```
 
 **Purpose**: To fetch multiple records with optional sorting, pagination, and model conversion.  
@@ -134,8 +137,8 @@ items = await item_crud.get_multi(db, offset=10, limit=5)
 
 ```python
 update(
-    db: AsyncSession, 
-    object: Union[UpdateSchemaType, dict[str, Any]], 
+    db: AsyncSession,
+    object: Union[UpdateSchemaType, dict[str, Any]],
     **kwargs: Any
 ) -> None
 ```
@@ -151,8 +154,8 @@ await item_crud.update(db, ItemUpdateSchema(description="Updated"), id=item_id)
 
 ```python
 delete(
-    db: AsyncSession, 
-    db_row: Optional[Row] = None, 
+    db: AsyncSession,
+    db_row: Optional[Row] = None,
     **kwargs: Any
 ) -> None
 ```
@@ -168,7 +171,7 @@ await item_crud.delete(db, id=item_id)
 
 ```python
 db_delete(
-    db: AsyncSession, 
+    db: AsyncSession,
     **kwargs: Any
 ) -> None
 ```
@@ -180,7 +183,8 @@ db_delete(
 await item_crud.db_delete(db, id=item_id)
 ```
 
-___
+---
+
 ## Advanced Methods for Complex Queries and Joins
 
 FastCRUD extends its functionality with advanced methods tailored for complex query operations and handling joins. These methods cater to specific use cases where more sophisticated data retrieval and manipulation are required.
@@ -189,13 +193,13 @@ FastCRUD extends its functionality with advanced methods tailored for complex qu
 
 ```python
 get_multi(
-    db: AsyncSession, 
-    offset: int = 0, 
-    limit: int = 100, 
-    schema_to_select: Optional[type[BaseModel]] = None, 
-    sort_columns: Optional[Union[str, list[str]]] = None, 
-    sort_orders: Optional[Union[str, list[str]]] = None, 
-    return_as_model: bool = False, 
+    db: AsyncSession,
+    offset: int = 0,
+    limit: int = 100,
+    schema_to_select: Optional[type[BaseModel]] = None,
+    sort_columns: Optional[Union[str, list[str]]] = None,
+    sort_orders: Optional[Union[str, list[str]]] = None,
+    return_as_model: bool = False,
     **kwargs: Any
 ) -> dict[str, Any]
 ```
@@ -211,12 +215,12 @@ items = await item_crud.get_multi(db, offset=0, limit=10, sort_columns=['name'],
 
 ```python
 get_joined(
-    db: AsyncSession, 
-    join_model: type[ModelType], 
-    join_prefix: Optional[str] = None, 
-    join_on: Optional[Union[Join, None]] = None, 
-    schema_to_select: Optional[type[BaseModel]] = None, 
-    join_schema_to_select: Optional[type[BaseModel]] = None, 
+    db: AsyncSession,
+    join_model: type[ModelType],
+    join_prefix: Optional[str] = None,
+    join_on: Optional[Union[Join, None]] = None,
+    schema_to_select: Optional[type[BaseModel]] = None,
+    join_schema_to_select: Optional[type[BaseModel]] = None,
     join_type: str = "left", **kwargs: Any
 ) -> Optional[dict[str, Any]]
 ```
@@ -226,10 +230,10 @@ get_joined(
 
 ```python
 order_details = await order_crud.get_joined(
-    db, 
-    join_model=Customer, 
-    schema_to_select=OrderSchema, 
-    join_schema_to_select=CustomerSchema, 
+    db,
+    join_model=Customer,
+    schema_to_select=OrderSchema,
+    join_schema_to_select=CustomerSchema,
     id=order_id
 )
 ```
@@ -238,18 +242,18 @@ order_details = await order_crud.get_joined(
 
 ```python
 get_multi_joined(
-    db: AsyncSession, 
-    join_model: type[ModelType], 
-    join_prefix: Optional[str] = None, 
-    join_on: Optional[Join] = None, 
-    schema_to_select: Optional[type[BaseModel]] = None, 
-    join_schema_to_select: Optional[type[BaseModel]] = None, 
-    join_type: str = "left", 
-    offset: int = 0, 
-    limit: int = 100, 
-    sort_columns: Optional[Union[str, list[str]]] = None, 
-    sort_orders: Optional[Union[str, list[str]]] = None, 
-    return_as_model: bool = False, 
+    db: AsyncSession,
+    join_model: type[ModelType],
+    join_prefix: Optional[str] = None,
+    join_on: Optional[Join] = None,
+    schema_to_select: Optional[type[BaseModel]] = None,
+    join_schema_to_select: Optional[type[BaseModel]] = None,
+    join_type: str = "left",
+    offset: int = 0,
+    limit: int = 100,
+    sort_columns: Optional[Union[str, list[str]]] = None,
+    sort_orders: Optional[Union[str, list[str]]] = None,
+    return_as_model: bool = False,
     **kwargs: Any
 ) -> dict[str, Any]
 ```
@@ -259,11 +263,11 @@ get_multi_joined(
 
 ```python
 orders = await order_crud.get_multi_joined(
-    db, 
-    join_model=Customer, 
-    offset=0, 
-    limit=5, 
-    schema_to_select=OrderSchema, 
+    db,
+    join_model=Customer,
+    offset=0,
+    limit=5,
+    schema_to_select=OrderSchema,
     join_schema_to_select=CustomerSchema
 )
 ```
@@ -272,12 +276,12 @@ orders = await order_crud.get_multi_joined(
 
 ```python
 get_multi_by_cursor(
-    db: AsyncSession, 
-    cursor: Any = None, 
-    limit: int = 100, 
-    schema_to_select: Optional[type[BaseModel]] = None, 
-    sort_column: str = "id", 
-    sort_order: str = "asc", 
+    db: AsyncSession,
+    cursor: Any = None,
+    limit: int = 100,
+    schema_to_select: Optional[type[BaseModel]] = None,
+    sort_column: str = "id",
+    sort_order: str = "asc",
     **kwargs: Any
 ) -> dict[str, Any]
 ```
@@ -287,13 +291,14 @@ get_multi_by_cursor(
 
 ```python
 paginated_items = await item_crud.get_multi_by_cursor(
-    db, 
-    cursor=last_cursor, 
-    limit=10, 
-    sort_column='created_at', 
+    db,
+    cursor=last_cursor,
+    limit=10,
+    sort_column='created_at',
     sort_order='desc'
 )
 ```
 
 ## Error Handling
+
 FastCRUD provides mechanisms to handle common database errors, ensuring robust API behavior.


### PR DESCRIPTION
In previous version all the endpoints have mandatory `local_kw` query parameter. And it was confusing..

It was solved by adding `get_session` dependency.
Also, added code what creates database tables before the app's start

# Pull Request Template for FastCRUD

## Description
This PR fixes the problem, explained in [issue 12](https://github.com/igorbenav/fastcrud/issues/12).

## Changes
Added `get_session` dependency in documentation examples.
Additionally, I added code that creates database tables before the app's start. I think it's better than new users can just run example and see results without any errors

## Tests
Еhese changes do not affect the library code. Only documentation

## Checklist
- [+] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [+] My code follows the code style of this project.
- [+] I have added necessary documentation (if appropriate).
- [+] I have added tests that cover my changes (if applicable).
- [+] All new and existing tests passed.

## Additional Notes
My formatter forced me to fix some markup problems in files (mostly extra spaces). If you don't like it, I can revert it
