### PR TITLE
Crud enhancement

### DIFF
--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -1,0 +1,70 @@
+
+# Advanced Use of FastCRUD
+
+FastCRUD offers a flexible and powerful approach to handling CRUD operations in FastAPI applications, leveraging the SQLAlchemy ORM. Beyond basic CRUD functionality, FastCRUD provides advanced features like `allow_multiple` for updates and deletes, and support for advanced filters (e.g., less than, greater than). These features enable more complex and fine-grained data manipulation and querying capabilities.
+
+## Allow Multiple Updates and Deletes
+
+One of FastCRUD's advanced features is the ability to update or delete multiple records at once based on specified conditions. This is particularly useful for batch operations where you need to modify or remove several records that match certain criteria.
+
+### Updating Multiple Records
+
+To update multiple records, you can set the `allow_multiple=True` parameter in the `update` method. This allows FastCRUD to apply the update to all records matching the given filters.
+
+```python
+# Assuming setup for FastCRUD instance `item_crud` and SQLAlchemy async session `db`
+
+# Update all items priced below $10 to a new price
+await item_crud.update(
+    db=db,
+    object={"price": 9.99},
+    allow_multiple=True,
+    price__lt=10
+)
+```
+
+### Deleting Multiple Records
+
+Similarly, you can delete multiple records by using the `allow_multiple=True` parameter in the `delete` or `db_delete` method, depending on whether you're performing a soft or hard delete.
+
+```python
+# Soft delete all items not sold in the last year
+await item_crud.delete(
+    db=db,
+    allow_multiple=True,
+    last_sold__lt=datetime.datetime.now() - datetime.timedelta(days=365)
+)
+```
+
+## Advanced Filters
+
+FastCRUD supports advanced filtering options, allowing you to query records using operators such as greater than (`__gt`), less than (`__lt`), and their inclusive counterparts (`__gte`, `__lte`). These filters can be used in any method that retrieves or operates on records, including `get`, `get_multi`, `exists`, `count`, `update`, and `delete`.
+
+### Using Advanced Filters
+
+The following examples demonstrate how to use advanced filters for querying and manipulating data:
+
+#### Fetching Records with Advanced Filters
+
+```python
+# Fetch items priced between $5 and $20
+items = await item_crud.get_multi(
+    db=db,
+    price__gte=5,
+    price__lte=20
+)
+```
+
+#### Counting Records
+
+```python
+# Count items added in the last month
+item_count = await item_crud.count(
+    db=db,
+    added_at__gte=datetime.datetime.now() - datetime.timedelta(days=30)
+)
+```
+
+## Conclusion
+
+The advanced features of FastCRUD, such as `allow_multiple` and support for advanced filters, empower developers to efficiently manage database records with complex conditions. By leveraging these capabilities, you can build more dynamic, robust, and scalable FastAPI applications that effectively interact with your data model.

--- a/docs/advanced/endpoint.md
+++ b/docs/advanced/endpoint.md
@@ -165,6 +165,70 @@ my_router = crud_router(
 app.include_router(my_router)
 ```
 
+## Custom Soft Delete
+
+To implement custom soft delete columns using `EndpointCreator` and `crud_router` in FastCRUD, you need to specify the names of the columns used for indicating deletion status and the deletion timestamp in your model. FastCRUD provides flexibility in handling soft deletes by allowing you to configure these column names directly when setting up CRUD operations or API endpoints.
+
+Here's how to specify custom soft delete columns when utilizing `EndpointCreator` and `crud_router`:
+
+### Defining Models with Custom Soft Delete Columns
+
+First, ensure your SQLAlchemy model is equipped with the custom soft delete columns. Here's an example model with custom columns for soft deletion:
+
+```python
+from sqlalchemy import Column, Integer, String, DateTime, Boolean
+from sqlalchemy.ext.declarative import declarative_base
+from datetime import datetime
+
+Base = declarative_base()
+
+class MyModel(Base):
+    __tablename__ = 'my_model'
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    archived = Column(Boolean, default=False)  # Custom soft delete column
+    archived_at = Column(DateTime)  # Custom timestamp column for soft delete
+```
+
+### Using `EndpointCreator` and `crud_router` with Custom Soft Delete Columns
+
+When initializing `crud_router` or creating a custom `EndpointCreator`, you can pass the names of your custom soft delete columns through the `FastCRUD` initialization. This informs FastCRUD which columns to check and update for soft deletion operations.
+
+Here's an example of using `crud_router` with custom soft delete columns:
+
+```python
+from fastapi import FastAPI
+from fastcrud import FastCRUD, crud_router
+from sqlalchemy.ext.asyncio import AsyncSession
+
+app = FastAPI()
+
+# Assuming async_session is your AsyncSession generator
+# and MyModel is your SQLAlchemy model
+
+# Initialize FastCRUD with custom soft delete columns
+my_model_crud = FastCRUD(MyModel,
+                         is_deleted_column='archived',  # Custom 'is_deleted' column name
+                         deleted_at_column='archived_at'  # Custom 'deleted_at' column name
+                        )
+
+# Setup CRUD router with the FastCRUD instance
+app.include_router(crud_router(
+    session=async_session,
+    model=MyModel,
+    crud=my_model_crud,
+    create_schema=CreateMyModelSchema,
+    update_schema=UpdateMyModelSchema,
+    delete_schema=DeleteMyModelSchema,
+    path="/mymodel",
+    tags=["MyModel"]
+))
+```
+
+This setup ensures that the soft delete functionality within your application utilizes the `archived` and `archived_at` columns for marking records as deleted, rather than the default `is_deleted` and `deleted_at` fields.
+
+By specifying custom column names for soft deletion, you can adapt FastCRUD to fit the design of your database models, providing a flexible solution for handling deleted records in a way that best suits your application's needs.
+
 ## Conclusion
 
 The `EndpointCreator` class in FastCRUD offers flexibility and control over CRUD operations and custom endpoint creation. By extending this class or using the `included_methods` and `deleted_methods` parameters, you can tailor your API's functionality to your specific requirements, ensuring a more customizable and streamlined experience.

--- a/docs/advanced/overview.md
+++ b/docs/advanced/overview.md
@@ -1,0 +1,28 @@
+# Advanced Usage Overview
+
+The Advanced section of our documentation delves into the sophisticated capabilities and features of our application, tailored for users looking to leverage advanced functionalities. This part of our guide aims to unlock deeper insights and efficiencies through more complex use cases and configurations.
+
+## Key Topics
+
+### 1. Advanced Filtering and Searching
+Explore how to implement advanced filtering and searching capabilities in your application. This guide covers the use of comparison operators (such as greater than, less than, etc.), pattern matching, and more to perform complex queries.
+
+- [Advanced Filtering Guide](crud.md#advanced-filters)
+
+### 2. Bulk Operations and Batch Processing
+Learn how to efficiently handle bulk operations and batch processing. This section provides insights into performing mass updates, deletes, and inserts, optimizing performance for large datasets.
+
+- [Bulk Operations Guide](crud.md#allow-multiple-updates-and-deletes)
+
+### 3. Soft Delete Mechanisms and Strategies
+Understand the implementation of soft delete mechanisms within our application. This guide covers configuring and using custom columns for soft deletes, restoring deleted records, and filtering queries to exclude soft-deleted entries.
+
+- [Soft Delete Strategies Guide](endpoint.md#custom-soft-delete)
+
+### 4. Advanced Use of EndpointCreator and crud_router
+This topic extends the use of `EndpointCreator` and `crud_router` for advanced endpoint management, including creating custom routes, selective method exposure, and integrating soft delete functionalities.
+
+- [Advanced Endpoint Management Guide](endpoint.md#advanced-use-of-endpointcreator)
+
+## Prerequisites
+Advanced usage assumes a solid understanding of the basic features and functionalities of our application. Knowledge of FastAPI, SQLAlchemy, and Pydantic is highly recommended to fully grasp the concepts discussed.

--- a/docs/usage/crud.md
+++ b/docs/usage/crud.md
@@ -65,8 +65,9 @@ new_item = await item_crud.create(db, ItemCreateSchema(name="New Item"))
 get(
     db: AsyncSession, 
     schema_to_select: Optional[type[BaseModel]] = None,
+    return_as_model: bool = False,
     **kwargs: Any
-) -> Optional[dict]
+) -> Optional[Union[dict, BaseModel]]
 ```
 
 **Purpose**: To fetch a single record based on filters, with an option to select specific columns using a Pydantic schema.  
@@ -136,6 +137,7 @@ items = await item_crud.get_multi(db, offset=10, limit=5)
 update(
     db: AsyncSession, 
     object: Union[UpdateSchemaType, dict[str, Any]], 
+    allow_multiple: bool = False,
     **kwargs: Any
 ) -> None
 ```
@@ -153,6 +155,7 @@ await item_crud.update(db, ItemUpdateSchema(description="Updated"), id=item_id)
 delete(
     db: AsyncSession, 
     db_row: Optional[Row] = None, 
+    allow_multiple: bool = False,
     **kwargs: Any
 ) -> None
 ```
@@ -169,6 +172,7 @@ await item_crud.delete(db, id=item_id)
 ```python
 db_delete(
     db: AsyncSession, 
+    allow_multiple: bool = False,
     **kwargs: Any
 ) -> None
 ```
@@ -217,7 +221,8 @@ get_joined(
     join_on: Optional[Union[Join, None]] = None, 
     schema_to_select: Optional[type[BaseModel]] = None, 
     join_schema_to_select: Optional[type[BaseModel]] = None, 
-    join_type: str = "left", **kwargs: Any
+    join_type: str = "left", 
+    **kwargs: Any
 ) -> Optional[dict[str, Any]]
 ```
 

--- a/fastcrud/endpoint/crud_router.py
+++ b/fastcrud/endpoint/crud_router.py
@@ -30,6 +30,8 @@ def crud_router(
     included_methods: Optional[list[str]] = None,
     deleted_methods: Optional[list[str]] = None,
     endpoint_creator: Optional[Type[EndpointCreator]] = None,
+    is_deleted_column: str = "is_deleted",
+    deleted_at_column: str = "deleted_at",
 ) -> APIRouter:
     """
     Creates and configures a FastAPI router with CRUD endpoints for a given model.
@@ -57,6 +59,8 @@ def crud_router(
         included_methods: Optional list of CRUD methods to include. If None, all methods are included.
         deleted_methods: Optional list of CRUD methods to exclude.
         endpoint_creator: Optional custom class derived from EndpointCreator for advanced customization.
+        is_deleted_column: Optional column name to use for indicating a soft delete. Defaults to "is_deleted".
+        deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to "deleted_at".
 
     Returns:
         Configured APIRouter instance with the CRUD endpoints.
@@ -210,6 +214,8 @@ def crud_router(
         delete_schema=delete_schema,
         path=path,
         tags=tags,
+        is_deleted_column=is_deleted_column,
+        deleted_at_column=deleted_at_column,
     )
 
     endpoint_creator_instance.add_routes_to_router(

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -35,6 +35,8 @@ class EndpointCreator:
         include_in_schema: Whether to include the created endpoints in the OpenAPI schema.
         path: Base path for the CRUD endpoints.
         tags: List of tags for grouping endpoints in the documentation.
+        is_deleted_column: Optional column name to use for indicating a soft delete. Defaults to "is_deleted".
+        deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to "deleted_at".
 
     Raises:
         ValueError: If both `included_methods` and `deleted_methods` are provided.
@@ -122,10 +124,16 @@ class EndpointCreator:
         delete_schema: Optional[Type[DeleteSchemaType]] = None,
         path: str = "",
         tags: Optional[list[str]] = None,
+        is_deleted_column: str = "is_deleted",
+        deleted_at_column: str = "deleted_at",
     ) -> None:
         self.primary_key_name = _get_primary_key(model)
         self.session = session
-        self.crud = crud
+        self.crud = crud or FastCRUD(
+            model=model,
+            is_deleted_column=is_deleted_column,
+            deleted_at_column=deleted_at_column,
+        )
         self.model = model
         self.create_schema = create_schema
         self.update_schema = update_schema
@@ -134,6 +142,8 @@ class EndpointCreator:
         self.path = path
         self.tags = tags or []
         self.router = APIRouter()
+        self.is_deleted_column = is_deleted_column
+        self.deleted_at_column = deleted_at_column
 
     def _create_item(self):
         """Creates an endpoint for creating items in the database."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,9 @@ nav:
     - Automatic Endpoints: usage/endpoint.md
     - CRUD Utilities: usage/crud.md
   - Advanced:
+    - Overview: advanced/overview.md
     - Custom Endpoints: advanced/endpoint.md
+    - Advanced CRUD Usage: advanced/crud.md
   - API Reference: 
     - Overview: api/overview.md
     - FastCRUD: api/fastcrud.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastcrud"
-version = "0.4.0"
+version = "0.5.0"
 description = "FastCRUD is a Python package for FastAPI, offering robust async CRUD operations and flexible endpoint creation utilities."
 authors = ["Igor Benav <igor.magalhaes.r@gmail.com>"]
 license = "MIT"

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -40,6 +40,12 @@ class CreateSchemaTest(BaseModel):
     tier_id: int
 
 
+class ReadSchemaTest(BaseModel):
+    id: int
+    name: str
+    tier_id: int
+
+
 class UpdateSchemaTest(BaseModel):
     name: str
 
@@ -99,6 +105,7 @@ def test_data() -> list[dict]:
         {"id": 8, "name": "Hannah", "tier_id": 2},
         {"id": 9, "name": "Ivan", "tier_id": 1},
         {"id": 10, "name": "Judy", "tier_id": 2},
+        {"id": 11, "name": "Alice", "tier_id": 1},
     ]
 
 
@@ -120,6 +127,11 @@ def tier_model():
 @pytest.fixture
 def create_schema():
     return CreateSchemaTest
+
+
+@pytest.fixture
+def read_schema():
+    return ReadSchemaTest
 
 
 @pytest.fixture

--- a/tests/sqlalchemy/crud/test_count.py
+++ b/tests/sqlalchemy/crud/test_count.py
@@ -34,3 +34,70 @@ async def test_count_no_matching_records(async_session, test_model):
     count = await crud.count(async_session, **non_existent_filter)
 
     assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_count_with_advanced_filters(async_session, test_model, test_data):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    count_gt = await crud.count(async_session, tier_id__gt=1)
+    assert count_gt == len([item for item in test_data if item["tier_id"] > 1])
+
+    count_lt = await crud.count(async_session, tier_id__lt=2)
+    assert count_lt == len([item for item in test_data if item["tier_id"] < 2])
+
+    count_ne = await crud.count(async_session, name__ne=test_data[0]["name"])
+    assert count_ne == len(test_data) - 1
+
+
+@pytest.mark.asyncio
+async def test_update_multiple_records_allow_multiple(
+    async_session, test_model, test_data
+):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    await crud.update(
+        async_session, {"name": "UpdatedName"}, allow_multiple=True, tier_id=1
+    )
+    updated_count = await crud.count(async_session, name="UpdatedName")
+    expected_count = len([item for item in test_data if item["tier_id"] == 1])
+
+    assert updated_count == expected_count
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_custom_columns(async_session, test_model, test_data):
+    crud = FastCRUD(
+        test_model,
+        is_deleted_column="custom_is_deleted",
+        deleted_at_column="custom_deleted_at",
+    )
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    existing_record = await crud.get(async_session, id=test_data[0]["id"])
+    assert existing_record is not None, "Record should exist before deletion"
+
+    await crud.delete(async_session, id=test_data[0]["id"], allow_multiple=False)
+
+    deleted_record = await crud.get(async_session, id=test_data[0]["id"])
+
+    if deleted_record is None:
+        assert True, "Record is considered 'deleted' and is not fetched by default"
+    else:
+        assert (
+            deleted_record.get("custom_is_deleted") is True
+        ), "Record should be marked as deleted"
+        assert (
+            "custom_deleted_at" in deleted_record
+            and deleted_record["custom_deleted_at"] is not None
+        ), "Deletion timestamp should be set"

--- a/tests/sqlalchemy/crud/test_delete.py
+++ b/tests/sqlalchemy/crud/test_delete.py
@@ -53,3 +53,55 @@ async def test_delete_hard_delete_as_fallback(
         select(tier_model).where(tier_model.id == some_existing_id)
     )
     assert hard_deleted_record.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_delete_multiple_records(async_session, test_data, test_model):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+    with pytest.raises(Exception):
+        await crud.delete(db=async_session, allow_multiple=False, tier_id=1)
+
+
+@pytest.mark.asyncio
+async def test_get_with_advanced_filters(async_session, test_data, test_model):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+    records = await crud.get_multi(db=async_session, id__gt=5)
+    for record in records["data"]:
+        assert record["id"] > 5, "All fetched records should have 'id' greater than 5"
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_with_custom_columns(async_session, test_data, test_model):
+    crud = FastCRUD(
+        test_model, is_deleted_column="is_deleted", deleted_at_column="deleted_at"
+    )
+    some_existing_id = test_data[0]["id"]
+
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    await crud.delete(db=async_session, id=some_existing_id, allow_multiple=False)
+
+    deleted_record = await async_session.execute(
+        select(test_model)
+        .where(test_model.id == some_existing_id)
+        .where(getattr(test_model, "is_deleted") is True)
+    )
+    deleted_record = deleted_record.scalar_one_or_none()
+
+    assert deleted_record is not None, "Record should exist after soft delete"
+    assert (
+        getattr(deleted_record, "is_deleted") is True
+    ), "Record should be marked as soft deleted"
+    assert (
+        getattr(deleted_record, "deleted_at") is not None
+    ), "Record should have a deletion timestamp"

--- a/tests/sqlalchemy/crud/test_delete.py
+++ b/tests/sqlalchemy/crud/test_delete.py
@@ -94,13 +94,13 @@ async def test_soft_delete_with_custom_columns(async_session, test_data, test_mo
     deleted_record = await async_session.execute(
         select(test_model)
         .where(test_model.id == some_existing_id)
-        .where(getattr(test_model, "is_deleted") is True)
+        .where(getattr(test_model, "is_deleted") == True)  # noqa
     )
     deleted_record = deleted_record.scalar_one_or_none()
 
     assert deleted_record is not None, "Record should exist after soft delete"
     assert (
-        getattr(deleted_record, "is_deleted") is True
+        getattr(deleted_record, "is_deleted") == True  # noqa
     ), "Record should be marked as soft deleted"
     assert (
         getattr(deleted_record, "deleted_at") is not None

--- a/tests/sqlalchemy/crud/test_exists.py
+++ b/tests/sqlalchemy/crud/test_exists.py
@@ -21,3 +21,32 @@ async def test_exists_record_not_found(async_session, test_model):
     exists = await crud.exists(async_session, **non_existent_filter)
 
     assert exists is False
+
+
+@pytest.mark.asyncio
+async def test_exists_with_advanced_filters(async_session, test_model, test_data):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+    exists_gt = await crud.exists(db=async_session, id__gt=1)
+    assert exists_gt is True, "Should find records with ID greater than 1"
+
+    advanced_filter_lt = {"id__lt": max([d["id"] for d in test_data])}
+    exists_lt = await crud.exists(async_session, **advanced_filter_lt)
+    assert exists_lt is True, "Should find records with ID less than the max ID"
+
+
+@pytest.mark.asyncio
+async def test_exists_multiple_records_match(async_session, test_model, test_data):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    duplicate_tier_id = test_data[0]["tier_id"]
+    crud = FastCRUD(test_model)
+    exists = await crud.exists(async_session, tier_id=duplicate_tier_id)
+    assert (
+        exists is True
+    ), "Should return True if multiple records match the filter criteria"

--- a/tests/sqlalchemy/crud/test_get.py
+++ b/tests/sqlalchemy/crud/test_get.py
@@ -1,4 +1,6 @@
 import pytest
+from pydantic import BaseModel
+
 from fastcrud.crud.fast_crud import FastCRUD
 from ...sqlalchemy.conftest import ModelTest
 from ...sqlalchemy.conftest import CreateSchemaTest
@@ -52,3 +54,62 @@ async def test_get_selecting_columns(async_session, test_data):
 
     assert fetched_record is not None
     assert "name" in fetched_record
+
+
+@pytest.mark.asyncio
+async def test_get_with_advanced_filters(async_session, test_data):
+    for item in test_data:
+        async_session.add(ModelTest(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    advanced_filter = {"id__gt": 1}
+    fetched_record_gt = await crud.get(async_session, **advanced_filter)
+
+    assert fetched_record_gt is not None
+    assert fetched_record_gt["id"] > 1, "Should fetch a record with ID greater than 1"
+
+    ne_filter = {"name__ne": test_data[0]["name"]}
+    fetched_record_ne = await crud.get(async_session, **ne_filter)
+
+    assert fetched_record_ne is not None
+    assert (
+        fetched_record_ne["name"] != test_data[0]["name"]
+    ), "Should fetch a record with a different name"
+
+
+@pytest.mark.asyncio
+async def test_get_with_schema_selecting_specific_columns(async_session, test_data):
+    async_session.add(ModelTest(**test_data[0]))
+    await async_session.commit()
+
+    class PartialSchema(BaseModel):
+        name: str
+
+    crud = FastCRUD(ModelTest)
+    fetched_record = await crud.get(
+        async_session, schema_to_select=PartialSchema, id=test_data[0]["id"]
+    )
+
+    assert fetched_record is not None
+    assert (
+        "name" in fetched_record and "tier_id" not in fetched_record
+    ), "Should only fetch the 'name' column based on the PartialSchema"
+
+
+@pytest.mark.asyncio
+async def test_get_return_as_model_instance(async_session, test_data, read_schema):
+    async_session.add(ModelTest(**test_data[0]))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    fetched_record = await crud.get(
+        async_session,
+        return_as_model=True,
+        schema_to_select=read_schema,
+        id=test_data[0]["id"],
+    )
+
+    assert isinstance(
+        fetched_record, read_schema
+    ), "The fetched record should be an instance of the ReadSchemaTest Pydantic model"

--- a/tests/sqlalchemy/crud/test_get_joined.py
+++ b/tests/sqlalchemy/crud/test_get_joined.py
@@ -1,7 +1,12 @@
 import pytest
 from sqlalchemy import and_
 from fastcrud.crud.fast_crud import FastCRUD
-from ...sqlalchemy.conftest import ModelTest, TierModel, CreateSchemaTest, TierSchemaTest
+from ...sqlalchemy.conftest import (
+    ModelTest,
+    TierModel,
+    CreateSchemaTest,
+    TierSchemaTest,
+)
 
 
 @pytest.mark.asyncio
@@ -133,3 +138,39 @@ async def test_get_joined_with_filters(async_session, test_data, test_data_tier)
 
     assert result is not None
     assert result["name"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_update_multiple_records_allow_multiple(
+    async_session, test_model, test_data
+):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+    await crud.update(
+        db=async_session,
+        object={"name": "Updated Name"},
+        allow_multiple=True,
+        name="Alice",
+    )
+
+    updated_records = await crud.get_multi(db=async_session, name="Updated Name")
+    assert (
+        len(updated_records["data"]) > 1
+    ), "Should update multiple records when allow_multiple is True"
+
+
+@pytest.mark.asyncio
+async def test_count_with_advanced_filters(async_session, test_model, test_data):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+    count_gt = await crud.count(async_session, id__gt=1)
+    assert count_gt > 0, "Should count records with ID greater than 1"
+
+    count_lt = await crud.count(async_session, id__lt=10)
+    assert count_lt > 0, "Should count records with ID less than 10"

--- a/tests/sqlalchemy/crud/test_get_multi_by_cursor.py
+++ b/tests/sqlalchemy/crud/test_get_multi_by_cursor.py
@@ -86,3 +86,55 @@ async def test_get_multi_by_cursor_edge_cases(async_session, test_data):
     zero_limit_result = await crud.get_multi_by_cursor(db=async_session, limit=0)
     assert len(zero_limit_result["data"]) == 0
     assert zero_limit_result["next_cursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_multi_by_cursor_with_advanced_filters(async_session, test_data):
+    for item in test_data:
+        async_session.add(ModelTest(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    advanced_filter_gt = await crud.get_multi_by_cursor(
+        db=async_session, limit=5, id__gt=5
+    )
+
+    assert len(advanced_filter_gt["data"]) <= 5
+    assert all(
+        item["id"] > 5 for item in advanced_filter_gt["data"]
+    ), "All fetched records should have ID greater than 5"
+
+    advanced_filter_lt = await crud.get_multi_by_cursor(
+        db=async_session, limit=5, id__lt=5
+    )
+    assert (
+        len(advanced_filter_lt["data"]) <= 5
+    ), "Should correctly paginate records with ID less than 5"
+
+
+@pytest.mark.asyncio
+async def test_get_multi_by_cursor_pagination_integrity(async_session, test_data):
+    for item in test_data:
+        async_session.add(ModelTest(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    first_batch = await crud.get_multi_by_cursor(db=async_session, limit=5)
+
+    await crud.update(
+        db=async_session,
+        object={"name": "Updated Name"},
+        allow_multiple=True,
+        name="SpecificName",
+    )
+
+    second_batch = await crud.get_multi_by_cursor(
+        db=async_session, cursor=first_batch["next_cursor"], limit=5
+    )
+
+    assert (
+        len(second_batch["data"]) == 5
+    ), "Pagination should fetch the correct number of records despite updates"
+    assert (
+        first_batch["data"][-1]["id"] < second_batch["data"][0]["id"]
+    ), "Pagination should maintain order across batches"

--- a/tests/sqlalchemy/crud/test_get_multi_joined.py
+++ b/tests/sqlalchemy/crud/test_get_multi_joined.py
@@ -1,6 +1,12 @@
 import pytest
 from fastcrud.crud.fast_crud import FastCRUD
-from ...sqlalchemy.conftest import ModelTest, TierModel, CreateSchemaTest, TierSchemaTest
+from ...sqlalchemy.conftest import (
+    ModelTest,
+    TierModel,
+    CreateSchemaTest,
+    TierSchemaTest,
+    ReadSchemaTest,
+)
 
 
 @pytest.mark.asyncio
@@ -141,6 +147,14 @@ async def test_get_multi_joined_return_model(async_session, test_data, test_data
 
 @pytest.mark.asyncio
 async def test_get_multi_joined_no_results(async_session, test_data, test_data_tier):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    await async_session.commit()
+
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
     crud = FastCRUD(ModelTest)
     result = await crud.get_multi_joined(
         db=async_session,
@@ -158,6 +172,14 @@ async def test_get_multi_joined_no_results(async_session, test_data, test_data_t
 
 @pytest.mark.asyncio
 async def test_get_multi_joined_large_offset(async_session, test_data, test_data_tier):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    await async_session.commit()
+
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
     crud = FastCRUD(ModelTest)
     result = await crud.get_multi_joined(
         db=async_session,
@@ -175,6 +197,14 @@ async def test_get_multi_joined_large_offset(async_session, test_data, test_data
 async def test_get_multi_joined_invalid_limit_offset(
     async_session, test_data, test_data_tier
 ):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    await async_session.commit()
+
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
     crud = FastCRUD(ModelTest)
     with pytest.raises(ValueError):
         await crud.get_multi_joined(
@@ -194,3 +224,35 @@ async def test_get_multi_joined_invalid_limit_offset(
             offset=0,
             limit=-1,
         )
+
+
+@pytest.mark.asyncio
+async def test_get_multi_joined_advanced_filtering(
+    async_session, test_data, test_data_tier
+):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    await async_session.commit()
+
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    advanced_filter_result = await crud.get_multi_joined(
+        db=async_session,
+        join_model=TierModel,
+        schema_to_select=ReadSchemaTest,
+        join_schema_to_select=TierSchemaTest,
+        join_prefix="tier_",
+        offset=0,
+        limit=10,
+        id__gt=5,
+    )
+
+    assert (
+        len(advanced_filter_result["data"]) > 0
+    ), "Should fetch records with ID greater than 5"
+    assert all(
+        item["id"] > 5 for item in advanced_filter_result["data"]
+    ), "All fetched records should meet the advanced filter condition"

--- a/tests/sqlmodel/conftest.py
+++ b/tests/sqlmodel/conftest.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 from sqlmodel import SQLModel, Field, Relationship
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -34,6 +34,12 @@ class TierModel(SQLModel, table=True):
 
 class CreateSchemaTest(SQLModel):
     model_config = ConfigDict(extra="forbid")
+    name: str
+    tier_id: int
+
+
+class ReadSchemaTest(SQLModel):
+    id: int
     name: str
     tier_id: int
 
@@ -97,6 +103,7 @@ def test_data() -> list[dict]:
         {"id": 8, "name": "Hannah", "tier_id": 2},
         {"id": 9, "name": "Ivan", "tier_id": 1},
         {"id": 10, "name": "Judy", "tier_id": 2},
+        {"id": 11, "name": "Alice", "tier_id": 1},
     ]
 
 
@@ -118,6 +125,11 @@ def tier_model():
 @pytest.fixture
 def create_schema():
     return CreateSchemaTest
+
+
+@pytest.fixture
+def read_schema():
+    return ReadSchemaTest
 
 
 @pytest.fixture

--- a/tests/sqlmodel/crud/test_count.py
+++ b/tests/sqlmodel/crud/test_count.py
@@ -34,3 +34,70 @@ async def test_count_no_matching_records(async_session, test_model):
     count = await crud.count(async_session, **non_existent_filter)
 
     assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_count_with_advanced_filters(async_session, test_model, test_data):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    count_gt = await crud.count(async_session, tier_id__gt=1)
+    assert count_gt == len([item for item in test_data if item["tier_id"] > 1])
+
+    count_lt = await crud.count(async_session, tier_id__lt=2)
+    assert count_lt == len([item for item in test_data if item["tier_id"] < 2])
+
+    count_ne = await crud.count(async_session, name__ne=test_data[0]["name"])
+    assert count_ne == len(test_data) - 1
+
+
+@pytest.mark.asyncio
+async def test_update_multiple_records_allow_multiple(
+    async_session, test_model, test_data
+):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+
+    await crud.update(
+        async_session, {"name": "UpdatedName"}, allow_multiple=True, tier_id=1
+    )
+    updated_count = await crud.count(async_session, name="UpdatedName")
+    expected_count = len([item for item in test_data if item["tier_id"] == 1])
+
+    assert updated_count == expected_count
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_custom_columns(async_session, test_model, test_data):
+    crud = FastCRUD(
+        test_model,
+        is_deleted_column="custom_is_deleted",
+        deleted_at_column="custom_deleted_at",
+    )
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    existing_record = await crud.get(async_session, id=test_data[0]["id"])
+    assert existing_record is not None, "Record should exist before deletion"
+
+    await crud.delete(async_session, id=test_data[0]["id"], allow_multiple=False)
+
+    deleted_record = await crud.get(async_session, id=test_data[0]["id"])
+
+    if deleted_record is None:
+        assert True, "Record is considered 'deleted' and is not fetched by default"
+    else:
+        assert (
+            deleted_record.get("custom_is_deleted") is True
+        ), "Record should be marked as deleted"
+        assert (
+            "custom_deleted_at" in deleted_record
+            and deleted_record["custom_deleted_at"] is not None
+        ), "Deletion timestamp should be set"

--- a/tests/sqlmodel/crud/test_delete.py
+++ b/tests/sqlmodel/crud/test_delete.py
@@ -53,3 +53,55 @@ async def test_delete_hard_delete_as_fallback(
         select(tier_model).where(tier_model.id == some_existing_id)
     )
     assert hard_deleted_record.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_delete_multiple_records(async_session, test_data, test_model):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+    with pytest.raises(Exception):
+        await crud.delete(db=async_session, allow_multiple=False, tier_id=1)
+
+
+@pytest.mark.asyncio
+async def test_get_with_advanced_filters(async_session, test_data, test_model):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+    records = await crud.get_multi(db=async_session, id__gt=5)
+    for record in records["data"]:
+        assert record["id"] > 5, "All fetched records should have 'id' greater than 5"
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_with_custom_columns(async_session, test_data, test_model):
+    crud = FastCRUD(
+        test_model, is_deleted_column="is_deleted", deleted_at_column="deleted_at"
+    )
+    some_existing_id = test_data[0]["id"]
+
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    await crud.delete(db=async_session, id=some_existing_id, allow_multiple=False)
+
+    deleted_record = await async_session.execute(
+        select(test_model)
+        .where(test_model.id == some_existing_id)
+        .where(getattr(test_model, "is_deleted") is True)
+    )
+    deleted_record = deleted_record.scalar_one_or_none()
+
+    assert deleted_record is not None, "Record should exist after soft delete"
+    assert (
+        getattr(deleted_record, "is_deleted") is True
+    ), "Record should be marked as soft deleted"
+    assert (
+        getattr(deleted_record, "deleted_at") is not None
+    ), "Record should have a deletion timestamp"

--- a/tests/sqlmodel/crud/test_delete.py
+++ b/tests/sqlmodel/crud/test_delete.py
@@ -94,13 +94,13 @@ async def test_soft_delete_with_custom_columns(async_session, test_data, test_mo
     deleted_record = await async_session.execute(
         select(test_model)
         .where(test_model.id == some_existing_id)
-        .where(getattr(test_model, "is_deleted") is True)
+        .where(getattr(test_model, "is_deleted") == True)  # noqa
     )
     deleted_record = deleted_record.scalar_one_or_none()
 
     assert deleted_record is not None, "Record should exist after soft delete"
     assert (
-        getattr(deleted_record, "is_deleted") is True
+        getattr(deleted_record, "is_deleted") == True  # noqa
     ), "Record should be marked as soft deleted"
     assert (
         getattr(deleted_record, "deleted_at") is not None

--- a/tests/sqlmodel/crud/test_exists.py
+++ b/tests/sqlmodel/crud/test_exists.py
@@ -21,3 +21,32 @@ async def test_exists_record_not_found(async_session, test_model):
     exists = await crud.exists(async_session, **non_existent_filter)
 
     assert exists is False
+
+
+@pytest.mark.asyncio
+async def test_exists_with_advanced_filters(async_session, test_model, test_data):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+    exists_gt = await crud.exists(db=async_session, id__gt=1)
+    assert exists_gt is True, "Should find records with ID greater than 1"
+
+    advanced_filter_lt = {"id__lt": max([d["id"] for d in test_data])}
+    exists_lt = await crud.exists(async_session, **advanced_filter_lt)
+    assert exists_lt is True, "Should find records with ID less than the max ID"
+
+
+@pytest.mark.asyncio
+async def test_exists_multiple_records_match(async_session, test_model, test_data):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    duplicate_tier_id = test_data[0]["tier_id"]
+    crud = FastCRUD(test_model)
+    exists = await crud.exists(async_session, tier_id=duplicate_tier_id)
+    assert (
+        exists is True
+    ), "Should return True if multiple records match the filter criteria"

--- a/tests/sqlmodel/crud/test_get.py
+++ b/tests/sqlmodel/crud/test_get.py
@@ -1,7 +1,9 @@
 import pytest
+from pydantic import BaseModel
+
 from fastcrud.crud.fast_crud import FastCRUD
-from ..conftest import ModelTest
-from ..conftest import CreateSchemaTest
+from ...sqlalchemy.conftest import ModelTest
+from ...sqlalchemy.conftest import CreateSchemaTest
 
 
 @pytest.mark.asyncio
@@ -52,3 +54,62 @@ async def test_get_selecting_columns(async_session, test_data):
 
     assert fetched_record is not None
     assert "name" in fetched_record
+
+
+@pytest.mark.asyncio
+async def test_get_with_advanced_filters(async_session, test_data):
+    for item in test_data:
+        async_session.add(ModelTest(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    advanced_filter = {"id__gt": 1}
+    fetched_record_gt = await crud.get(async_session, **advanced_filter)
+
+    assert fetched_record_gt is not None
+    assert fetched_record_gt["id"] > 1, "Should fetch a record with ID greater than 1"
+
+    ne_filter = {"name__ne": test_data[0]["name"]}
+    fetched_record_ne = await crud.get(async_session, **ne_filter)
+
+    assert fetched_record_ne is not None
+    assert (
+        fetched_record_ne["name"] != test_data[0]["name"]
+    ), "Should fetch a record with a different name"
+
+
+@pytest.mark.asyncio
+async def test_get_with_schema_selecting_specific_columns(async_session, test_data):
+    async_session.add(ModelTest(**test_data[0]))
+    await async_session.commit()
+
+    class PartialSchema(BaseModel):
+        name: str
+
+    crud = FastCRUD(ModelTest)
+    fetched_record = await crud.get(
+        async_session, schema_to_select=PartialSchema, id=test_data[0]["id"]
+    )
+
+    assert fetched_record is not None
+    assert (
+        "name" in fetched_record and "tier_id" not in fetched_record
+    ), "Should only fetch the 'name' column based on the PartialSchema"
+
+
+@pytest.mark.asyncio
+async def test_get_return_as_model_instance(async_session, test_data, read_schema):
+    async_session.add(ModelTest(**test_data[0]))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    fetched_record = await crud.get(
+        async_session,
+        return_as_model=True,
+        schema_to_select=read_schema,
+        id=test_data[0]["id"],
+    )
+
+    assert isinstance(
+        fetched_record, read_schema
+    ), "The fetched record should be an instance of the ReadSchemaTest Pydantic model"

--- a/tests/sqlmodel/crud/test_get_multi_joined.py
+++ b/tests/sqlmodel/crud/test_get_multi_joined.py
@@ -1,6 +1,12 @@
 import pytest
 from fastcrud.crud.fast_crud import FastCRUD
-from ..conftest import ModelTest, TierModel, CreateSchemaTest, TierSchemaTest
+from ...sqlalchemy.conftest import (
+    ModelTest,
+    TierModel,
+    CreateSchemaTest,
+    TierSchemaTest,
+    ReadSchemaTest,
+)
 
 
 @pytest.mark.asyncio
@@ -141,6 +147,14 @@ async def test_get_multi_joined_return_model(async_session, test_data, test_data
 
 @pytest.mark.asyncio
 async def test_get_multi_joined_no_results(async_session, test_data, test_data_tier):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    await async_session.commit()
+
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
     crud = FastCRUD(ModelTest)
     result = await crud.get_multi_joined(
         db=async_session,
@@ -158,6 +172,14 @@ async def test_get_multi_joined_no_results(async_session, test_data, test_data_t
 
 @pytest.mark.asyncio
 async def test_get_multi_joined_large_offset(async_session, test_data, test_data_tier):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    await async_session.commit()
+
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
     crud = FastCRUD(ModelTest)
     result = await crud.get_multi_joined(
         db=async_session,
@@ -175,6 +197,14 @@ async def test_get_multi_joined_large_offset(async_session, test_data, test_data
 async def test_get_multi_joined_invalid_limit_offset(
     async_session, test_data, test_data_tier
 ):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    await async_session.commit()
+
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
     crud = FastCRUD(ModelTest)
     with pytest.raises(ValueError):
         await crud.get_multi_joined(
@@ -194,3 +224,35 @@ async def test_get_multi_joined_invalid_limit_offset(
             offset=0,
             limit=-1,
         )
+
+
+@pytest.mark.asyncio
+async def test_get_multi_joined_advanced_filtering(
+    async_session, test_data, test_data_tier
+):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    await async_session.commit()
+
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    advanced_filter_result = await crud.get_multi_joined(
+        db=async_session,
+        join_model=TierModel,
+        schema_to_select=ReadSchemaTest,
+        join_schema_to_select=TierSchemaTest,
+        join_prefix="tier_",
+        offset=0,
+        limit=10,
+        id__gt=5,
+    )
+
+    assert (
+        len(advanced_filter_result["data"]) > 0
+    ), "Should fetch records with ID greater than 5"
+    assert all(
+        item["id"] > 5 for item in advanced_filter_result["data"]
+    ), "All fetched records should meet the advanced filter condition"

--- a/tests/sqlmodel/crud/test_update.py
+++ b/tests/sqlmodel/crud/test_update.py
@@ -1,9 +1,10 @@
 import pytest
 
 from sqlalchemy import select
+from sqlalchemy.exc import MultipleResultsFound
 
 from fastcrud.crud.fast_crud import FastCRUD
-from ..conftest import ModelTest
+from ...sqlalchemy.conftest import ModelTest
 
 
 @pytest.mark.asyncio
@@ -91,3 +92,61 @@ async def test_update_additional_fields(async_session, test_data):
         await crud.update(db=async_session, object=updated_data, id=some_existing_id)
 
     assert "Extra fields provided" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_update_with_advanced_filters(async_session, test_data):
+    for item in test_data:
+        async_session.add(ModelTest(**item))
+    await async_session.commit()
+
+    advanced_filter = {"id__gt": 5}
+    updated_data = {"name": "Updated for Advanced Filter"}
+
+    crud = FastCRUD(ModelTest)
+    await crud.update(
+        db=async_session, object=updated_data, allow_multiple=True, **advanced_filter
+    )
+
+    updated_records = await async_session.execute(
+        select(ModelTest).where(ModelTest.id > 5)
+    )
+    assert all(
+        record.name == "Updated for Advanced Filter"
+        for record in updated_records.scalars()
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_multiple_records(async_session, test_data):
+    for item in test_data:
+        async_session.add(ModelTest(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    updated_data = {"name": "Updated Multiple"}
+    await crud.update(
+        db=async_session, object=updated_data, allow_multiple=True, tier_id=2
+    )
+
+    updated_records = await async_session.execute(
+        select(ModelTest).where(ModelTest.tier_id == 2)
+    )
+    assert all(
+        record.name == "Updated Multiple" for record in updated_records.scalars()
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_multiple_records_restriction(async_session, test_data):
+    for item in test_data:
+        async_session.add(ModelTest(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    updated_data = {"name": "Should Fail"}
+
+    with pytest.raises(MultipleResultsFound) as exc_info:
+        await crud.update(db=async_session, object=updated_data, id__lt=10)
+
+    assert "Expected exactly one record to update" in str(exc_info.value)


### PR DESCRIPTION
# Crud Enhancement

## Added 
- Advanced filters (Django ORM style)
- Optional Bulk Operations
- Custom soft delete mechanisms in FastCRUD, EndpointCreator and crud_router
- Tests for new features

## Detailed
___
### Using `EndpointCreator` and `crud_router` with Custom Soft Delete Columns

When initializing `crud_router` or creating a custom `EndpointCreator`, you can pass the names of your custom soft delete columns through the `FastCRUD` initialization. This informs FastCRUD which columns to check and update for soft deletion operations.

Here's an example of using `crud_router` with custom soft delete columns:

```python
from fastapi import FastAPI
from fastcrud import FastCRUD, crud_router
from sqlalchemy.ext.asyncio import AsyncSession

app = FastAPI()

# Assuming async_session is your AsyncSession generator
# and MyModel is your SQLAlchemy model

# Initialize FastCRUD with custom soft delete columns
my_model_crud = FastCRUD(MyModel,
                         is_deleted_column='archived',  # Custom 'is_deleted' column name
                         deleted_at_column='archived_at'  # Custom 'deleted_at' column name
                        )

# Setup CRUD router with the FastCRUD instance
app.include_router(crud_router(
    session=async_session,
    model=MyModel,
    crud=my_model_crud,
    create_schema=CreateMyModelSchema,
    update_schema=UpdateMyModelSchema,
    delete_schema=DeleteMyModelSchema,
    path="/mymodel",
    tags=["MyModel"]
))
```

This setup ensures that the soft delete functionality within your application utilizes the `archived` and `archived_at` columns for marking records as deleted, rather than the default `is_deleted` and `deleted_at` fields.

___
### Updating Multiple Records

To update multiple records, you can set the `allow_multiple=True` parameter in the `update` method. This allows FastCRUD to apply the update to all records matching the given filters.

```python
# Assuming setup for FastCRUD instance `item_crud` and SQLAlchemy async session `db`

# Update all items priced below $10 to a new price
await item_crud.update(
    db=db,
    object={"price": 9.99},
    allow_multiple=True,
    price__lt=10
)
```

### Deleting Multiple Records

Similarly, you can delete multiple records by using the `allow_multiple=True` parameter in the `delete` or `db_delete` method, depending on whether you're performing a soft or hard delete.

```python
# Soft delete all items not sold in the last year
await item_crud.delete(
    db=db,
    allow_multiple=True,
    last_sold__lt=datetime.datetime.now() - datetime.timedelta(days=365)
)
```

___
### Advanced Filters

FastCRUD supports advanced filtering options, allowing you to query records using operators such as greater than (`__gt`), less than (`__lt`), and their inclusive counterparts (`__gte`, `__lte`). These filters can be used in any method that retrieves or operates on records, including `get`, `get_multi`, `exists`, `count`, `update`, and `delete`.

### Using Advanced Filters

The following examples demonstrate how to use advanced filters for querying and manipulating data:

#### Fetching Records with Advanced Filters

```python
# Fetch items priced between $5 and $20
items = await item_crud.get_multi(
    db=db,
    price__gte=5,
    price__lte=20
)
```

#### Counting Records

```python
# Count items added in the last month
item_count = await item_crud.count(
    db=db,
    added_at__gte=datetime.datetime.now() - datetime.timedelta(days=30)
)
```

