### PR TITLE
feat: filter __in

### DIFF
--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -100,6 +100,15 @@ items = await item_crud.get_multi(
 )
 ```
 
+Currently supported filter operators are:
+- __gt - greater than
+- __lt - less than
+- __gte - greater than or equal to
+- __lte - less than or equal to
+- __ne - not equal
+- __in - included in (tuple, list or set)
+- __not_in - not included in (tuple, list or set)
+
 #### Counting Records
 
 ```python

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -383,9 +383,9 @@ class FastCRUD(
             '__gt' (greater than),
             '__lt' (less than),
             '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), and
-            '__ne' (not equal).
-            '__in' (included in [tuple, list or set]).
+            '__lte' (less than or equal to),
+            '__ne' (not equal),
+            '__in' (included in [tuple, list or set]),
             '__not_in' (not included in [tuple, list or set]).
 
         Args:
@@ -449,9 +449,9 @@ class FastCRUD(
             '__gt' (greater than),
             '__lt' (less than),
             '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), and
-            '__ne' (not equal).
-            '__in' (included in [tuple, list or set]).
+            '__lte' (less than or equal to),
+            '__ne' (not equal),
+            '__in' (included in [tuple, list or set]),
             '__not_in' (not included in [tuple, list or set]).
 
         Args:
@@ -509,9 +509,9 @@ class FastCRUD(
             '__gt' (greater than),
             '__lt' (less than),
             '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), and
-            '__ne' (not equal).
-            '__in' (included in [tuple, list or set]).
+            '__lte' (less than or equal to),
+            '__ne' (not equal),
+            '__in' (included in [tuple, list or set]),
             '__not_in' (not included in [tuple, list or set]).
 
         Args:
@@ -558,8 +558,8 @@ class FastCRUD(
         Counts records that match specified filters, supporting advanced filtering through comparison operators:
             '__gt' (greater than), '__lt' (less than),
             '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), and '__ne' (not equal).
-            '__in' (included in [tuple, list or set]).
+            '__lte' (less than or equal to), '__ne' (not equal),
+            '__in' (included in [tuple, list or set]),
             '__not_in' (not included in [tuple, list or set]).
         Can also count records based on a configuration of joins, useful for complex queries involving relationships.
 
@@ -684,9 +684,9 @@ class FastCRUD(
             '__gt' (greater than),
             '__lt' (less than),
             '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), and
-            '__ne' (not equal).
-            '__in' (included in [tuple, list or set]).
+            '__lte' (less than or equal to),
+            '__ne' (not equal),
+            '__in' (included in [tuple, list or set]),
             '__not_in' (not included in [tuple, list or set]).
 
         Args:
@@ -798,9 +798,9 @@ class FastCRUD(
             '__gt' (greater than),
             '__lt' (less than),
             '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), and
-            '__ne' (not equal).
-            '__in' (included in [tuple, list or set]).
+            '__lte' (less than or equal to),
+            '__ne' (not equal),
+            '__in' (included in [tuple, list or set]),
             '__not_in' (not included in [tuple, list or set]).
 
         Args:
@@ -1045,9 +1045,9 @@ class FastCRUD(
             '__gt' (greater than),
             '__lt' (less than),
             '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), and
-            '__ne' (not equal).
-            '__in' (included in [tuple, list or set]).
+            '__lte' (less than or equal to),
+            '__ne' (not equal),
+            '__in' (included in [tuple, list or set]),
             '__not_in' (not included in [tuple, list or set]).
 
         Args:
@@ -1367,9 +1367,9 @@ class FastCRUD(
             '__gt' (greater than),
             '__lt' (less than),
             '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), and
-            '__ne' (not equal).
-            '__in' (included in [tuple, list or set]).
+            '__lte' (less than or equal to),
+            '__ne' (not equal),
+            '__in' (included in [tuple, list or set]),
             '__not_in' (not included in [tuple, list or set]).
 
         Args:
@@ -1456,9 +1456,9 @@ class FastCRUD(
             '__gt' (greater than),
             '__lt' (less than),
             '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), and
-            '__ne' (not equal).
-            '__in' (included in [tuple, list or set]).
+            '__lte' (less than or equal to),
+            '__ne' (not equal),
+            '__in' (included in [tuple, list or set]),
             '__not_in' (not included in [tuple, list or set]).
 
         Args:
@@ -1530,9 +1530,9 @@ class FastCRUD(
             '__gt' (greater than),
             '__lt' (less than),
             '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), and
-            '__ne' (not equal).
-            '__in' (included in [tuple, list or set]).
+            '__lte' (less than or equal to),
+            '__ne' (not equal),
+            '__in' (included in [tuple, list or set]),
             '__not_in' (not included in [tuple, list or set]).
 
         Args:
@@ -1588,9 +1588,9 @@ class FastCRUD(
             '__gt' (greater than),
             '__lt' (less than),
             '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), and
-            '__ne' (not equal).
-            '__in' (included in [tuple, list or set]).
+            '__lte' (less than or equal to),
+            '__ne' (not equal),
+            '__in' (included in [tuple, list or set]),
             '__not_in' (not included in [tuple, list or set]).
 
         Args:

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -386,7 +386,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
-            '__not_in' (included in [tuple, list or set]).
+            '__not_in' (not included in [tuple, list or set]).
 
         Args:
             schema_to_select: Pydantic schema to determine which columns to include in the selection. If not provided, selects all columns of the model.
@@ -452,7 +452,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
-            '__not_in' (included in [tuple, list or set]).
+            '__not_in' (not included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -512,7 +512,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
-            '__not_in' (included in [tuple, list or set]).
+            '__not_in' (not included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -560,7 +560,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
-            '__not_in' (included in [tuple, list or set]).
+            '__not_in' (not included in [tuple, list or set]).
         Can also count records based on a configuration of joins, useful for complex queries involving relationships.
 
         Args:
@@ -687,7 +687,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
-            '__not_in' (included in [tuple, list or set]).
+            '__not_in' (not included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -801,7 +801,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
-            '__not_in' (included in [tuple, list or set]).
+            '__not_in' (not included in [tuple, list or set]).
 
         Args:
             db: The SQLAlchemy async session.
@@ -1048,7 +1048,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
-            '__not_in' (included in [tuple, list or set]).
+            '__not_in' (not included in [tuple, list or set]).
 
         Args:
             db: The SQLAlchemy async session.
@@ -1370,7 +1370,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
-            '__not_in' (included in [tuple, list or set]).
+            '__not_in' (not included in [tuple, list or set]).
 
         Args:
             db: The SQLAlchemy async session.
@@ -1459,7 +1459,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
-            '__not_in' (included in [tuple, list or set]).
+            '__not_in' (not included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -1533,7 +1533,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
-            '__not_in' (included in [tuple, list or set]).
+            '__not_in' (not included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -1591,7 +1591,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
-            '__not_in' (included in [tuple, list or set]).
+            '__not_in' (not included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -188,6 +188,12 @@ class FastCRUD(
                     filters.append(column <= value)
                 elif op == "ne":
                     filters.append(column != value)
+                elif op == "in":
+                    if not isinstance(value, (tuple, list, set)):
+                        raise ValueError(
+                            f"\"in\" filter must be tuple, list or set"
+                        )
+                    filters.append(column.in_(value))
             else:
                 column = getattr(model, key, None)
                 if column is not None:
@@ -303,6 +309,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and
             '__ne' (not equal).
+            '__in' (included in [tuple, list or set]).
 
         Args:
             schema_to_select (Optional[type[BaseModel]], optional):
@@ -368,6 +375,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and
             '__ne' (not equal).
+            '__in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -430,6 +438,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and
             '__ne' (not equal).
+            '__in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -476,6 +485,7 @@ class FastCRUD(
             '__gt' (greater than), '__lt' (less than),
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and '__ne' (not equal).
+            '__in' (included in [tuple, list or set]).
         Can also count records based on a configuration of joins, useful for complex queries involving relationships.
 
         Args:
@@ -601,6 +611,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and
             '__ne' (not equal).
+            '__in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -708,6 +719,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and
             '__ne' (not equal).
+            '__in' (included in [tuple, list or set]).
 
         Args:
             db: The SQLAlchemy async session.
@@ -942,6 +954,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and
             '__ne' (not equal).
+            '__in' (included in [tuple, list or set]).
 
         Args:
             db: The SQLAlchemy async session.
@@ -1240,6 +1253,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and
             '__ne' (not equal).
+            '__in' (included in [tuple, list or set]).
 
         Args:
             db: The SQLAlchemy async session.
@@ -1328,6 +1342,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and
             '__ne' (not equal).
+            '__in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -1394,6 +1409,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and
             '__ne' (not equal).
+            '__in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -1447,6 +1463,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and
             '__ne' (not equal).
+            '__in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -192,7 +192,7 @@ class FastCRUD(
                 elif op == "in":
                     if not isinstance(value, (tuple, list, set)):
                         raise ValueError(
-                            f"\"in\" filter must be tuple, list or set"
+                            "\"in\" filter must be tuple, list or set"
                         )
                     filters.append(column.in_(value))
             else:

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -219,6 +219,12 @@ class FastCRUD(
                             "in filter must be tuple, list or set"
                         )
                     filters.append(column.in_(value))
+                elif op == "not_in":
+                    if not isinstance(value, (tuple, list, set)):
+                        raise ValueError(
+                            "in filter must be tuple, list or set"
+                        )
+                    filters.append(column.not_in(value))
             else:
                 column = getattr(model, key, None)
                 if column is not None:
@@ -380,6 +386,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
+            '__not_in' (included in [tuple, list or set]).
 
         Args:
             schema_to_select: Pydantic schema to determine which columns to include in the selection. If not provided, selects all columns of the model.
@@ -445,6 +452,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
+            '__not_in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -504,6 +512,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
+            '__not_in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -551,6 +560,7 @@ class FastCRUD(
             '__gte' (greater than or equal to),
             '__lte' (less than or equal to), and '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
+            '__not_in' (included in [tuple, list or set]).
         Can also count records based on a configuration of joins, useful for complex queries involving relationships.
 
         Args:
@@ -677,6 +687,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
+            '__not_in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -790,6 +801,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
+            '__not_in' (included in [tuple, list or set]).
 
         Args:
             db: The SQLAlchemy async session.
@@ -1036,6 +1048,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
+            '__not_in' (included in [tuple, list or set]).
 
         Args:
             db: The SQLAlchemy async session.
@@ -1357,6 +1370,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
+            '__not_in' (included in [tuple, list or set]).
 
         Args:
             db: The SQLAlchemy async session.
@@ -1445,6 +1459,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
+            '__not_in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -1518,6 +1533,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
+            '__not_in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.
@@ -1575,6 +1591,7 @@ class FastCRUD(
             '__lte' (less than or equal to), and
             '__ne' (not equal).
             '__in' (included in [tuple, list or set]).
+            '__not_in' (included in [tuple, list or set]).
 
         Args:
             db: The database session to use for the operation.

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -192,7 +192,7 @@ class FastCRUD(
                 elif op == "in":
                     if not isinstance(value, (tuple, list, set)):
                         raise ValueError(
-                            "\"in\" filter must be tuple, list or set"
+                            "in filter must be tuple, list or set"
                         )
                     filters.append(column.in_(value))
             else:

--- a/tests/sqlalchemy/core/test_parse_filters.py
+++ b/tests/sqlalchemy/core/test_parse_filters.py
@@ -36,7 +36,7 @@ async def test_parse_filters_contained_in_exception(test_model):
     fast_crud = FastCRUD(test_model)
     with pytest.raises(ValueError) as exc:
         fast_crud._parse_filters(category_id__in=1)
-    assert exc.value == "in filter must be tuple, list or set"
+    assert str(exc.value) == "in filter must be tuple, list or set"
 
 
 @pytest.mark.asyncio

--- a/tests/sqlalchemy/core/test_parse_filters.py
+++ b/tests/sqlalchemy/core/test_parse_filters.py
@@ -32,6 +32,14 @@ async def test_parse_filters_contained_in(test_model):
 
 
 @pytest.mark.asyncio
+async def test_parse_filters_contained_in_exception(test_model):
+    fast_crud = FastCRUD(test_model)
+    with pytest.raises(ValueError) as exc:
+        fast_crud._parse_filters(category_id__in=1)
+    assert exc.value == "in filter must be tuple, list or set"
+
+
+@pytest.mark.asyncio
 async def test_parse_filters_invalid_column(test_model):
     fast_crud = FastCRUD(test_model)
 

--- a/tests/sqlalchemy/core/test_parse_filters.py
+++ b/tests/sqlalchemy/core/test_parse_filters.py
@@ -22,6 +22,16 @@ async def test_parse_filters_multiple_conditions(test_model):
 
 
 @pytest.mark.asyncio
+async def test_parse_filters_contained_in(test_model):
+    fast_crud = FastCRUD(test_model)
+    filters = fast_crud._parse_filters(category_id__in=[1, 2])
+    assert len(filters) == 1
+    assert str(
+        filters[0]
+    ) == "test.category_id IN (__[POSTCOMPILE_category_id_1])"
+
+
+@pytest.mark.asyncio
 async def test_parse_filters_invalid_column(test_model):
     fast_crud = FastCRUD(test_model)
 

--- a/tests/sqlalchemy/core/test_parse_filters.py
+++ b/tests/sqlalchemy/core/test_parse_filters.py
@@ -32,10 +32,28 @@ async def test_parse_filters_contained_in(test_model):
 
 
 @pytest.mark.asyncio
-async def test_parse_filters_contained_in_exception(test_model):
+async def test_parse_filters_not_contained_in(test_model):
+    fast_crud = FastCRUD(test_model)
+    filters = fast_crud._parse_filters(category_id__not_in=[1, 2])
+    assert len(filters) == 1
+    assert str(
+        filters[0]
+    ) == "(test.category_id NOT IN (__[POSTCOMPILE_category_id_1]))"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'type', ('in', 'not_in')
+)
+async def test_parse_filters_contained_in_raises_exception(
+    test_model, type: str
+):
     fast_crud = FastCRUD(test_model)
     with pytest.raises(ValueError) as exc:
-        fast_crud._parse_filters(category_id__in=1)
+        if type == 'in':
+            fast_crud._parse_filters(category_id__in=1)
+        elif type == 'not_in':
+            fast_crud._parse_filters(category_id__not_in=1)
     assert str(exc.value) == "in filter must be tuple, list or set"
 
 

--- a/tests/sqlmodel/core/test_parse_filters.py
+++ b/tests/sqlmodel/core/test_parse_filters.py
@@ -36,7 +36,7 @@ async def test_parse_filters_contained_in_exception(test_model):
     fast_crud = FastCRUD(test_model)
     with pytest.raises(ValueError) as exc:
         fast_crud._parse_filters(category_id__in=1)
-    assert exc.value == "in filter must be tuple, list or set"
+    assert str(exc.value) == "in filter must be tuple, list or set"
 
 
 @pytest.mark.asyncio

--- a/tests/sqlmodel/core/test_parse_filters.py
+++ b/tests/sqlmodel/core/test_parse_filters.py
@@ -32,6 +32,14 @@ async def test_parse_filters_contained_in(test_model):
 
 
 @pytest.mark.asyncio
+async def test_parse_filters_contained_in_exception(test_model):
+    fast_crud = FastCRUD(test_model)
+    with pytest.raises(ValueError) as exc:
+        fast_crud._parse_filters(category_id__in=1)
+    assert exc.value == "in filter must be tuple, list or set"
+
+
+@pytest.mark.asyncio
 async def test_parse_filters_invalid_column(test_model):
     fast_crud = FastCRUD(test_model)
 

--- a/tests/sqlmodel/core/test_parse_filters.py
+++ b/tests/sqlmodel/core/test_parse_filters.py
@@ -22,6 +22,16 @@ async def test_parse_filters_multiple_conditions(test_model):
 
 
 @pytest.mark.asyncio
+async def test_parse_filters_contained_in(test_model):
+    fast_crud = FastCRUD(test_model)
+    filters = fast_crud._parse_filters(category_id__in=[1, 2])
+    assert len(filters) == 1
+    assert str(
+        filters[0]
+    ) == "test.category_id IN (__[POSTCOMPILE_category_id_1])"
+
+
+@pytest.mark.asyncio
 async def test_parse_filters_invalid_column(test_model):
     fast_crud = FastCRUD(test_model)
 


### PR DESCRIPTION
# Pull Request Template for FastCRUD

## Description
This PR adds support for in_ filtering in crud methods like FastCRUD.select(item_id__in=[1,2]).

## Changes
Extended parse_filters method with addtional elif op == "in", mapping to sqlalchemy/sqlmodel or() filter.

## Tests
Added a test to test_parse_filters for both sqlalchemy and sqlmodel.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.

## Additional Notes
I was trying to acomplish something similar for or_() but it turned out to be too complex for now.