### PR TITLE
Passing CRUD now optional, Custom updated_at Column name

### DIFF
--- a/docs/advanced/endpoint.md
+++ b/docs/advanced/endpoint.md
@@ -192,13 +192,13 @@ class MyModel(Base):
     archived_at = Column(DateTime)  # Custom timestamp column for soft delete
 ```
 
-### Using `EndpointCreator` and `crud_router` with Custom Soft Delete Columns
+### Using `EndpointCreator` and `crud_router` with Custom Soft Delete or Update Columns
 
 When initializing `crud_router` or creating a custom `EndpointCreator`, you can pass the names of your custom soft delete columns through the `FastCRUD` initialization. This informs FastCRUD which columns to check and update for soft deletion operations.
 
 Here's an example of using `crud_router` with custom soft delete columns:
 
-```python
+```python hl_lines="11-14 20"
 from fastapi import FastAPI
 from fastcrud import FastCRUD, crud_router
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -224,6 +224,37 @@ app.include_router(crud_router(
     delete_schema=DeleteMyModelSchema,
     path="/mymodel",
     tags=["MyModel"]
+))
+```
+
+You may also directly pass the names of the columns to crud_router or EndpointCreator:
+
+```python hl_lines="9 10"
+app.include_router(endpoint_creator(
+    session=async_session,
+    model=MyModel,
+    create_schema=CreateMyModelSchema,
+    update_schema=UpdateMyModelSchema,
+    delete_schema=DeleteMyModelSchema,
+    path="/mymodel",
+    tags=["MyModel"],
+    is_deleted_column='archived',
+    deleted_at_column='archived_at'
+))
+```
+
+You can also customize your `updated_at` column:
+
+```python hl_lines="9"
+app.include_router(endpoint_creator(
+    session=async_session,
+    model=MyModel,
+    create_schema=CreateMyModelSchema,
+    update_schema=UpdateMyModelSchema,
+    delete_schema=DeleteMyModelSchema,
+    path="/mymodel",
+    tags=["MyModel"],
+    updated_at_column='date_updated'
 ))
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False
 Use `crud_router` and include it in your `FastAPI` application
 
 ```python
-from fastcrud import FastCRUD, crud_router
+from fastcrud import crud_router
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
     async with async_session() as session:
@@ -86,7 +86,6 @@ app = FastAPI(lifespan=lifespan)
 item_router = crud_router(
     session=get_session,
     model=Item,
-    crud=FastCRUD(Item),
     create_schema=ItemSchema,
     update_schema=ItemSchema,
     path="/items",
@@ -171,7 +170,7 @@ class ItemUpdateSchema(BaseModel):
 from typing import AsyncGenerator
 
 from fastapi import FastAPI
-from fastcrud import FastCRUD, crud_router
+from fastcrud import crud_router
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -201,7 +200,6 @@ crud = FastCRUD(Item)
 item_router = crud_router(
     session=get_session,
     model=Item,
-    crud=crud,
     create_schema=ItemCreateSchema,
     update_schema=ItemUpdateSchema,
     path="/items",

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -82,8 +82,8 @@ async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False
 
 Use `crud_router` and include it in your `FastAPI` application
 
-```python title="main.py" hl_lines="17-25 27"
-from fastcrud import FastCRUD, crud_router
+```python title="main.py" hl_lines="17-24 26"
+from fastcrud import crud_router
 
 # Database session dependency
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
@@ -102,7 +102,6 @@ app = FastAPI(lifespan=lifespan)
 item_router = crud_router(
     session=session,
     model=Item,
-    crud=FastCRUD(Item),
     create_schema=ItemSchema,
     update_schema=ItemSchema,
     path="/items",

--- a/docs/sqlmodel.md
+++ b/docs/sqlmodel.md
@@ -66,8 +66,8 @@ async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False
 
 Use `crud_router` and include it in your `FastAPI` application
 
-```python title="main.py" hl_lines="17-25 27"
-from fastcrud import FastCRUD, crud_router
+```python title="main.py" hl_lines="17-24 26"
+from fastcrud import crud_router
 
 # Database session dependency
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
@@ -86,7 +86,6 @@ app = FastAPI(lifespan=lifespan)
 item_router = crud_router(
     session=get_session,
     model=Item,
-    crud=FastCRUD(Item),
     create_schema=ItemSchema,
     update_schema=ItemSchema,
     path="/items",

--- a/docs/usage/endpoint.md
+++ b/docs/usage/endpoint.md
@@ -43,7 +43,7 @@ class ItemUpdateSchema(BaseModel):
 
 ### Step 2: Set Up FastAPI and FastCRUD
 
-Next, set up your FastAPI application and FastCRUD instances. This involves configuring the database connection and creating a CRUD instance for your model.
+Next, set up your FastAPI application, you can optionally set up a custom FastCRUD instance as well. This involves configuring the database connection.
 
 ```python
 from typing import AsyncGenerator
@@ -71,9 +71,6 @@ async def lifespan(app: FastAPI):
 
 # FastAPI app
 app = FastAPI(lifespan=lifespan)
-
-# CRUD operations setup
-crud = FastCRUD(Item)
 ```
 
 ### Step 3: Use `crud_router` to Create Endpoints
@@ -83,7 +80,6 @@ crud = FastCRUD(Item)
 item_router = crud_router(
     session=get_session,
     model=Item,
-    crud=crud,
     create_schema=ItemCreateSchema,
     update_schema=ItemUpdateSchema,
     path="/items",
@@ -176,7 +172,6 @@ from fastcrud import EndpointCreator
 endpoint_creator = EndpointCreator(
     session=get_session,
     model=YourModel,
-    crud=your_crud_instance,
     create_schema=YourCreateSchema,
     update_schema=YourUpdateSchema,
     delete_schema=YourDeleteSchema,

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -154,7 +154,7 @@ class FastCRUD(
         model: type[ModelType],
         is_deleted_column: str = "is_deleted",
         deleted_at_column: str = "deleted_at",
-        updated_at_column: str = "updated_at"
+        updated_at_column: str = "updated_at",
     ) -> None:
         self.model = model
         self.is_deleted_column = is_deleted_column

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -44,6 +44,7 @@ class FastCRUD(
         model: The SQLAlchemy model type.
         is_deleted_column: Optional column name to use for indicating a soft delete. Defaults to "is_deleted".
         deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to "deleted_at".
+        updated_at_column: Optional column name to use for storing the timestamp of an update. Defaults to "updated_at".
 
     Methods:
         create:
@@ -153,10 +154,12 @@ class FastCRUD(
         model: type[ModelType],
         is_deleted_column: str = "is_deleted",
         deleted_at_column: str = "deleted_at",
+        updated_at_column: str = "updated_at"
     ) -> None:
         self.model = model
         self.is_deleted_column = is_deleted_column
         self.deleted_at_column = deleted_at_column
+        self.updated_at_column = updated_at_column
 
     def _parse_filters(self, **kwargs) -> list[BinaryExpression]:
         filters = []
@@ -987,8 +990,9 @@ class FastCRUD(
         else:
             update_data = object.model_dump(exclude_unset=True)
 
-        if "updated_at" in update_data.keys():
-            update_data["updated_at"] = datetime.now(timezone.utc)
+        updated_at_col = getattr(self.model, self.updated_at_column, None)
+        if updated_at_col and updated_at_col in update_data.keys():
+            update_data[updated_at_col] = datetime.now(timezone.utc)
 
         model_columns = {column.name for column in inspect(self.model).c}
         extra_fields = set(update_data) - model_columns

--- a/fastcrud/endpoint/crud_router.py
+++ b/fastcrud/endpoint/crud_router.py
@@ -208,7 +208,7 @@ def crud_router(
         deleted_at_column=deleted_at_column,
         updated_at_column=updated_at_column,
     )
-    
+
     endpoint_creator_class = endpoint_creator or EndpointCreator
     endpoint_creator_instance = endpoint_creator_class(
         session=session,
@@ -222,7 +222,7 @@ def crud_router(
         tags=tags,
         is_deleted_column=is_deleted_column,
         deleted_at_column=deleted_at_column,
-        updated_at_column=updated_at_column
+        updated_at_column=updated_at_column,
     )
 
     endpoint_creator_instance.add_routes_to_router(

--- a/fastcrud/endpoint/crud_router.py
+++ b/fastcrud/endpoint/crud_router.py
@@ -14,9 +14,9 @@ DeleteSchemaType = TypeVar("DeleteSchemaType", bound=BaseModel)
 def crud_router(
     session: AsyncSession,
     model: DeclarativeBase,
-    crud: FastCRUD,
     create_schema: Type[CreateSchemaType],
     update_schema: Type[UpdateSchemaType],
+    crud: Optional[FastCRUD] = None,
     delete_schema: Optional[Type[DeleteSchemaType]] = None,
     path: str = "",
     tags: Optional[List[str]] = None,
@@ -32,6 +32,7 @@ def crud_router(
     endpoint_creator: Optional[Type[EndpointCreator]] = None,
     is_deleted_column: str = "is_deleted",
     deleted_at_column: str = "deleted_at",
+    updated_at_column: str = "updated_at",
 ) -> APIRouter:
     """
     Creates and configures a FastAPI router with CRUD endpoints for a given model.
@@ -43,7 +44,7 @@ def crud_router(
     Args:
         session: The SQLAlchemy async session.
         model: The SQLAlchemy model.
-        crud: The FastCRUD instance.
+        crud: An optional FastCRUD instance. If not provided, uses FastCRUD(model).
         create_schema: Pydantic schema for creating an item.
         update_schema: Pydantic schema for updating an item.
         delete_schema: Optional Pydantic schema for deleting an item.
@@ -61,6 +62,7 @@ def crud_router(
         endpoint_creator: Optional custom class derived from EndpointCreator for advanced customization.
         is_deleted_column: Optional column name to use for indicating a soft delete. Defaults to "is_deleted".
         deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to "deleted_at".
+        updated_at_column: Optional column name to use for storing the timestamp of an update. Defaults to "updated_at".
 
     Returns:
         Configured APIRouter instance with the CRUD endpoints.
@@ -74,7 +76,6 @@ def crud_router(
         router = crud_router(
             session=async_session,
             model=MyModel,
-            crud=CRUDMyModel(MyModel),
             create_schema=CreateMyModelSchema,
             update_schema=UpdateMyModelSchema,
             path="/mymodel",
@@ -91,7 +92,6 @@ def crud_router(
         router = crud_router(
             session=async_session,
             model=UserModel,
-            crud=CRUDUserModel(UserModel),
             create_schema=CreateUserSchema,
             update_schema=UpdateUserSchema,
             read_deps=[get_current_user],
@@ -106,7 +106,6 @@ def crud_router(
         router = crud_router(
             session=async_session,
             model=ProductModel,
-            crud=CRUDProductModel(ProductModel),
             create_schema=CreateProductSchema,
             update_schema=UpdateProductSchema,
             delete_schema=DeleteProductSchema,
@@ -203,6 +202,13 @@ def crud_router(
         app.include_router(my_router)
         ```
     """
+    crud = crud or FastCRUD(
+        model=model,
+        is_deleted_column=is_deleted_column,
+        deleted_at_column=deleted_at_column,
+        updated_at_column=updated_at_column,
+    )
+    
     endpoint_creator_class = endpoint_creator or EndpointCreator
     endpoint_creator_instance = endpoint_creator_class(
         session=session,
@@ -216,6 +222,7 @@ def crud_router(
         tags=tags,
         is_deleted_column=is_deleted_column,
         deleted_at_column=deleted_at_column,
+        updated_at_column=updated_at_column
     )
 
     endpoint_creator_instance.add_routes_to_router(

--- a/fastcrud/exceptions/__init__.py
+++ b/fastcrud/exceptions/__init__.py
@@ -1,3 +1,3 @@
-import http_exceptions
+from . import http_exceptions
 
 __all__ = ["http_exceptions"]

--- a/fastcrud/exceptions/__init__.py
+++ b/fastcrud/exceptions/__init__.py
@@ -1,0 +1,3 @@
+import http_exceptions
+
+__all__ = ["http_exceptions"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastcrud"
-version = "0.5.0"
+version = "0.6.0"
 description = "FastCRUD is a Python package for FastAPI, offering robust async CRUD operations and flexible endpoint creation utilities."
 authors = ["Igor Benav <igor.magalhaes.r@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
# Passing CRUD now optional, Custom updated_at Column name

## Added
- custom updated_at column name
- passing crud to crud_router and EndpointCreator now optional
- exceptions in http_exceptions now also in exceptions module

## Detailed
___
### Passing custom `updated_at` column
```python
You can also customize your `updated_at` column:

```python hl_lines="9"
app.include_router(endpoint_creator(
    session=async_session,
    model=MyModel,
    create_schema=CreateMyModelSchema,
    update_schema=UpdateMyModelSchema,
    delete_schema=DeleteMyModelSchema,
    path="/mymodel",
    tags=["MyModel"],
    updated_at_column='date_updated'
))
```