### PR TITLE
Missing sqlalchemy operators

### DIFF
--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -85,29 +85,62 @@ await item_crud.delete(
 
 FastCRUD supports advanced filtering options, allowing you to query records using operators such as greater than (`__gt`), less than (`__lt`), and their inclusive counterparts (`__gte`, `__lte`). These filters can be used in any method that retrieves or operates on records, including `get`, `get_multi`, `exists`, `count`, `update`, and `delete`.
 
-### Using Advanced Filters
+### Single parameter filters
 
-The following examples demonstrate how to use advanced filters for querying and manipulating data:
-
-#### Fetching Records with Advanced Filters
+Most filter operators require a single string or integer value.
 
 ```python
-# Fetch items priced between $5 and $20
+# Fetch items priced between above $5
 items = await item_crud.get_multi(
     db=db,
     price__gte=5,
-    price__lte=20
 )
 ```
 
-Currently supported filter operators are:
+Currently supported single parameter filters are:
 - __gt - greater than
 - __lt - less than
 - __gte - greater than or equal to
 - __lte - less than or equal to
 - __ne - not equal
-- __in - included in (tuple, list or set)
-- __not_in - not included in (tuple, list or set)
+- __is - used to test True, False and None identity
+- __is_not - negation of "is"
+- __like - SQL "like" search for specific text pattern
+- __notlike - negation of "like"
+- __ilike - case insensitive "like"
+- __notilike - case insensitive "notlike"
+- __startswith - text starts with given string
+- __endswith - text ends with given string
+- __contains - text contains given string
+- __match - database-specific match expression
+
+### Complex parameter filters
+
+Some operators require multiple values. They must be passed as a python tuple, list or set.
+
+```python
+# Fetch items priced between $5 and $20
+items = await item_crud.get_multi(
+    db=db,
+    price__between=(5, 20),
+)
+```
+- __between - between 2 numeric values
+- __in - included in
+- __not_in - not included in
+
+### OR parameter filters
+
+More complex OR filters are supported. They must be passed as dictionary, where each key is a library-supported operator to be used in OR expression and values get's passed as the parameter.
+
+```python
+# Fetch items priced under $5 or above $20
+items = await item_crud.get_multi(
+    db=db,
+    price__or={'lt': 5, 'gt': 20},
+)
+```
+
 
 #### Counting Records
 

--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -131,7 +131,7 @@ items = await item_crud.get_multi(
 
 ### OR parameter filters
 
-More complex OR filters are supported. They must be passed as dictionary, where each key is a library-supported operator to be used in OR expression and values get's passed as the parameter.
+More complex OR filters are supported. They must be passed as dictionary, where each key is a library-supported operator to be used in OR expression and values is what get's passed as the parameter.
 
 ```python
 # Fetch items priced under $5 or above $20

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -400,14 +400,8 @@ class FastCRUD(
         """
         Constructs a SQL Alchemy `Select` statement with optional column selection, filtering, and sorting.
         This method allows for advanced filtering through comparison operators, enabling queries to be refined beyond simple equality checks.
-        Supported operators include:
-            '__gt' (greater than),
-            '__lt' (less than),
-            '__gte' (greater than or equal to),
-            '__lte' (less than or equal to),
-            '__ne' (not equal),
-            '__in' (included in [tuple, list or set]),
-            '__not_in' (not included in [tuple, list or set]).
+        For filtering details see:
+        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
 
         Args:
             schema_to_select: Pydantic schema to determine which columns to include in the selection. If not provided, selects all columns of the model.
@@ -466,14 +460,8 @@ class FastCRUD(
         """
         Fetches a single record based on specified filters.
         This method allows for advanced filtering through comparison operators, enabling queries to be refined beyond simple equality checks.
-        Supported operators include:
-            '__gt' (greater than),
-            '__lt' (less than),
-            '__gte' (greater than or equal to),
-            '__lte' (less than or equal to),
-            '__ne' (not equal),
-            '__in' (included in [tuple, list or set]),
-            '__not_in' (not included in [tuple, list or set]).
+        For filtering details see:
+        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
 
         Args:
             db: The database session to use for the operation.
@@ -573,14 +561,8 @@ class FastCRUD(
     async def exists(self, db: AsyncSession, **kwargs: Any) -> bool:
         """
         Checks if any records exist that match the given filter conditions.
-        This method supports advanced filtering with comparison operators:
-            '__gt' (greater than),
-            '__lt' (less than),
-            '__gte' (greater than or equal to),
-            '__lte' (less than or equal to),
-            '__ne' (not equal),
-            '__in' (included in [tuple, list or set]),
-            '__not_in' (not included in [tuple, list or set]).
+        For filtering details see:
+        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
 
         Args:
             db: The database session to use for the operation.
@@ -623,12 +605,9 @@ class FastCRUD(
         **kwargs: Any,
     ) -> int:
         """
-        Counts records that match specified filters, supporting advanced filtering through comparison operators:
-            '__gt' (greater than), '__lt' (less than),
-            '__gte' (greater than or equal to),
-            '__lte' (less than or equal to), '__ne' (not equal),
-            '__in' (included in [tuple, list or set]),
-            '__not_in' (not included in [tuple, list or set]).
+        Counts records that match specified filters. For filtering details see:
+        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+
         Can also count records based on a configuration of joins, useful for complex queries involving relationships.
 
         Args:
@@ -748,14 +727,9 @@ class FastCRUD(
         **kwargs: Any,
     ) -> dict[str, Any]:
         """
-        Fetches multiple records based on filters, supporting sorting, pagination, and advanced filtering with comparison operators:
-            '__gt' (greater than),
-            '__lt' (less than),
-            '__gte' (greater than or equal to),
-            '__lte' (less than or equal to),
-            '__ne' (not equal),
-            '__in' (included in [tuple, list or set]),
-            '__not_in' (not included in [tuple, list or set]).
+        Fetches multiple records based on filters, supporting sorting, pagination.
+        For filtering details see:
+        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
 
         Args:
             db: The database session to use for the operation.
@@ -862,14 +836,8 @@ class FastCRUD(
         """
         Fetches a single record with one or multiple joins on other models. If 'join_on' is not provided, the method attempts
         to automatically detect the join condition using foreign key relationships. For multiple joins, use 'joins_config' to
-        specify each join configuration. Advanced filters supported:
-            '__gt' (greater than),
-            '__lt' (less than),
-            '__gte' (greater than or equal to),
-            '__lte' (less than or equal to),
-            '__ne' (not equal),
-            '__in' (included in [tuple, list or set]),
-            '__not_in' (not included in [tuple, list or set]).
+        specify each join configuration. For filtering details see:
+        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
 
         Args:
             db: The SQLAlchemy async session.
@@ -1108,15 +1076,9 @@ class FastCRUD(
         **kwargs: Any,
     ) -> dict[str, Any]:
         """
-        Fetch multiple records with a join on another model, allowing for pagination, optional sorting, and model conversion,
-        supporting advanced filtering with comparison operators:
-            '__gt' (greater than),
-            '__lt' (less than),
-            '__gte' (greater than or equal to),
-            '__lte' (less than or equal to),
-            '__ne' (not equal),
-            '__in' (included in [tuple, list or set]),
-            '__not_in' (not included in [tuple, list or set]).
+        Fetch multiple records with a join on another model, allowing for pagination, optional sorting, and model conversion.
+        For filtering details see:
+        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
 
         Args:
             db: The SQLAlchemy async session.
@@ -1431,14 +1393,8 @@ class FastCRUD(
     ) -> dict[str, Any]:
         """
         Implements cursor-based pagination for fetching records. This method is designed for efficient data retrieval in large datasets and is ideal for features like infinite scrolling.
-        It supports advanced filtering with comparison operators:
-            '__gt' (greater than),
-            '__lt' (less than),
-            '__gte' (greater than or equal to),
-            '__lte' (less than or equal to),
-            '__ne' (not equal),
-            '__in' (included in [tuple, list or set]),
-            '__not_in' (not included in [tuple, list or set]).
+        For filtering details see:
+        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
 
         Args:
             db: The SQLAlchemy async session.
@@ -1520,14 +1476,8 @@ class FastCRUD(
     ) -> None:
         """
         Updates an existing record or multiple records in the database based on specified filters. This method allows for precise targeting of records to update.
-        It supports advanced filtering through comparison operators:
-            '__gt' (greater than),
-            '__lt' (less than),
-            '__gte' (greater than or equal to),
-            '__lte' (less than or equal to),
-            '__ne' (not equal),
-            '__in' (included in [tuple, list or set]),
-            '__not_in' (not included in [tuple, list or set]).
+        For filtering details see:
+        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
 
         Args:
             db: The database session to use for the operation.
@@ -1594,14 +1544,9 @@ class FastCRUD(
         **kwargs: Any,
     ) -> None:
         """
-        Deletes a record or multiple records from the database based on specified filters, with support for advanced filtering through comparison operators:
-            '__gt' (greater than),
-            '__lt' (less than),
-            '__gte' (greater than or equal to),
-            '__lte' (less than or equal to),
-            '__ne' (not equal),
-            '__in' (included in [tuple, list or set]),
-            '__not_in' (not included in [tuple, list or set]).
+        Deletes a record or multiple records from the database based on specified filters.
+        For filtering details see:
+        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
 
         Args:
             db: The database session to use for the operation.
@@ -1652,14 +1597,8 @@ class FastCRUD(
     ) -> None:
         """
         Soft deletes a record or optionally multiple records if it has an "is_deleted" attribute, otherwise performs a hard delete, based on specified filters.
-        Supports advanced filtering through comparison operators:
-            '__gt' (greater than),
-            '__lt' (less than),
-            '__gte' (greater than or equal to),
-            '__lte' (less than or equal to),
-            '__ne' (not equal),
-            '__in' (included in [tuple, list or set]),
-            '__not_in' (not included in [tuple, list or set]).
+        For filtering details see:
+        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
 
         Args:
             db: The database session to use for the operation.

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -179,14 +179,11 @@ class FastCRUD(
         ```
     """
     _SUPPORTED_FILTERS = {
-        'gt': lambda column: column.__gt__,
+        "gt": lambda column: column.__gt__,
         "lt": lambda column: column.__lt__,
         "gte": lambda column: column.__ge__,
         "lte": lambda column: column.__le__,
         "ne": lambda column: column.__ne__,
-        "between": lambda column: column.between,
-        "in": lambda column: column.in_,
-        "not_in": lambda column: column.not_in,
         "is": lambda column: column.is_,
         "is_not": lambda column: column.is_not,
         "like": lambda column: column.like,
@@ -197,6 +194,9 @@ class FastCRUD(
         "endswith": lambda column: column.endswith,
         "contains": lambda column: column.contains,
         "match": lambda column: column.match,
+        "between": lambda column: column.between,
+        "in": lambda column: column.in_,
+        "not_in": lambda column: column.not_in,
     }
 
     def __init__(
@@ -216,10 +216,10 @@ class FastCRUD(
     def _get_sqlalchemy_filter(
         self, operator: str, value: Any,
     ) ->Optional[Callable[[str], Callable]]:
-        if operator in {'in', 'not_in'}:
+        if operator in {'in', 'not_in', 'between'}:
             if not isinstance(value, (tuple, list, set)):
                 raise ValueError(
-                    "in filter must be tuple, list or set"
+                    f"<{operator}> filter must be tuple, list or set"
                 )
         return self._SUPPORTED_FILTERS.get(operator)
 

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.engine.row import Row
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm.util import AliasedClass
-from sqlalchemy.sql.elements import BinaryExpression
+from sqlalchemy.sql.elements import BinaryExpression, ColumnElement
 from sqlalchemy.sql.selectable import Select
 
 from .helper import (
@@ -225,7 +225,7 @@ class FastCRUD(
 
     def _parse_filters(
         self, model: Optional[Union[type[ModelType], AliasedClass]] = None, **kwargs
-    ) -> list[BinaryExpression]:
+    ) -> list[ColumnElement]:
         model = model or self.model
         filters = []
 

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -237,15 +237,18 @@ class FastCRUD(
                     raise ValueError(f"Invalid filter column: {field_name}")
                 if op == 'or':
                     or_filters = [
-                        self._get_sqlalchemy_filter(or_key, or_value)(column)(or_value)
+                        sqlalchemy_filter(column)(or_value)
                         for or_key, or_value in value.items()
-                        if self._get_sqlalchemy_filter(or_key, value)
+                        if (sqlalchemy_filter := self._get_sqlalchemy_filter(
+                            or_key, value)) is not None
                     ]
                     filters.append(or_(*or_filters))
                 else:
-                    filters.append(
-                        self._get_sqlalchemy_filter(op, value)(column)(value)
-                    )
+                    sqlalchemy_filter = self._get_sqlalchemy_filter(op, value)
+                    if sqlalchemy_filter:
+                        filters.append(
+                                sqlalchemy_filter(column)(value)
+                        )
             else:
                 column = getattr(model, key, None)
                 if column is not None:

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -215,7 +215,7 @@ class FastCRUD(
 
     def _get_sqlalchemy_filter(
         self, operator: str, value: Any,
-    ) -> Callable[[str], Callable] | None:
+    ) ->Optional[Callable[[str], Callable]]:
         if operator in {'in', 'not_in'}:
             if not isinstance(value, (tuple, list, set)):
                 raise ValueError(

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -215,7 +215,7 @@ class FastCRUD(
 
     def get_sqlalchemy_filter(
         self, operator: str, value: Any,
-    ) -> Callable[[str], str] | None:
+    ) -> Optional[Callable[[str], str]]:
         if operator == 'in' or operator == 'not_in':
             if not isinstance(value, (tuple, list, set)):
                 raise ValueError(

--- a/tests/sqlalchemy/core/test_parse_filters.py
+++ b/tests/sqlalchemy/core/test_parse_filters.py
@@ -22,6 +22,17 @@ async def test_parse_filters_multiple_conditions(test_model):
 
 
 @pytest.mark.asyncio
+async def test_parse_filters_or_condition(test_model):
+    fast_crud = FastCRUD(test_model)
+
+    filters = fast_crud._parse_filters(
+        name__or={'gt': 1, 'lt': 5}
+    )
+    assert len(filters) == 1
+    assert str(filters[0]) == "test.name > :name_1 OR test.name < :name_2"
+
+
+@pytest.mark.asyncio
 async def test_parse_filters_contained_in(test_model):
     fast_crud = FastCRUD(test_model)
     filters = fast_crud._parse_filters(category_id__in=[1, 2])

--- a/tests/sqlalchemy/core/test_parse_filters.py
+++ b/tests/sqlalchemy/core/test_parse_filters.py
@@ -51,15 +51,17 @@ async def test_parse_filters_not_contained_in(test_model):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("type", ("in", "not_in"))
-async def test_parse_filters_contained_in_raises_exception(test_model, type: str):
+@pytest.mark.parametrize("operator", ("in", "not_in", "between"))
+async def test_parse_filters_raises_exception(test_model, operator: str):
     fast_crud = FastCRUD(test_model)
     with pytest.raises(ValueError) as exc:
-        if type == "in":
+        if operator == "in":
             fast_crud._parse_filters(category_id__in=1)
-        elif type == "not_in":
+        elif operator == "not_in":
             fast_crud._parse_filters(category_id__not_in=1)
-    assert str(exc.value) == "in filter must be tuple, list or set"
+        elif operator == "between":
+            fast_crud._parse_filters(category_id__between=1)
+    assert str(exc.value) == f"<{operator}> filter must be tuple, list or set"
 
 
 @pytest.mark.asyncio

--- a/tests/sqlmodel/core/test_parse_filters.py
+++ b/tests/sqlmodel/core/test_parse_filters.py
@@ -41,11 +41,17 @@ async def test_parse_filters_contained_in(test_model):
 
 
 @pytest.mark.asyncio
-async def test_parse_filters_contained_in_exception(test_model):
+@pytest.mark.parametrize("operator", ("in", "not_in", "between"))
+async def test_parse_filters_raises_exception(test_model, operator: str):
     fast_crud = FastCRUD(test_model)
     with pytest.raises(ValueError) as exc:
-        fast_crud._parse_filters(category_id__in=1)
-    assert str(exc.value) == "in filter must be tuple, list or set"
+        if operator == "in":
+            fast_crud._parse_filters(category_id__in=1)
+        elif operator == "not_in":
+            fast_crud._parse_filters(category_id__not_in=1)
+        elif operator == "between":
+            fast_crud._parse_filters(category_id__between=1)
+    assert str(exc.value) == f"<{operator}> filter must be tuple, list or set"
 
 
 @pytest.mark.asyncio

--- a/tests/sqlmodel/core/test_parse_filters.py
+++ b/tests/sqlmodel/core/test_parse_filters.py
@@ -22,6 +22,17 @@ async def test_parse_filters_multiple_conditions(test_model):
 
 
 @pytest.mark.asyncio
+async def test_parse_filters_or_condition(test_model):
+    fast_crud = FastCRUD(test_model)
+
+    filters = fast_crud._parse_filters(
+        name__or={'gt': 1, 'lt': 5}
+    )
+    assert len(filters) == 1
+    assert str(filters[0]) == "test.name > :name_1 OR test.name < :name_2"
+
+
+@pytest.mark.asyncio
 async def test_parse_filters_contained_in(test_model):
     fast_crud = FastCRUD(test_model)
     filters = fast_crud._parse_filters(category_id__in=[1, 2])


### PR DESCRIPTION
This implements #79 by introducing `FastCRUD._get_sqlalchemy_filter()` method and a dictonary of filter mappings in `FastCRUD._SUPPORTED_FILTERS`. Adding new sqlalchemy opertors is as simple as extending the dictonary.

It also solves the `or_()` operator issue:
```
                    ItemCRUD.get_multi(
                        name__or={'startswith': 'foo', 'endswith': 'bar'}
                    )
```

There is some mypy issue which I struggle to solve, but it looks like it's not required. The tests pass with good coverage.