### PR TITLE
16 is there a way to customize the path suffix added by crud router

### DIFF
--- a/docs/advanced/endpoint.md
+++ b/docs/advanced/endpoint.md
@@ -150,6 +150,82 @@ app.include_router(my_router)
 
         If `included_methods` and `deleted_methods` are both provided, a ValueError will be raised.
 
+## Customizing Endpoint Names
+
+You can customize the names of the auto generated endpoints by passing an `endpoint_names` dictionary when initializing the `EndpointCreator` or calling the `crud_router` function. This dictionary should map the CRUD operation names (`create`, `read`, `update`, `delete`, `db_delete`, `read_multi`, `read_paginated`) to your desired endpoint names.
+
+### Example: Using `crud_router`
+
+Here's how you can customize endpoint names using the `crud_router` function:
+
+```python
+from fastapi import FastAPI
+from yourapp.crud import crud_router
+from yourapp.models import YourModel
+from yourapp.schemas import CreateYourModelSchema, UpdateYourModelSchema
+from yourapp.database import async_session
+
+app = FastAPI()
+
+# Custom endpoint names
+custom_endpoint_names = {
+    "create": "add",
+    "read": "fetch",
+    "update": "modify",
+    "delete": "remove",
+    "read_multi": "list",
+    "read_paginated": "paginate"
+}
+
+# Setup CRUD router with custom endpoint names
+app.include_router(crud_router(
+    session=async_session,
+    model=YourModel,
+    create_schema=CreateYourModelSchema,
+    update_schema=UpdateYourModelSchema,
+    path="/yourmodel",
+    tags=["YourModel"],
+    endpoint_names=custom_endpoint_names
+))
+```
+
+In this example, the standard CRUD endpoints will be replaced with `/add`, `/fetch/{id}`, `/modify/{id}`, `/remove/{id}`, `/list`, and `/paginate`.
+
+### Example: Using `EndpointCreator`
+
+If you are using `EndpointCreator`, you can also pass the `endpoint_names` dictionary to customize the endpoint names similarly:
+
+```python
+# Custom endpoint names
+custom_endpoint_names = {
+    "create": "add_new",
+    "read": "get_single",
+    "update": "change",
+    "delete": "erase",
+    "db_delete": "hard_erase",
+    "read_multi": "get_all",
+    "read_paginated": "get_page"
+}
+
+# Initialize and use the custom EndpointCreator
+endpoint_creator = EndpointCreator(
+    session=async_session,
+    model=YourModel,
+    create_schema=CreateYourModelSchema,
+    update_schema=UpdateYourModelSchema,
+    path="/yourmodel",
+    tags=["YourModel"],
+    endpoint_names=custom_endpoint_names
+)
+
+endpoint_creator.add_routes_to_router()
+app.include_router(endpoint_creator.router)
+```
+
+!!! TIP
+
+    You only need to pass the names of the endpoints you want to change in the endpoint_names dict.
+
 ## Extending EndpointCreator
 
 You can create a subclass of `EndpointCreator` and override or add new methods to define custom routes. Here's an example:

--- a/fastcrud/endpoint/crud_router.py
+++ b/fastcrud/endpoint/crud_router.py
@@ -34,6 +34,7 @@ def crud_router(
     is_deleted_column: str = "is_deleted",
     deleted_at_column: str = "deleted_at",
     updated_at_column: str = "updated_at",
+    endpoint_names: Optional[dict[str, str]] = None,
 ) -> APIRouter:
     """
     Creates and configures a FastAPI router with CRUD endpoints for a given model.
@@ -64,6 +65,9 @@ def crud_router(
         is_deleted_column: Optional column name to use for indicating a soft delete. Defaults to "is_deleted".
         deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to "deleted_at".
         updated_at_column: Optional column name to use for storing the timestamp of an update. Defaults to "updated_at".
+        endpoint_names: Optional dictionary to customize endpoint names for CRUD operations. Keys are operation types
+                        ("create", "read", "update", "delete", "db_delete", "read_multi", "read_paginated"), and 
+                        values are the custom names to use. Unspecified operations will use default names.
 
     Returns:
         Configured APIRouter instance with the CRUD endpoints.
@@ -202,6 +206,27 @@ def crud_router(
 
         app.include_router(my_router)
         ```
+
+        Customizing Endpoint Names:
+        ```python
+        router = crud_router(
+            session=async_session,
+            model=TaskModel,
+            create_schema=CreateTaskSchema,
+            update_schema=UpdateTaskSchema,
+            path="/tasks",
+            tags=["Task Management"],
+            endpoint_names={
+                "create": "add_task",
+                "read": "get_task",
+                "update": "modify_task",
+                "delete": "remove_task",
+                "db_delete": "permanently_remove_task",
+                "read_multi": "list_tasks",
+                "read_paginated": "paginate_tasks"
+            }
+        )
+        ```
     """
     crud = crud or FastCRUD(
         model=model,
@@ -224,6 +249,7 @@ def crud_router(
         is_deleted_column=is_deleted_column,
         deleted_at_column=deleted_at_column,
         updated_at_column=updated_at_column,
+        endpoint_names=endpoint_names,
     )
 
     endpoint_creator_instance.add_routes_to_router(

--- a/fastcrud/endpoint/crud_router.py
+++ b/fastcrud/endpoint/crud_router.py
@@ -66,7 +66,7 @@ def crud_router(
         deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to "deleted_at".
         updated_at_column: Optional column name to use for storing the timestamp of an update. Defaults to "updated_at".
         endpoint_names: Optional dictionary to customize endpoint names for CRUD operations. Keys are operation types
-                        ("create", "read", "update", "delete", "db_delete", "read_multi", "read_paginated"), and 
+                        ("create", "read", "update", "delete", "db_delete", "read_multi", "read_paginated"), and
                         values are the custom names to use. Unspecified operations will use default names.
 
     Returns:

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -41,7 +41,7 @@ class EndpointCreator:
         deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to "deleted_at".
         updated_at_column: Optional column name to use for storing the timestamp of an update. Defaults to "updated_at".
         endpoint_names: Optional dictionary to customize endpoint names for CRUD operations. Keys are operation types
-                        ("create", "read", "update", "delete", "db_delete", "read_multi", "read_paginated"), and 
+                        ("create", "read", "update", "delete", "db_delete", "read_multi", "read_paginated"), and
                         values are the custom names to use. Unspecified operations will use default names.
 
     Raises:
@@ -177,7 +177,7 @@ class EndpointCreator:
             "delete": "delete",
             "db_delete": "db_delete",
             "read_multi": "get_multi",
-            "read_paginated": "get_paginated"
+            "read_paginated": "get_paginated",
         }
         self.endpoint_names = {**self.default_endpoint_names, **(endpoint_names or {})}
 
@@ -285,10 +285,12 @@ class EndpointCreator:
             return {"message": "Item permanently deleted from the database"}
 
         return endpoint
-    
+
     def _get_endpoint_name(self, operation: str) -> str:
         """Get the endpoint name for a given CRUD operation, using defaults if not overridden by the user."""
-        return self.endpoint_names.get(operation, self.default_endpoint_names.get(operation))
+        return self.endpoint_names.get(
+            operation, self.default_endpoint_names.get(operation, operation)
+        )
 
     def add_routes_to_router(
         self,

--- a/tests/sqlalchemy/endpoint/test_endpoint_custom_names.py
+++ b/tests/sqlalchemy/endpoint/test_endpoint_custom_names.py
@@ -1,0 +1,42 @@
+import pytest
+
+from fastapi.testclient import TestClient
+from fastcrud import crud_router
+
+from ..conftest import get_session_local
+
+@pytest.mark.asyncio
+async def test_endpoint_custom_names(
+    client: TestClient, test_data, async_session, test_model, create_schema, update_schema
+):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    custom_endpoint_names = {
+        "create": "add",
+        "read": "fetch",
+    }
+
+    custom_router = crud_router(
+        session=get_session_local,
+        model=test_model,
+        create_schema=create_schema,
+        update_schema=update_schema,
+        endpoint_names=custom_endpoint_names,
+        path="/test_custom_names",
+        tags=["TestCustomNames"],
+    )
+
+    client.app.include_router(custom_router)
+
+    create_response = client.post(
+        "/test_custom_names/add", json={"name": "Custom Endpoint Item", "tier_id": 1}
+    )
+    assert create_response.status_code == 200, "Failed to create item with custom endpoint name"
+
+    item_id = create_response.json()["id"]
+
+    fetch_response = client.get(f"/test_custom_names/fetch/{item_id}")
+    assert fetch_response.status_code == 200, "Failed to fetch item with custom endpoint name"
+    assert fetch_response.json()["id"] == item_id, "Fetched item ID does not match created item ID"

--- a/tests/sqlalchemy/endpoint/test_endpoint_custom_names.py
+++ b/tests/sqlalchemy/endpoint/test_endpoint_custom_names.py
@@ -5,9 +5,15 @@ from fastcrud import crud_router
 
 from ..conftest import get_session_local
 
+
 @pytest.mark.asyncio
 async def test_endpoint_custom_names(
-    client: TestClient, test_data, async_session, test_model, create_schema, update_schema
+    client: TestClient,
+    test_data,
+    async_session,
+    test_model,
+    create_schema,
+    update_schema,
 ):
     for item in test_data:
         async_session.add(test_model(**item))
@@ -33,10 +39,16 @@ async def test_endpoint_custom_names(
     create_response = client.post(
         "/test_custom_names/add", json={"name": "Custom Endpoint Item", "tier_id": 1}
     )
-    assert create_response.status_code == 200, "Failed to create item with custom endpoint name"
+    assert (
+        create_response.status_code == 200
+    ), "Failed to create item with custom endpoint name"
 
     item_id = create_response.json()["id"]
 
     fetch_response = client.get(f"/test_custom_names/fetch/{item_id}")
-    assert fetch_response.status_code == 200, "Failed to fetch item with custom endpoint name"
-    assert fetch_response.json()["id"] == item_id, "Fetched item ID does not match created item ID"
+    assert (
+        fetch_response.status_code == 200
+    ), "Failed to fetch item with custom endpoint name"
+    assert (
+        fetch_response.json()["id"] == item_id
+    ), "Fetched item ID does not match created item ID"

--- a/tests/sqlmodel/endpoint/test_endpoint_custom_names.py
+++ b/tests/sqlmodel/endpoint/test_endpoint_custom_names.py
@@ -1,0 +1,42 @@
+import pytest
+
+from fastapi.testclient import TestClient
+from fastcrud import crud_router
+
+from ..conftest import get_session_local
+
+@pytest.mark.asyncio
+async def test_endpoint_custom_names(
+    client: TestClient, test_data, async_session, test_model, create_schema, update_schema
+):
+    for item in test_data:
+        async_session.add(test_model(**item))
+    await async_session.commit()
+
+    custom_endpoint_names = {
+        "create": "add",
+        "read": "fetch",
+    }
+
+    custom_router = crud_router(
+        session=get_session_local,
+        model=test_model,
+        create_schema=create_schema,
+        update_schema=update_schema,
+        endpoint_names=custom_endpoint_names,
+        path="/test_custom_names",
+        tags=["TestCustomNames"],
+    )
+
+    client.app.include_router(custom_router)
+
+    create_response = client.post(
+        "/test_custom_names/add", json={"name": "Custom Endpoint Item", "tier_id": 1}
+    )
+    assert create_response.status_code == 200, "Failed to create item with custom endpoint name"
+
+    item_id = create_response.json()["id"]
+
+    fetch_response = client.get(f"/test_custom_names/fetch/{item_id}")
+    assert fetch_response.status_code == 200, "Failed to fetch item with custom endpoint name"
+    assert fetch_response.json()["id"] == item_id, "Fetched item ID does not match created item ID"

--- a/tests/sqlmodel/endpoint/test_endpoint_custom_names.py
+++ b/tests/sqlmodel/endpoint/test_endpoint_custom_names.py
@@ -5,9 +5,15 @@ from fastcrud import crud_router
 
 from ..conftest import get_session_local
 
+
 @pytest.mark.asyncio
 async def test_endpoint_custom_names(
-    client: TestClient, test_data, async_session, test_model, create_schema, update_schema
+    client: TestClient,
+    test_data,
+    async_session,
+    test_model,
+    create_schema,
+    update_schema,
 ):
     for item in test_data:
         async_session.add(test_model(**item))
@@ -33,10 +39,16 @@ async def test_endpoint_custom_names(
     create_response = client.post(
         "/test_custom_names/add", json={"name": "Custom Endpoint Item", "tier_id": 1}
     )
-    assert create_response.status_code == 200, "Failed to create item with custom endpoint name"
+    assert (
+        create_response.status_code == 200
+    ), "Failed to create item with custom endpoint name"
 
     item_id = create_response.json()["id"]
 
     fetch_response = client.get(f"/test_custom_names/fetch/{item_id}")
-    assert fetch_response.status_code == 200, "Failed to fetch item with custom endpoint name"
-    assert fetch_response.json()["id"] == item_id, "Fetched item ID does not match created item ID"
+    assert (
+        fetch_response.status_code == 200
+    ), "Failed to fetch item with custom endpoint name"
+    assert (
+        fetch_response.json()["id"] == item_id
+    ), "Fetched item ID does not match created item ID"


### PR DESCRIPTION
## Customizing Endpoint Names

You can customize the names of the auto generated endpoints by passing an `endpoint_names` dictionary when initializing the `EndpointCreator` or calling the `crud_router` function. This dictionary should map the CRUD operation names (`create`, `read`, `update`, `delete`, `db_delete`, `read_multi`, `read_paginated`) to your desired endpoint names.

### Example: Using `crud_router`

Here's how you can customize endpoint names using the `crud_router` function:

```python
from fastapi import FastAPI
from yourapp.crud import crud_router
from yourapp.models import YourModel
from yourapp.schemas import CreateYourModelSchema, UpdateYourModelSchema
from yourapp.database import async_session

app = FastAPI()

# Custom endpoint names
custom_endpoint_names = {
    "create": "add",
    "read": "fetch",
    "update": "modify",
    "delete": "remove",
    "read_multi": "list",
    "read_paginated": "paginate"
}

# Setup CRUD router with custom endpoint names
app.include_router(crud_router(
    session=async_session,
    model=YourModel,
    create_schema=CreateYourModelSchema,
    update_schema=UpdateYourModelSchema,
    path="/yourmodel",
    tags=["YourModel"],
    endpoint_names=custom_endpoint_names
))
```

In this example, the standard CRUD endpoints will be replaced with `/add`, `/fetch/{id}`, `/modify/{id}`, `/remove/{id}`, `/list`, and `/paginate`.

### Example: Using `EndpointCreator`

If you are using `EndpointCreator`, you can also pass the `endpoint_names` dictionary to customize the endpoint names similarly:

```python
# Custom endpoint names
custom_endpoint_names = {
    "create": "add_new",
    "read": "get_single",
    "update": "change",
    "delete": "erase",
    "db_delete": "hard_erase",
    "read_multi": "get_all",
    "read_paginated": "get_page"
}

# Initialize and use the custom EndpointCreator
endpoint_creator = EndpointCreator(
    session=async_session,
    model=YourModel,
    create_schema=CreateYourModelSchema,
    update_schema=UpdateYourModelSchema,
    path="/yourmodel",
    tags=["YourModel"],
    endpoint_names=custom_endpoint_names
)

endpoint_creator.add_routes_to_router()
app.include_router(endpoint_creator.router)
```

> [!TIP]
> You only need to pass the names of the endpoints you want to change in the endpoint_names dict.