### PR TITLE
Skip count call when possible

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -1358,8 +1358,7 @@ class FastCRUD(
             update(db, {'username': 'new_username'}, id__ne=1, allow_multiple=False)
             ```
         """
-        total_count = await self.count(db, **kwargs)
-        if not allow_multiple and total_count > 1:
+        if not allow_multiple and (total_count := await self.count(db, **kwargs)) > 1:
             raise MultipleResultsFound(
                 f"Expected exactly one record to update, found {total_count}."
             )
@@ -1423,8 +1422,7 @@ class FastCRUD(
             db_delete(db, username='unique_username', allow_multiple=False)
             ```
         """
-        total_count = await self.count(db, **kwargs)
-        if not allow_multiple and total_count > 1:
+        if not allow_multiple and (total_count := await self.count(db, **kwargs)) > 1:
             raise MultipleResultsFound(
                 f"Expected exactly one record to delete, found {total_count}."
             )


### PR DESCRIPTION
# Pull Request Template for FastCRUD

## Description
Hi, I saw you fixed the optional count feature on your own. Sorry, I was a bit busy recently and had some minor issues running poetry on my WSL. New implementation looks cool, just 1 additional thing which I spotted during my development is count can be skipped in some cases entirerly.

## Tests
Tests pass without changes.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.
