### PR TITLE
feat: ✨ add multiple primary keys support

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -540,14 +540,13 @@ class FastCRUD(
         primary_filters = self._parse_filters(**kwargs)
 
         if joins_config is not None:
-            primary_keys = _get_primary_keys(self.model)
+            primary_keys = [p.name for p in _get_primary_keys(self.model)]
             if not any(primary_keys):
                 raise ValueError(
                     f"The model '{self.model.__name__}' does not have a primary key defined, which is required for counting with joins."
                 )
             to_select = [
-                getattr(self.model, pk).label(f"distinct_{pk.name}")
-                for pk in primary_keys
+                getattr(self.model, pk).label(f"distinct_{pk}") for pk in primary_keys
             ]
             base_query = select(*to_select)
 

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Type, TypeVar, Optional, Callable, Sequence, Union
+from typing import Dict, Type, TypeVar, Optional, Callable, Sequence, Union
 from enum import Enum
 
 from fastapi import Depends, Body, Query, APIRouter, params
@@ -19,7 +19,13 @@ UpdateSchemaInternalType = TypeVar("UpdateSchemaInternalType", bound=BaseModel)
 DeleteSchemaType = TypeVar("DeleteSchemaType", bound=BaseModel)
 
 
-def apply_model_pk(**pkeys):
+def apply_model_pk(**pkeys: Dict[str, type]):
+    """
+    This decorator injects positional arguments into a fastCRUD endpoint.
+    It dynamically changes the endpoint signature and allows to use
+    multiple primary keys without defining them explicitly.
+    """
+
     def wrapper(endpoint):
         signature = inspect.signature(endpoint)
         parameters = [

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -11,7 +11,12 @@ from ..crud.fast_crud import FastCRUD
 from ..exceptions.http_exceptions import DuplicateValueException, NotFoundException
 from ..paginated.helper import compute_offset
 from ..paginated.response import paginated_response
-from .helper import CRUDMethods, _extract_unique_columns, _get_primary_keys
+from .helper import (
+    CRUDMethods,
+    _extract_unique_columns,
+    _get_primary_keys,
+    _get_python_type,
+)
 
 CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
 UpdateSchemaType = TypeVar("UpdateSchemaType", bound=BaseModel)
@@ -183,7 +188,7 @@ class EndpointCreator:
     ) -> None:
         self._primary_keys = _get_primary_keys(model)
         self._primary_keys_types = {
-            pk.name: pk.type.python_type for pk in self._primary_keys
+            pk.name: _get_python_type(pk) for pk in self._primary_keys
         }
         self.primary_key_names = [pk.name for pk in self._primary_keys]
         self.session = session

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -3,16 +3,15 @@ from enum import Enum
 import forge
 
 from fastapi import Depends, Body, Query, APIRouter, params
+from pydantic import BaseModel, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase
-from pydantic import BaseModel, ValidationError
 
-from ..exceptions.http_exceptions import NotFoundException
 from ..crud.fast_crud import FastCRUD
-from ..exceptions.http_exceptions import DuplicateValueException
-from .helper import CRUDMethods, _get_primary_keys, _extract_unique_columns
-from ..paginated.response import paginated_response
+from ..exceptions.http_exceptions import DuplicateValueException, NotFoundException
 from ..paginated.helper import compute_offset
+from ..paginated.response import paginated_response
+from .helper import CRUDMethods, _extract_unique_columns, _get_primary_keys
 
 CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
 UpdateSchemaType = TypeVar("UpdateSchemaType", bound=BaseModel)

--- a/fastcrud/endpoint/helper.py
+++ b/fastcrud/endpoint/helper.py
@@ -52,7 +52,8 @@ def _get_primary_keys(model: DeclarativeBase) -> Union[str, None]:
     primary_key_columns = inspector.primary_key
 
     # Some patching when using derived sa.TypeDecorator as primary keys
-    #
+    # if sa.TypeDecorator.python_type is not implemented by using
+    # the sa.TypeDecorator.impl.python_type one.
     for pk in primary_key_columns:
         try:
             pk.type.python_type

--- a/fastcrud/endpoint/helper.py
+++ b/fastcrud/endpoint/helper.py
@@ -2,7 +2,7 @@ from typing import Union, Annotated, Sequence
 from pydantic import BaseModel, Field, ValidationError
 from pydantic.functional_validators import field_validator
 
-from sqlalchemy import inspect
+from sqlalchemy import Column, inspect
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.sql.elements import KeyedColumnElement
 
@@ -43,10 +43,10 @@ class CRUDMethods(BaseModel):
 
 
 def _get_primary_key(model: type[DeclarativeBase]) -> Union[str, None]:
-    return _get_primary_keys(model)[0]
+    return _get_primary_keys(model)[0].name
 
 
-def _get_primary_keys(model: DeclarativeBase) -> Union[str, None]:
+def _get_primary_keys(model: type[DeclarativeBase]) -> Sequence[Column]:
     """Get the primary key of a SQLAlchemy model."""
     inspector = inspect(model).mapper
     primary_key_columns = inspector.primary_key
@@ -58,7 +58,7 @@ def _get_primary_keys(model: DeclarativeBase) -> Union[str, None]:
         try:
             pk.type.python_type
         except NotImplementedError:
-            pk.type.__class__.python_type = pk.type.__class__.impl.python_type
+            pk.type.__class__.python_type = pk.type.__class__.impl.python_type  # type: ignore
 
     return primary_key_columns
 

--- a/fastcrud/endpoint/helper.py
+++ b/fastcrud/endpoint/helper.py
@@ -50,10 +50,7 @@ def _get_primary_keys(model: DeclarativeBase) -> Union[str, None]:
     """Get the primary key of a SQLAlchemy model."""
     inspector = inspect(model).mapper
     primary_key_columns = inspector.primary_key
-    return [
-        primary_key_column.name if primary_key_columns else None
-        for primary_key_column in primary_key_columns
-    ]
+    return primary_key_columns
 
 
 def _extract_unique_columns(

--- a/fastcrud/endpoint/helper.py
+++ b/fastcrud/endpoint/helper.py
@@ -43,10 +43,17 @@ class CRUDMethods(BaseModel):
 
 
 def _get_primary_key(model: type[DeclarativeBase]) -> Union[str, None]:
+    return _get_primary_keys(model)[0]
+
+
+def _get_primary_keys(model: DeclarativeBase) -> Union[str, None]:
     """Get the primary key of a SQLAlchemy model."""
     inspector = inspect(model).mapper
     primary_key_columns = inspector.primary_key
-    return primary_key_columns[0].name if primary_key_columns else None
+    return [
+        primary_key_column.name if primary_key_columns else None
+        for primary_key_column in primary_key_columns
+    ]
 
 
 def _extract_unique_columns(

--- a/fastcrud/endpoint/helper.py
+++ b/fastcrud/endpoint/helper.py
@@ -58,8 +58,8 @@ def _get_python_type(column: Column) -> Optional[type]:
     try:
         return column.type.python_type
     except NotImplementedError:
-        if hasattr(column.type, "impl") and hasattr(column.type.impl, "python_type"):
-            return column.type.impl.python_type
+        if hasattr(column.type, "impl") and hasattr(column.type.impl, "python_type"):  # type: ignore
+            return column.type.impl.python_type  # type: ignore
         else:
             raise NotImplementedError(
                 f"The primary key column {column.name} uses a custom type without a defined `python_type` or suitable `impl` fallback."

--- a/fastcrud/endpoint/helper.py
+++ b/fastcrud/endpoint/helper.py
@@ -50,6 +50,15 @@ def _get_primary_keys(model: DeclarativeBase) -> Union[str, None]:
     """Get the primary key of a SQLAlchemy model."""
     inspector = inspect(model).mapper
     primary_key_columns = inspector.primary_key
+
+    # Some patching when using derived sa.TypeDecorator as primary keys
+    #
+    for pk in primary_key_columns:
+        try:
+            pk.type.python_type
+        except NotImplementedError:
+            pk.type.__class__.python_type = pk.type.__class__.impl.python_type
+
     return primary_key_columns
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ SQLAlchemy = "^2.0.0"
 pydantic = "^2.0.0"
 SQLAlchemy-Utils = "^0.41.1"
 fastapi = ">=0.100.0,<0.110.0"
+python-forge = "^18.6.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,7 @@ authors = ["Igor Benav <igor.magalhaes.r@gmail.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/igorbenav/fastcrud"
-include = [
-    "LICENSE",
-]
+include = ["LICENSE"]
 
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -22,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
     "Framework :: FastAPI",
-    "Typing :: Typed"
+    "Typing :: Typed",
 ]
 
 keywords = ["fastapi", "crud", "async", "sqlalchemy", "pydantic"]
@@ -33,7 +31,6 @@ SQLAlchemy = "^2.0.0"
 pydantic = "^2.0.0"
 SQLAlchemy-Utils = "^0.41.1"
 fastapi = ">=0.100.0,<0.110.0"
-python-forge = "^18.6.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.4"

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -21,8 +21,8 @@ class Base(DeclarativeBase):
 class MultiPkModel(Base):
     __tablename__ = "multi_pk"
     # tests = relationship("ModelTest", back_populates="category")
-    id1 = Column(Integer, primary_key=True)
-    id2 = Column(Integer, primary_key=True)
+    id = Column(Integer, primary_key=True)
+    uuid = Column(String(32), primary_key=True)
     name = Column(String, unique=True)
     test_id = Column(Integer, ForeignKey("test.id"))
     test = relationship("ModelTest", back_populates="multi_pk")
@@ -133,8 +133,8 @@ class CategorySchemaTest(BaseModel):
 
 
 class MultiPkSchema(BaseModel):
-    id1: int
-    id2: int
+    id: int
+    uuid: str
     name: str
 
 
@@ -206,12 +206,15 @@ def test_data_category() -> list[dict]:
     return [{"id": 1, "name": "Tech"}, {"id": 2, "name": "Health"}]
 
 
-@pytest.fixture(scope="function")
-def test_data_multipk() -> list[dict]:
-    return [
-        {"id1": 1, "id2": 1, "name": "Tech"},
-        {"id1": 1, "id2": 2, "name": "Health"},
-    ]
+@pytest.fixture(
+    scope="function",
+    params=[
+        {"id": 1, "uuid": "a", "name": "Tech"},
+        {"id": 1, "uuid": "b", "name": "Health"},
+    ],
+)
+def test_data_multipk(request) -> list[dict]:
+    return request.param
 
 
 @pytest.fixture(scope="function")
@@ -336,8 +339,8 @@ def client(
             create_schema=multi_pk_test_create_schema,
             update_schema=multi_pk_test_schema,
             delete_schema=multi_pk_test_schema,
-            path="/multi_pk_model",
-            tags=["multi_pk_model"],
+            path="/multi_pk",
+            tags=["multi_pk"],
         )
     )
 

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -18,6 +18,14 @@ class Base(DeclarativeBase):
     pass
 
 
+class ModelMultiPK(Base):
+    __tablename__ = "multi_pk"
+    # tests = relationship("ModelTest", back_populates="category")
+    id1 = Column(Integer, primary_key=True)
+    id2 = Column(Integer, primary_key=True)
+    name = Column(String, unique=True)
+
+
 class CategoryModel(Base):
     __tablename__ = "category"
     tests = relationship("ModelTest", back_populates="category")
@@ -121,6 +129,15 @@ class CategorySchemaTest(BaseModel):
     name: str
 
 
+class MultiPkCreate(BaseModel):
+    name: str
+
+
+class MultiPkSchema(MultiPkCreate):
+    id1: int
+    id2: int
+
+
 class BookingSchema(BaseModel):
     id: Optional[int] = None
     owner_id: int
@@ -186,6 +203,19 @@ def test_data_category() -> list[dict]:
 
 
 @pytest.fixture(scope="function")
+def test_data_multipk() -> list[dict]:
+    return [
+        {"id1": 1, "id2": 1, "name": "Tech"},
+        {"id1": 1, "id2": 2, "name": "Health"},
+    ]
+
+
+@pytest.fixture
+def multi_pk_model():
+    return ModelMultiPK
+
+
+@pytest.fixture(scope="function")
 def test_data_booking() -> list[dict]:
     return [
         {
@@ -244,14 +274,27 @@ def tier_delete_schema():
 
 
 @pytest.fixture
+def multi_pk_test_schema():
+    return MultiPkSchema
+
+
+@pytest.fixture
+def multi_pk_test_create_schema():
+    return MultiPkCreate
+
+
+@pytest.fixture
 def client(
     test_model,
     tier_model,
+    multi_pk_model,
     create_schema,
     update_schema,
     delete_schema,
     tier_schema,
     tier_delete_schema,
+    multi_pk_test_schema,
+    multi_pk_test_create_schema,
 ):
     app = FastAPI()
 
@@ -278,6 +321,19 @@ def client(
             delete_schema=tier_delete_schema,
             path="/tier",
             tags=["tier"],
+        )
+    )
+
+    app.include_router(
+        crud_router(
+            session=get_session_local,
+            model=multi_pk_model,
+            crud=FastCRUD(multi_pk_model),
+            create_schema=multi_pk_test_create_schema,
+            update_schema=multi_pk_test_schema,
+            delete_schema=multi_pk_test_schema,
+            path="/multi_pk_model",
+            tags=["multi_pk_model"],
         )
     )
 

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -132,13 +132,14 @@ class CategorySchemaTest(BaseModel):
     name: str
 
 
-class MultiPkCreate(BaseModel):
+class MultiPkSchema(BaseModel):
     id1: int
     id2: int
-
-
-class MultiPkSchema(BaseModel):
     name: str
+
+
+class MultiPkCreate(MultiPkSchema):
+    pass
 
 
 class BookingSchema(BaseModel):

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -18,12 +18,14 @@ class Base(DeclarativeBase):
     pass
 
 
-class ModelMultiPK(Base):
+class MultiPkModel(Base):
     __tablename__ = "multi_pk"
     # tests = relationship("ModelTest", back_populates="category")
     id1 = Column(Integer, primary_key=True)
     id2 = Column(Integer, primary_key=True)
     name = Column(String, unique=True)
+    test_id = Column(Integer, ForeignKey("test.id"))
+    test = relationship("ModelTest", back_populates="multi_pk")
 
 
 class CategoryModel(Base):
@@ -43,6 +45,7 @@ class ModelTest(Base):
     )
     tier = relationship("TierModel", back_populates="tests")
     category = relationship("CategoryModel", back_populates="tests")
+    multi_pk = relationship("MultiPkModel", back_populates="test")
     is_deleted = Column(Boolean, default=False)
     deleted_at = Column(DateTime, nullable=True, default=None)
 
@@ -130,12 +133,12 @@ class CategorySchemaTest(BaseModel):
 
 
 class MultiPkCreate(BaseModel):
-    name: str
-
-
-class MultiPkSchema(MultiPkCreate):
     id1: int
     id2: int
+
+
+class MultiPkSchema(BaseModel):
+    name: str
 
 
 class BookingSchema(BaseModel):
@@ -210,11 +213,6 @@ def test_data_multipk() -> list[dict]:
     ]
 
 
-@pytest.fixture
-def multi_pk_model():
-    return ModelMultiPK
-
-
 @pytest.fixture(scope="function")
 def test_data_booking() -> list[dict]:
     return [
@@ -271,6 +269,11 @@ def delete_schema():
 @pytest.fixture
 def tier_delete_schema():
     return TierDeleteSchemaTest
+
+
+@pytest.fixture
+def multi_pk_model():
+    return MultiPkModel
 
 
 @pytest.fixture

--- a/tests/sqlalchemy/crud/test_create.py
+++ b/tests/sqlalchemy/crud/test_create.py
@@ -69,7 +69,7 @@ async def test_create_successful_multi_pk(
     async_session, multi_pk_model, multi_pk_test_create_schema
 ):
     crud = FastCRUD(multi_pk_model)
-    new_data = multi_pk_test_create_schema(name="New Record", id1=1, id2=1)
+    new_data = multi_pk_test_create_schema(name="New Record", id=1, uuid="a")
     await crud.create(async_session, new_data)
 
     stmt = select(multi_pk_model).where(multi_pk_model.name == "New Record")
@@ -78,5 +78,5 @@ async def test_create_successful_multi_pk(
 
     assert fetched_record is not None
     assert fetched_record.name == "New Record"
-    assert fetched_record.id1 == 1
-    assert fetched_record.id2 == 1
+    assert fetched_record.id == 1
+    assert fetched_record.uuid == "a"

--- a/tests/sqlalchemy/crud/test_create.py
+++ b/tests/sqlalchemy/crud/test_create.py
@@ -62,3 +62,21 @@ async def test_create_with_invalid_data_types(async_session, test_model, create_
     invalid_data = {"name": 123, "tier_id": "invalid"}
     with pytest.raises(ValidationError):
         await crud.create(async_session, create_schema(**invalid_data))
+
+
+@pytest.mark.asyncio
+async def test_create_successful_multi_pk(
+    async_session, multi_pk_model, multi_pk_test_create_schema
+):
+    crud = FastCRUD(multi_pk_model)
+    new_data = multi_pk_test_create_schema(name="New Record", id1=1, id2=1)
+    await crud.create(async_session, new_data)
+
+    stmt = select(multi_pk_model).where(multi_pk_model.name == "New Record")
+    result = await async_session.execute(stmt)
+    fetched_record = result.scalar_one_or_none()
+
+    assert fetched_record is not None
+    assert fetched_record.name == "New Record"
+    assert fetched_record.id1 == 1
+    assert fetched_record.id2 == 1

--- a/tests/sqlalchemy/endpoint/test_create_item.py
+++ b/tests/sqlalchemy/endpoint/test_create_item.py
@@ -21,6 +21,31 @@ async def test_create_item(client: TestClient, async_session, test_model, test_d
 
 
 @pytest.mark.asyncio
+async def test_create_item_with_multiple_primary_keys(
+    client: TestClient, async_session, multi_pk_model, test_data_multipk
+):
+    # for test_data_multipk in test_data_multipk:
+    response = client.post(
+        "/multi_pk/create",
+        json=test_data_multipk,
+    )
+
+    assert response.status_code == 200
+
+    stmt = select(multi_pk_model).where(
+        multi_pk_model.name == test_data_multipk["name"]
+    )
+
+    result = await async_session.execute(stmt)
+    fetched_record = result.scalar_one_or_none()
+
+    assert fetched_record is not None, response.text
+    assert fetched_record.name == test_data_multipk["name"]
+    assert fetched_record.id == test_data_multipk["id"]
+    assert fetched_record.uuid == test_data_multipk["uuid"]
+
+
+@pytest.mark.asyncio
 async def test_create_tier_duplicate_check(client: TestClient, async_session):
     test_tier_1 = {"name": "Premium"}
     response = client.post("/tier/create", json=test_tier_1)

--- a/tests/sqlalchemy/endpoint/test_get_item.py
+++ b/tests/sqlalchemy/endpoint/test_get_item.py
@@ -22,6 +22,25 @@ async def test_read_item_success(
 
 
 @pytest.mark.asyncio
+async def test_read_multi_primary_key_item_success(
+    client: TestClient, async_session, multi_pk_model, test_data_multipk
+):
+    tester_data = test_data_multipk
+    new_item = multi_pk_model(**tester_data)
+    async_session.add(new_item)
+    await async_session.commit()
+    await async_session.refresh(new_item)
+
+    response = client.get(f"/multi_pk/get/{new_item.id}/{new_item.uuid}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == tester_data["name"]
+    assert data["id"] == tester_data["id"]
+    assert data["uuid"] == tester_data["uuid"]
+
+
+@pytest.mark.asyncio
 async def test_read_item_not_found(client: TestClient, async_session, test_model):
     stmt = select(test_model.id).order_by(test_model.id.desc()).limit(1)
     result = await async_session.execute(stmt)

--- a/tests/sqlmodel/conftest.py
+++ b/tests/sqlmodel/conftest.py
@@ -319,4 +319,17 @@ def client(
         )
     )
 
+    app.include_router(
+        crud_router(
+            session=get_session_local,
+            model=multi_pk_model,
+            crud=FastCRUD(multi_pk_model),
+            create_schema=multi_pk_test_create_schema,
+            update_schema=multi_pk_test_schema,
+            delete_schema=multi_pk_test_schema,
+            path="/multi_pk",
+            tags=["multi_pk"],
+        )
+    )
+
     return TestClient(app)

--- a/tests/sqlmodel/conftest.py
+++ b/tests/sqlmodel/conftest.py
@@ -15,6 +15,15 @@ from fastcrud.crud.fast_crud import FastCRUD
 from fastcrud.endpoint.crud_router import crud_router
 
 
+class MultiPKModel(SQLModel, table=True):
+    __tablename__ = "multi_pk"
+    id1: Optional[int] = Field(default=None, primary_key=True)
+    id2: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    # tier_id: int = Field(default=None, foreign_key="tier.id")
+    # tier: "TierModel" = Relationship(back_populates="multi_pk")
+
+
 class CategoryModel(SQLModel, table=True):
     __tablename__ = "category"
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -176,6 +185,14 @@ def test_data_tier() -> list[dict]:
 @pytest.fixture(scope="function")
 def test_data_category() -> list[dict]:
     return [{"id": 1, "name": "Tech"}, {"id": 2, "name": "Health"}]
+
+
+@pytest.fixture(scope="function")
+def test_data_multipk() -> list[dict]:
+    return [
+        {"id1": 1, "id2": 1, "name": "Tech"},
+        {"id1": 1, "id2": 2, "name": "Health"},
+    ]
 
 
 @pytest.fixture(scope="function")

--- a/tests/sqlmodel/conftest.py
+++ b/tests/sqlmodel/conftest.py
@@ -20,8 +20,8 @@ class MultiPKModel(SQLModel, table=True):
     id1: Optional[int] = Field(default=None, primary_key=True)
     id2: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(index=True)
-    # tier_id: int = Field(default=None, foreign_key="tier.id")
-    # tier: "TierModel" = Relationship(back_populates="multi_pk")
+    test_id: Optional[int] = Field(default=None, foreign_key="test.id")
+    test: "ModelTest" = Relationship(back_populates="multi_pk")
 
 
 class CategoryModel(SQLModel, table=True):
@@ -38,6 +38,7 @@ class ModelTest(SQLModel, table=True):
     tier_id: int = Field(default=None, foreign_key="tier.id")
     category_id: Optional[int] = Field(default=None, foreign_key="category.id")
     tier: "TierModel" = Relationship(back_populates="tests")
+    multi_pk: "MultiPKModel" = Relationship(back_populates="test")
     category: "CategoryModel" = Relationship(back_populates="tests")
     is_deleted: bool = Field(default=False)
     deleted_at: Optional[datetime] = Field(default=None)
@@ -128,6 +129,18 @@ class BookingSchema(SQLModel):
     owner_id: int
     user_id: int
     booking_date: datetime
+
+
+class MultiPkCreate(SQLModel):
+    id1: int
+    id2: int
+    name: str
+    test_id: int = None
+
+
+class MultiPkSchema(SQLModel):
+    name: str
+    test_id: int = None
 
 
 async_engine = create_async_engine(
@@ -251,6 +264,21 @@ def delete_schema():
 @pytest.fixture
 def tier_delete_schema():
     return TierDeleteSchemaTest
+
+
+@pytest.fixture
+def multi_pk_model():
+    return MultiPKModel
+
+
+@pytest.fixture
+def multi_pk_test_schema():
+    return MultiPkSchema
+
+
+@pytest.fixture
+def multi_pk_test_create_schema():
+    return MultiPkCreate
 
 
 @pytest.fixture

--- a/tests/sqlmodel/conftest.py
+++ b/tests/sqlmodel/conftest.py
@@ -17,8 +17,8 @@ from fastcrud.endpoint.crud_router import crud_router
 
 class MultiPKModel(SQLModel, table=True):
     __tablename__ = "multi_pk"
-    id1: Optional[int] = Field(default=None, primary_key=True)
-    id2: Optional[int] = Field(default=None, primary_key=True)
+    id: Optional[int] = Field(default=None, primary_key=True)
+    uuid: Optional[str] = Field(default=None, primary_key=True, max_length=25)
     name: str = Field(index=True)
     test_id: Optional[int] = Field(default=None, foreign_key="test.id")
     test: "ModelTest" = Relationship(back_populates="multi_pk")
@@ -132,8 +132,8 @@ class BookingSchema(SQLModel):
 
 
 class MultiPkCreate(SQLModel):
-    id1: int
-    id2: int
+    id: int
+    uuid: str
     name: str
     test_id: int = None
 
@@ -200,12 +200,15 @@ def test_data_category() -> list[dict]:
     return [{"id": 1, "name": "Tech"}, {"id": 2, "name": "Health"}]
 
 
-@pytest.fixture(scope="function")
-def test_data_multipk() -> list[dict]:
-    return [
-        {"id1": 1, "id2": 1, "name": "Tech"},
-        {"id1": 1, "id2": 2, "name": "Health"},
-    ]
+@pytest.fixture(
+    scope="function",
+    params=[
+        {"id": 1, "uuid": "a", "name": "Tech"},
+        {"id": 1, "uuid": "b", "name": "Health"},
+    ],
+)
+def test_data_multipk(request) -> list[dict]:
+    return request.param
 
 
 @pytest.fixture(scope="function")
@@ -285,11 +288,14 @@ def multi_pk_test_create_schema():
 def client(
     test_model,
     tier_model,
+    multi_pk_model,
     create_schema,
     update_schema,
     delete_schema,
     tier_schema,
     tier_delete_schema,
+    multi_pk_test_schema,
+    multi_pk_test_create_schema,
 ):
     app = FastAPI()
 

--- a/tests/sqlmodel/crud/test_create.py
+++ b/tests/sqlmodel/crud/test_create.py
@@ -69,7 +69,7 @@ async def test_create_successful_multi_pk(
     async_session, multi_pk_model, multi_pk_test_create_schema
 ):
     crud = FastCRUD(multi_pk_model)
-    new_data = multi_pk_test_create_schema(name="New Record", id1=1, id2=1)
+    new_data = multi_pk_test_create_schema(name="New Record", id=1, uuid="a")
     await crud.create(async_session, new_data)
 
     stmt = select(multi_pk_model).where(multi_pk_model.name == "New Record")
@@ -78,5 +78,5 @@ async def test_create_successful_multi_pk(
 
     assert fetched_record is not None
     assert fetched_record.name == "New Record"
-    assert fetched_record.id1 == 1
-    assert fetched_record.id2 == 1
+    assert fetched_record.id == 1
+    assert fetched_record.uuid == "a"

--- a/tests/sqlmodel/crud/test_create.py
+++ b/tests/sqlmodel/crud/test_create.py
@@ -62,3 +62,21 @@ async def test_create_with_invalid_data_types(async_session, test_model, create_
     invalid_data = {"name": 123, "tier_id": "invalid"}
     with pytest.raises(ValidationError):
         await crud.create(async_session, create_schema(**invalid_data))
+
+
+@pytest.mark.asyncio
+async def test_create_successful_multi_pk(
+    async_session, multi_pk_model, multi_pk_test_create_schema
+):
+    crud = FastCRUD(multi_pk_model)
+    new_data = multi_pk_test_create_schema(name="New Record", id1=1, id2=1)
+    await crud.create(async_session, new_data)
+
+    stmt = select(multi_pk_model).where(multi_pk_model.name == "New Record")
+    result = await async_session.execute(stmt)
+    fetched_record = result.scalar_one_or_none()
+
+    assert fetched_record is not None
+    assert fetched_record.name == "New Record"
+    assert fetched_record.id1 == 1
+    assert fetched_record.id2 == 1

--- a/tests/sqlmodel/endpoint/test_create_item.py
+++ b/tests/sqlmodel/endpoint/test_create_item.py
@@ -32,3 +32,28 @@ async def test_create_tier_duplicate_check(client: TestClient, async_session):
     assert response.status_code == 422, response.text
 
     assert "is already registered" in response.text, response.text
+
+
+@pytest.mark.asyncio
+async def test_create_item_with_multiple_primary_keys(
+    client: TestClient, async_session, multi_pk_model, test_data_multipk
+):
+    # for test_data_multipk in test_data_multipk:
+    response = client.post(
+        "/multi_pk/create",
+        json=test_data_multipk,
+    )
+
+    assert response.status_code == 200
+
+    stmt = select(multi_pk_model).where(
+        multi_pk_model.name == test_data_multipk["name"]
+    )
+
+    result = await async_session.execute(stmt)
+    fetched_record = result.scalar_one_or_none()
+
+    assert fetched_record is not None, response.text
+    assert fetched_record.name == test_data_multipk["name"]
+    assert fetched_record.id == test_data_multipk["id"]
+    assert fetched_record.uuid == test_data_multipk["uuid"]

--- a/tests/sqlmodel/endpoint/test_get_item.py
+++ b/tests/sqlmodel/endpoint/test_get_item.py
@@ -32,3 +32,22 @@ async def test_read_item_not_found(client: TestClient, async_session, test_model
     response = client.get(f"/test/get/{non_existent_id}")
     assert response.status_code == 404
     assert response.json() == {"detail": "Item not found"}
+
+
+@pytest.mark.asyncio
+async def test_read_multi_primary_key_item_success(
+    client: TestClient, async_session, multi_pk_model, test_data_multipk
+):
+    tester_data = test_data_multipk
+    new_item = multi_pk_model(**tester_data)
+    async_session.add(new_item)
+    await async_session.commit()
+    await async_session.refresh(new_item)
+
+    response = client.get(f"/multi_pk/get/{new_item.id}/{new_item.uuid}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == tester_data["name"]
+    assert data["id"] == tester_data["id"]
+    assert data["uuid"] == tester_data["uuid"]


### PR DESCRIPTION
# Pull Request Template for FastCRUD

## Description
This PR aims to provide multiple primary key handling with the basic crud and the endpoint creator. 
This way, for a model such as :
```python
class MultiPkModel(Base):
    __tablename__ = "multi_pk"
    id = Column(Integer, primary_key=True)
    uuid = Column(String(32), primary_key=True)
    name = Column(String, unique=True)
```
the endpoint creator should gives a path like `/multi_pk/get/{id}/{uuid}` for the different endpoints (get, update and delete) that need primary keys to interact with the database. The order of path parameter is given by the column order.

## Changes
There is some monkey patching of TypeDecorator to also cover custom types. 
Although it works, this piece of code seems a bit hacky and might need improvement from SQLModel or even better sqlalchemy.

## Tests
Add multiple primary keys tests on create, get and delete crud/endpoints for both sqlmodel and sqlalchemy.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.

## Additional Notes
This PR also allows to not be restricted to the `id` name for primary key 😄 
