### PR TITLE
Using Aliases

### DIFF
--- a/docs/advanced/overview.md
+++ b/docs/advanced/overview.md
@@ -24,5 +24,10 @@ This topic extends the use of `EndpointCreator` and `crud_router` for advanced e
 
 - [Advanced Endpoint Management Guide](endpoint.md#advanced-use-of-endpointcreator)
 
+### 5. Using `get_joined` and `get_multi_joined` for multiple models
+Explore the use of `get_joined` and `get_multi_joined` functions for complex queries that involve joining multiple models, including self-joins and scenarios requiring multiple joins on the same model.
+
+- [Joining Multiple Models Guide](crud.md#using-get_joined-and-get_multi_joined-for-multiple-models)
+
 ## Prerequisites
 Advanced usage assumes a solid understanding of the basic features and functionalities of our application. Knowledge of FastAPI, SQLAlchemy, and Pydantic is highly recommended to fully grasp the concepts discussed.

--- a/fastcrud/__init__.py
+++ b/fastcrud/__init__.py
@@ -1,6 +1,16 @@
+from sqlalchemy.orm import aliased
+from sqlalchemy.orm.util import AliasedClass
+
 from .crud.fast_crud import FastCRUD
 from .endpoint.endpoint_creator import EndpointCreator
 from .endpoint.crud_router import crud_router
 from .crud.helper import JoinConfig
 
-__all__ = ["FastCRUD", "EndpointCreator", "crud_router", "JoinConfig"]
+__all__ = [
+    "FastCRUD",
+    "EndpointCreator",
+    "crud_router",
+    "JoinConfig",
+    "aliased",
+    "AliasedClass",
+]

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from datetime import datetime
 
 import pytest
 import pytest_asyncio
@@ -45,6 +46,16 @@ class TierModel(Base):
     tests = relationship("ModelTest", back_populates="tier")
 
 
+class BookingModel(Base):
+    __tablename__ = "booking"
+    id = Column(Integer, primary_key=True)
+    owner_id = Column(Integer, ForeignKey("test.id"), nullable=False)
+    user_id = Column(Integer, ForeignKey("test.id"), nullable=False)
+    booking_date = Column(DateTime, nullable=False)
+    owner = relationship("ModelTest", foreign_keys=[owner_id], backref="owned_bookings")
+    user = relationship("ModelTest", foreign_keys=[user_id], backref="user_bookings")
+
+
 class CreateSchemaTest(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str
@@ -78,6 +89,13 @@ class TierDeleteSchemaTest(BaseModel):
 class CategorySchemaTest(BaseModel):
     id: Optional[int] = None
     name: str
+
+
+class BookingSchema(BaseModel):
+    id: Optional[int] = None
+    owner_id: int
+    user_id: int
+    booking_date: datetime
 
 
 async_engine = create_async_engine(
@@ -135,6 +153,24 @@ def test_data_tier() -> list[dict]:
 @pytest.fixture(scope="function")
 def test_data_category() -> list[dict]:
     return [{"id": 1, "name": "Tech"}, {"id": 2, "name": "Health"}]
+
+
+@pytest.fixture(scope="function")
+def test_data_booking() -> list[dict]:
+    return [
+        {
+            "id": 1,
+            "owner_id": 1,
+            "user_id": 2,
+            "booking_date": datetime(2024, 3, 10, 15, 30),
+        },
+        {
+            "id": 2,
+            "owner_id": 1,
+            "user_id": 3,
+            "booking_date": datetime(2024, 3, 11, 10, 0),
+        },
+    ]
 
 
 @pytest.fixture

--- a/tests/sqlalchemy/crud/test_get_multi_joined.py
+++ b/tests/sqlalchemy/crud/test_get_multi_joined.py
@@ -1,5 +1,5 @@
 import pytest
-from fastcrud import FastCRUD, JoinConfig
+from fastcrud import FastCRUD, JoinConfig, aliased
 from ...sqlalchemy.conftest import (
     ModelTest,
     TierModel,
@@ -8,6 +8,8 @@ from ...sqlalchemy.conftest import (
     ReadSchemaTest,
     CategoryModel,
     CategorySchemaTest,
+    BookingModel,
+    BookingSchema,
 )
 
 
@@ -304,3 +306,137 @@ async def test_get_multi_joined_with_additional_join_model(
     assert all(
         "tier_name" in item and "category_name" in item for item in result["data"]
     )
+
+
+@pytest.mark.asyncio
+async def test_get_multi_joined_with_aliases(
+    async_session, test_data, test_data_tier, test_data_category, test_data_booking
+):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    for category_item in test_data_category:
+        async_session.add(CategoryModel(**category_item))
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    for booking_item in test_data_booking:
+        async_session.add(BookingModel(**booking_item))
+    await async_session.commit()
+
+    crud = FastCRUD(BookingModel)
+
+    expected_owner_name = "Charlie"
+    expected_user_name = "Alice"
+
+    owner_alias = aliased(ModelTest, name="owner")
+    user_alias = aliased(ModelTest, name="user")
+
+    result = await crud.get_multi_joined(
+        db=async_session,
+        schema_to_select=BookingSchema,
+        joins_config=[
+            JoinConfig(
+                model=ModelTest,
+                join_on=BookingModel.owner_id == owner_alias.id,
+                join_prefix="owner_",
+                alias=owner_alias,
+                schema_to_select=ReadSchemaTest,
+            ),
+            JoinConfig(
+                model=ModelTest,
+                join_on=BookingModel.user_id == user_alias.id,
+                join_prefix="user_",
+                alias=user_alias,
+                schema_to_select=ReadSchemaTest,
+            ),
+        ],
+        offset=0,
+        limit=10,
+        sort_columns=["booking_date"],
+        sort_orders=["asc"],
+    )
+
+    assert "data" in result and isinstance(
+        result["data"], list
+    ), "The result should have a 'data' key with a list of records."
+    for booking in result["data"]:
+        assert (
+            "owner_name" in booking
+        ), "Each record should include 'owner_name' from the joined owner ModelTest data."
+        assert (
+            "user_name" in booking
+        ), "Each record should include 'user_name' from the joined user ModelTest data."
+    assert result is not None
+    assert result["total_count"] >= 1, "Expected at least one booking record"
+    first_result = result["data"][0]
+    assert (
+        first_result["owner_name"] == expected_owner_name
+    ), "Owner name does not match expected value"
+    assert (
+        first_result["user_name"] == expected_user_name
+    ), "User name does not match expected value"
+
+
+@pytest.mark.asyncio
+async def test_get_multi_joined_with_aliases_no_schema(
+    async_session, test_data, test_data_tier, test_data_category, test_data_booking
+):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    for category_item in test_data_category:
+        async_session.add(CategoryModel(**category_item))
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    for booking_item in test_data_booking:
+        async_session.add(BookingModel(**booking_item))
+    await async_session.commit()
+
+    crud = FastCRUD(BookingModel)
+
+    expected_owner_name = "Charlie"
+    expected_user_name = "Alice"
+
+    owner_alias = aliased(ModelTest, name="owner")
+    user_alias = aliased(ModelTest, name="user")
+
+    result = await crud.get_multi_joined(
+        db=async_session,
+        schema_to_select=BookingSchema,
+        joins_config=[
+            JoinConfig(
+                model=ModelTest,
+                join_on=BookingModel.owner_id == owner_alias.id,
+                join_prefix="owner_",
+                alias=owner_alias,
+            ),
+            JoinConfig(
+                model=ModelTest,
+                join_on=BookingModel.user_id == user_alias.id,
+                join_prefix="user_",
+                alias=user_alias,
+            ),
+        ],
+        offset=0,
+        limit=10,
+        sort_columns=["booking_date"],
+        sort_orders=["asc"],
+    )
+
+    assert "data" in result and isinstance(
+        result["data"], list
+    ), "The result should have a 'data' key with a list of records."
+    for booking in result["data"]:
+        assert (
+            "owner_name" in booking
+        ), "Each record should include 'owner_name' from the joined owner ModelTest data."
+        assert (
+            "user_name" in booking
+        ), "Each record should include 'user_name' from the joined user ModelTest data."
+    assert result is not None
+    assert result["total_count"] >= 1, "Expected at least one booking record"
+    first_result = result["data"][0]
+    assert (
+        first_result["owner_name"] == expected_owner_name
+    ), "Owner name does not match expected value"
+    assert (
+        first_result["user_name"] == expected_user_name
+    ), "User name does not match expected value"

--- a/tests/sqlmodel/conftest.py
+++ b/tests/sqlmodel/conftest.py
@@ -47,6 +47,20 @@ class CreateSchemaTest(SQLModel):
     tier_id: int
 
 
+class BookingModel(SQLModel, table=True):
+    __tablename__ = "booking"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    owner_id: int = Field(default=None, foreign_key="test.id")
+    user_id: int = Field(default=None, foreign_key="test.id")
+    booking_date: datetime
+    owner: "ModelTest" = Relationship(
+        sa_relationship_kwargs={"foreign_keys": "BookingModel.owner_id"}
+    )
+    user: "ModelTest" = Relationship(
+        sa_relationship_kwargs={"foreign_keys": "BookingModel.user_id"}
+    )
+
+
 class ReadSchemaTest(SQLModel):
     id: int
     name: str
@@ -67,6 +81,18 @@ class TierSchemaTest(SQLModel):
 
 class TierDeleteSchemaTest(SQLModel):
     pass
+
+
+class CategorySchemaTest(SQLModel):
+    id: Optional[int] = None
+    name: str
+
+
+class BookingSchema(SQLModel):
+    id: Optional[int] = None
+    owner_id: int
+    user_id: int
+    booking_date: datetime
 
 
 async_engine = create_async_engine(
@@ -102,17 +128,17 @@ async def async_session() -> AsyncSession:
 @pytest.fixture(scope="function")
 def test_data() -> list[dict]:
     return [
-        {"id": 1, "name": "Charlie", "tier_id": 1},
-        {"id": 2, "name": "Alice", "tier_id": 2},
-        {"id": 3, "name": "Bob", "tier_id": 1},
-        {"id": 4, "name": "David", "tier_id": 2},
-        {"id": 5, "name": "Eve", "tier_id": 1},
-        {"id": 6, "name": "Frank", "tier_id": 2},
-        {"id": 7, "name": "Grace", "tier_id": 1},
-        {"id": 8, "name": "Hannah", "tier_id": 2},
-        {"id": 9, "name": "Ivan", "tier_id": 1},
-        {"id": 10, "name": "Judy", "tier_id": 2},
-        {"id": 11, "name": "Alice", "tier_id": 1},
+        {"id": 1, "name": "Charlie", "tier_id": 1, "category_id": 1},
+        {"id": 2, "name": "Alice", "tier_id": 2, "category_id": 1},
+        {"id": 3, "name": "Bob", "tier_id": 1, "category_id": 2},
+        {"id": 4, "name": "David", "tier_id": 2, "category_id": 1},
+        {"id": 5, "name": "Eve", "tier_id": 1, "category_id": 1},
+        {"id": 6, "name": "Frank", "tier_id": 2, "category_id": 2},
+        {"id": 7, "name": "Grace", "tier_id": 1, "category_id": 2},
+        {"id": 8, "name": "Hannah", "tier_id": 2, "category_id": 1},
+        {"id": 9, "name": "Ivan", "tier_id": 1, "category_id": 1},
+        {"id": 10, "name": "Judy", "tier_id": 2, "category_id": 2},
+        {"id": 11, "name": "Alice", "tier_id": 1, "category_id": 1},
     ]
 
 
@@ -124,6 +150,24 @@ def test_data_tier() -> list[dict]:
 @pytest.fixture(scope="function")
 def test_data_category() -> list[dict]:
     return [{"id": 1, "name": "Tech"}, {"id": 2, "name": "Health"}]
+
+
+@pytest.fixture(scope="function")
+def test_data_booking() -> list[dict]:
+    return [
+        {
+            "id": 1,
+            "owner_id": 1,
+            "user_id": 2,
+            "booking_date": datetime(2024, 3, 10, 15, 30),
+        },
+        {
+            "id": 2,
+            "owner_id": 1,
+            "user_id": 3,
+            "booking_date": datetime(2024, 3, 11, 10, 0),
+        },
+    ]
 
 
 @pytest.fixture

--- a/tests/sqlmodel/crud/test_get.py
+++ b/tests/sqlmodel/crud/test_get.py
@@ -2,8 +2,8 @@ import pytest
 from pydantic import BaseModel
 
 from fastcrud.crud.fast_crud import FastCRUD
-from ...sqlalchemy.conftest import ModelTest
-from ...sqlalchemy.conftest import CreateSchemaTest
+from ...sqlmodel.conftest import ModelTest
+from ...sqlmodel.conftest import CreateSchemaTest
 
 
 @pytest.mark.asyncio

--- a/tests/sqlmodel/crud/test_get_joined.py
+++ b/tests/sqlmodel/crud/test_get_joined.py
@@ -1,13 +1,16 @@
 import pytest
 from sqlalchemy import and_
-from fastcrud import FastCRUD, JoinConfig
-from ...sqlalchemy.conftest import (
+from fastcrud import FastCRUD, JoinConfig, aliased
+from ...sqlmodel.conftest import (
     ModelTest,
     TierModel,
     CreateSchemaTest,
     TierSchemaTest,
     CategoryModel,
     CategorySchemaTest,
+    BookingModel,
+    BookingSchema,
+    ReadSchemaTest,
 )
 
 
@@ -222,3 +225,113 @@ async def test_get_joined_multiple_models(
     assert "name" in result
     assert "tier_name" in result
     assert "category_name" in result
+
+
+@pytest.mark.asyncio
+async def test_get_joined_with_aliases(
+    async_session, test_data, test_data_tier, test_data_category, test_data_booking
+):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    for category_item in test_data_category:
+        async_session.add(CategoryModel(**category_item))
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
+    for booking_item in test_data_booking:
+        async_session.add(BookingModel(**booking_item))
+    await async_session.commit()
+
+    crud = FastCRUD(BookingModel)
+
+    specific_booking_id = 1
+    expected_owner_name = "Charlie"
+    expected_user_name = "Alice"
+
+    owner = aliased(ModelTest, name="owner")
+    user = aliased(ModelTest, name="user")
+
+    result = await crud.get_joined(
+        db=async_session,
+        schema_to_select=BookingSchema,
+        joins_config=[
+            JoinConfig(
+                model=ModelTest,
+                join_on=BookingModel.owner_id == owner.id,
+                join_prefix="owner_",
+                alias=owner,
+                schema_to_select=ReadSchemaTest,
+            ),
+            JoinConfig(
+                model=ModelTest,
+                join_on=BookingModel.user_id == user.id,
+                join_prefix="user_",
+                alias=user,
+                schema_to_select=ReadSchemaTest,
+            ),
+        ],
+        id=specific_booking_id,
+    )
+
+    assert result is not None
+    assert (
+        result["owner_name"] == expected_owner_name
+    ), "Owner name does not match expected value"
+    assert (
+        result["user_name"] == expected_user_name
+    ), "User name does not match expected value"
+
+
+@pytest.mark.asyncio
+async def test_get_joined_with_aliases_no_schema(
+    async_session, test_data, test_data_tier, test_data_category, test_data_booking
+):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    for category_item in test_data_category:
+        async_session.add(CategoryModel(**category_item))
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
+    for booking_item in test_data_booking:
+        async_session.add(BookingModel(**booking_item))
+    await async_session.commit()
+
+    crud = FastCRUD(BookingModel)
+
+    specific_booking_id = 1
+    expected_owner_name = "Charlie"
+    expected_user_name = "Alice"
+
+    owner = aliased(ModelTest, name="owner")
+    user = aliased(ModelTest, name="user")
+
+    result = await crud.get_joined(
+        db=async_session,
+        schema_to_select=BookingSchema,
+        joins_config=[
+            JoinConfig(
+                model=ModelTest,
+                join_on=BookingModel.owner_id == owner.id,
+                join_prefix="owner_",
+                alias=owner,
+            ),
+            JoinConfig(
+                model=ModelTest,
+                join_on=BookingModel.user_id == user.id,
+                join_prefix="user_",
+                alias=user,
+            ),
+        ],
+        id=specific_booking_id,
+    )
+
+    assert result is not None
+    assert (
+        result["owner_name"] == expected_owner_name
+    ), "Owner name does not match expected value"
+    assert (
+        result["user_name"] == expected_user_name
+    ), "User name does not match expected value"

--- a/tests/sqlmodel/crud/test_get_multi_by_cursor.py
+++ b/tests/sqlmodel/crud/test_get_multi_by_cursor.py
@@ -1,6 +1,6 @@
 import pytest
 from fastcrud.crud.fast_crud import FastCRUD
-from ...sqlalchemy.conftest import ModelTest
+from ...sqlmodel.conftest import ModelTest
 
 
 @pytest.mark.asyncio

--- a/tests/sqlmodel/crud/test_update.py
+++ b/tests/sqlmodel/crud/test_update.py
@@ -4,7 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import MultipleResultsFound
 
 from fastcrud.crud.fast_crud import FastCRUD
-from ...sqlalchemy.conftest import ModelTest
+from ...sqlmodel.conftest import ModelTest
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Using aliases
## Added
- Now get_joined and get_multi_joined can be used with aliases, making it possible to join the same model multiple times.

## Detailed
___

In complex query scenarios, particularly when you need to join a table to itself or perform multiple joins on the same table for different purposes, aliasing becomes crucial. Aliasing allows you to refer to the same table in different contexts with unique identifiers, avoiding conflicts and ambiguity in your queries.

For both `get_joined` and `get_multi_joined` methods, when you need to join the same model multiple times, you can utilize the `alias` parameter within your `JoinConfig` to differentiate between the joins. This parameter expects an instance of `AliasedClass`, which can be created using the `aliased` function from SQLAlchemy (also in fastcrud for convenience).

#### Example: Joining the Same Model Multiple Times

Consider a task management application where tasks have both an owner and an assigned user, represented by the same `UserModel`. To fetch tasks with details of both users, we use aliases to join the `UserModel` twice, distinguishing between owners and assigned users.

Let's start by creating the aliases and passing them to the join configuration. Don't forget to use the alias for `join_on`:

```python hl_lines="4-5 11 15 19 23" title="Join Configurations with Aliases"
from fastcrud import FastCRUD, JoinConfig, aliased

# Create aliases for UserModel to distinguish between the owner and the assigned user
owner_alias = aliased(UserModel, name="owner")
assigned_user_alias = aliased(UserModel, name="assigned_user")

# Configure joins with aliases
joins_config = [
    JoinConfig(
        model=UserModel,
        join_on=Task.owner_id == owner_alias.id,
        join_prefix="owner_",
        schema_to_select=UserSchema,
        join_type="inner",
        alias=owner_alias  # Pass the aliased class instance
    ),
    JoinConfig(
        model=UserModel,
        join_on=Task.assigned_user_id == assigned_user_alias.id,
        join_prefix="assigned_",
        schema_to_select=UserSchema,
        join_type="inner",
        alias=assigned_user_alias  # Pass the aliased class instance
    )
]

# Initialize your FastCRUD instance for TaskModel
task_crud = FastCRUD(TaskModel)

# Fetch tasks with joined user details
tasks = await task_crud.get_multi_joined(
    db=session,
    schema_to_select=TaskSchema,
    joins_config=joins_config,
    offset=0,
    limit=10
)
```

Then just pass this joins_config to `get_multi_joined`:

```python hl_lines="17" title="Passing joins_config to get_multi_joined"
from fastcrud import FastCRUD, JoinConfig, aliased

...

# Configure joins with aliases
joins_config = [
    ...
]

# Initialize your FastCRUD instance for TaskModel
task_crud = FastCRUD(TaskModel)

# Fetch tasks with joined user details
tasks = await task_crud.get_multi_joined(
    db=session,
    schema_to_select=TaskSchema,
    joins_config=joins_config,
    offset=0,
    limit=10
)
```

In this example, `owner_alias` and `assigned_user_alias` are created from `UserModel` to distinguish between the task's owner and the assigned user within the task management system. By using aliases, you can join the same model multiple times for different purposes in your queries, enhancing expressiveness and eliminating ambiguity.

Closes #27 