### PR TITLE
refactor: :recycle: reuse of select method in FastCRUD

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -348,6 +348,7 @@ class FastCRUD(
         )
         filters = self._parse_filters(**kwargs)
         stmt = select(*to_select).filter(*filters)
+
         if sort_columns:
             stmt = self._apply_sorting(stmt, sort_columns, sort_orders)
         return stmt
@@ -401,11 +402,7 @@ class FastCRUD(
             user = await crud.get(db, username__ne='admin')
             ```
         """
-        to_select = _extract_matching_columns_from_schema(
-            model=self.model, schema=schema_to_select
-        )
-        filters = self._parse_filters(**kwargs)
-        stmt = select(*to_select).filter(*filters)
+        stmt = await self.select(schema_to_select=schema_to_select, **kwargs)
 
         db_row = await db.execute(stmt)
         result: Optional[Row] = db_row.first()
@@ -653,12 +650,12 @@ class FastCRUD(
         if limit < 0 or offset < 0:
             raise ValueError("Limit and offset must be non-negative.")
 
-        to_select = _extract_matching_columns_from_schema(self.model, schema_to_select)
-        filters = self._parse_filters(**kwargs)
-        stmt = select(*to_select).filter(*filters)
-
-        if sort_columns:
-            stmt = self._apply_sorting(stmt, sort_columns, sort_orders)
+        stmt = await self.select(
+            schema_to_select=schema_to_select,
+            sort_columns=sort_columns,
+            sort_orders=sort_orders,
+            **kwargs,
+        )
 
         stmt = stmt.offset(offset).limit(limit)
         result = await db.execute(stmt)
@@ -1281,12 +1278,10 @@ class FastCRUD(
         if limit == 0:
             return {"data": [], "next_cursor": None}
 
-        to_select = _extract_matching_columns_from_schema(self.model, schema_to_select)
-        filters = self._parse_filters(**kwargs)
-
-        stmt = select(*to_select)
-        if filters:
-            stmt = stmt.filter(*filters)
+        stmt = await self.select(
+            schema_to_select=schema_to_select,
+            **kwargs,
+        )
 
         if cursor:
             if sort_order == "asc":


### PR DESCRIPTION
## Description
This PR is a small refactor of #28, it makes use of `select` method across FastCRUD class to avoid code duplication.

## Changes
`fast_crud.py` : `get`, `get_multi` and `get_multi_by_cursor`

## Tests
No tests added, it passes all current ones

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
