### PR TITLE
One-to-many support in joins

### DIFF
--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -225,6 +225,30 @@ In this example, users are joined with the `Tier` and `Department` models. The `
 
     If both single join parameters and `joins_config` are used simultaneously, an error will be raised.
 
+### Handling One-to-One and One-to-Many Joins in FastCRUD
+
+FastCRUD provides flexibility in handling one-to-one and one-to-many relationships through its `get_joined` and `get_multi_joined` methods, along with the ability to specify how joined data should be structured using both the `relationship_type` (default `one-to-one`) and the `nest_joins` (default `False`) parameters.
+
+#### One-to-One Joins
+**One-to-one** relationships can be efficiently managed using either `get_joined` or `get_multi_joined`. The `get_joined` method is typically used when you want to fetch a single record from the database along with its associated record from another table, such as a user and their corresponding profile details. If you're retrieving multiple records, `get_multi_joined` can also be used for one-to-one joins. The parameter that deals with it, `relationship_type`, defaults to `one-on-one`.
+
+#### One-to-Many Joins
+For **one-to-many** relationships, where a single record can be associated with multiple records in another table, `get_joined` can be used with `nest_joins` set to `True`. This setup allows the primary record to include a nested list of associated records, making it suitable for scenarios such as retrieving a user and all their blog posts. Alternatively, `get_multi_joined` is also applicable here for fetching multiple primary records, each with their nested lists of related records.
+
+!!! WARNING
+
+    When using `nested_joins=True`, the performance will always be a bit worse than when using `nested_joins=False`. For cases where more performance is necessary, consider using `nested_joins=False` and remodeling your database.
+
+#### One-to-One Relationships
+- **`get_joined`**: Fetch a single record and its directly associated record (e.g., a user and their profile).
+- **`get_multi_joined`** (with `nest_joins=False`): Retrieve multiple records, each linked to a single related record from another table (e.g., users and their profiles).
+
+#### One-to-Many Relationships
+- **`get_joined`** (with `nest_joins=True`): Retrieve a single record with all its related records nested within it (e.g., a user and all their blog posts).
+- **`get_multi_joined`** (with `nest_joins=True`): Fetch multiple primary records, each with their related records nested (e.g., multiple users and all their blog posts).
+
+For a more detailed explanation, you may check the [joins docs](joins.md#handling-one-to-one-and-one-to-many-joins-in-fastcrud).
+
 ### Using aliases
 
 In complex query scenarios, particularly when you need to join a table to itself or perform multiple joins on the same table for different purposes, aliasing becomes crucial. Aliasing allows you to refer to the same table in different contexts with unique identifiers, avoiding conflicts and ambiguity in your queries.

--- a/docs/advanced/joins.md
+++ b/docs/advanced/joins.md
@@ -211,12 +211,6 @@ from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
 
-# Association table for the many-to-many relationship
-projects_participants_association = Table('projects_participants_association', Base.metadata,
-    Column('project_id', Integer, ForeignKey('projects.id'), primary_key=True),
-    Column('participant_id', Integer, ForeignKey('participants.id'), primary_key=True)
-)
-
 class Project(Base):
     __tablename__ = 'projects'
     id = Column(Integer, primary_key=True)
@@ -232,6 +226,12 @@ class Participant(Base):
     role = Column(String)
     # Relationship to Project through the association table
     projects = relationship("Project", secondary=projects_participants_association)
+
+# Association table for the many-to-many relationship
+class ProjectsParticipantsAssociation(Base):
+    __tablename__ = "projects_participants_association"
+    project_id = Column(Integer, ForeignKey("projects.id"), primary_key=True)
+    participant_id = Column(Integer, ForeignKey("participants.id"), primary_key=True)
 ```
 
 ##### Fetching Data with `get_multi_joined`

--- a/docs/usage/crud.md
+++ b/docs/usage/crud.md
@@ -237,6 +237,7 @@ get_joined(
     join_filters: Optional[dict] = None,
     joins_config: Optional[list[JoinConfig]] = None,
     nest_joins: bool = False,
+    relationship_type: Optional[str] = None,
     **kwargs: Any,
 ) -> Optional[dict[str, Any]]
 ```
@@ -275,6 +276,7 @@ get_multi_joined(
     return_as_model: bool = False,
     joins_config: Optional[list[JoinConfig]] = None,
     return_total_count: bool = True,
+    relationship_type: Optional[str] = None,
     **kwargs: Any,
 ) -> dict[str, Any]
 ```

--- a/fastcrud/crud/helper.py
+++ b/fastcrud/crud/helper.py
@@ -484,7 +484,7 @@ def _nest_multi_join_data(
                 for key, value in new_row.items():
                     if isinstance(value, list) and any(
                         item[join_primary_key] is None for item in value
-                    ):
+                    ):  # pragma: no cover
                         new_row[key] = []
 
                 pre_nested_data[primary_key_value] = new_row
@@ -492,7 +492,9 @@ def _nest_multi_join_data(
                 existing_row = pre_nested_data[primary_key_value]
                 for key, value in new_row.items():
                     if isinstance(value, list):
-                        if any(item[join_primary_key] is None for item in value):
+                        if any(
+                            item[join_primary_key] is None for item in value
+                        ):  # pragma: no cover
                             existing_row[key] = []
                         else:
                             existing_row[key].extend(value)
@@ -508,7 +510,7 @@ def _nest_multi_join_data(
                             item[prefix] = [
                                 schema(**nested_item) for nested_item in item[prefix]
                             ]
-                        else:
+                        else:  # pragma: no cover
                             item[prefix] = schema(**item[prefix])
             if schema_to_select:
                 nested_data[i] = schema_to_select(**item)

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -204,8 +204,10 @@ local_session = sessionmaker(
 )
 
 
-def get_session_local():
-    yield local_session()
+async def get_session_local():
+    async with local_session() as session:
+        yield session
+        await session.close()  # Ensure the session is properly closed
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -113,6 +113,23 @@ class ProjectsParticipantsAssociation(Base):
     participant_id = Column(Integer, ForeignKey("participants.id"), primary_key=True)
 
 
+class Card(Base):
+    __tablename__ = "cards"
+    id = Column(Integer, primary_key=True)
+    title = Column(String)
+
+
+class Article(Base):
+    __tablename__ = "articles"
+    id = Column(Integer, primary_key=True)
+    title = Column(String)
+    card_id = Column(Integer, ForeignKey("cards.id"))
+    card = relationship("Card", back_populates="articles")
+
+
+Card.articles = relationship("Article", order_by=Article.id, back_populates="card")
+
+
 class CreateSchemaTest(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str
@@ -163,6 +180,18 @@ class BookingSchema(BaseModel):
     owner_id: int
     user_id: int
     booking_date: datetime
+
+
+class ArticleSchema(BaseModel):
+    id: int
+    title: str
+    card_id: int
+
+
+class CardSchema(BaseModel):
+    id: int
+    title: str
+    articles: Optional[list[ArticleSchema]] = []
 
 
 async_engine = create_async_engine(

--- a/tests/sqlalchemy/core/test_nest_multi_join_data.py
+++ b/tests/sqlalchemy/core/test_nest_multi_join_data.py
@@ -1,0 +1,365 @@
+import pytest
+
+from fastcrud.crud.fast_crud import FastCRUD, JoinConfig
+
+from ..conftest import (
+    Article,
+    Card,
+    ArticleSchema,
+    CardSchema,
+)
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_new_row_none(async_session):
+    cards = [
+        Card(title="Card A"),
+        Card(title="Card B"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+        Article(
+            title="Article 2", card_id=None
+        ),  # This should trigger new_row[key] = []
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    card_a = next((c for c in data if c["id"] == cards[0].id), None)
+    assert (
+        card_a is not None and "articles" in card_a
+    ), "Card A should have nested articles."
+    assert len(card_a["articles"]) == 1, "Card A should have one valid article."
+    assert (
+        card_a["articles"][0]["title"] == "Article 1"
+    ), "Card A's article title should be 'Article 1'."
+
+    card_b = next((c for c in data if c["id"] == cards[1].id), None)
+    assert (
+        card_b is not None and "articles" in card_b
+    ), "Card B should have nested articles."
+    assert (
+        len(card_b["articles"]) == 0
+    ), "Card B should have no articles due to None card_id in Article."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_existing_row_none(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+        Article(title="Article 2", card_id=cards[0].id),
+        Article(
+            title="Article 3", card_id=None
+        ),  # This will trigger existing_row[key] = []
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    card_a = next((c for c in data if c["id"] == cards[0].id), None)
+    assert (
+        card_a is not None and "articles" in card_a
+    ), "Card A should have nested articles."
+    assert len(card_a["articles"]) == 2, "Card A should have two valid articles."
+    assert (
+        card_a["articles"][0]["title"] == "Article 1"
+    ), "Card A's first article title should be 'Article 1'."
+    assert (
+        card_a["articles"][1]["title"] == "Article 2"
+    ), "Card A's second article title should be 'Article 2'."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_nested_schema(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        return_as_model=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                schema_to_select=ArticleSchema,
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    assert len(data) == 1, "Expected one card record."
+    card_a = data[0]
+    assert isinstance(card_a, CardSchema), "Card should be an instance of CardSchema."
+    assert hasattr(card_a, "articles"), "Card should have nested articles."
+    assert len(card_a.articles) == 1, "Card should have one article."
+    assert isinstance(
+        card_a.articles[0], ArticleSchema
+    ), "Article should be an instance of ArticleSchema."
+    assert (
+        card_a.articles[0].title == "Article 1"
+    ), "Article title should be 'Article 1'."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_prefix_in_item(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        return_as_model=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                schema_to_select=ArticleSchema,
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    assert len(data) == 1, "Expected one card record."
+    card_a = data[0]
+    assert isinstance(card_a, CardSchema), "Card should be an instance of CardSchema."
+    assert hasattr(card_a, "articles"), "Card should have nested articles."
+    assert len(card_a.articles) == 1, "Card should have one article."
+    assert isinstance(
+        card_a.articles[0], ArticleSchema
+    ), "Article should be an instance of ArticleSchema."
+    assert (
+        card_a.articles[0].title == "Article 1"
+    ), "Article title should be 'Article 1'."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_isinstance_list(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+        Article(title="Article 2", card_id=cards[0].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        return_as_model=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                schema_to_select=ArticleSchema,
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    assert len(data) == 1, "Expected one card record."
+    card_a = data[0]
+    assert isinstance(card_a, CardSchema), "Card should be an instance of CardSchema."
+    assert hasattr(card_a, "articles"), "Card should have nested articles."
+    assert len(card_a.articles) == 2, "Card should have two articles."
+    assert all(
+        isinstance(article, ArticleSchema) for article in card_a.articles
+    ), "All articles should be instances of ArticleSchema."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_convert_list_to_schema(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+        Article(title="Article 2", card_id=cards[0].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        return_as_model=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                schema_to_select=ArticleSchema,
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    assert len(data) == 1, "Expected one card record."
+    card_a = data[0]
+    assert isinstance(card_a, CardSchema), "Card should be an instance of CardSchema."
+    assert hasattr(card_a, "articles"), "Card should have nested articles."
+    assert len(card_a.articles) == 2, "Card should have two articles."
+    assert all(
+        isinstance(article, ArticleSchema) for article in card_a.articles
+    ), "All articles should be instances of ArticleSchema."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_convert_dict_to_schema(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        return_as_model=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                schema_to_select=ArticleSchema,
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    assert len(data) == 1, "Expected one card record."
+    card_a = data[0]
+    assert isinstance(card_a, CardSchema), "Card should be an instance of CardSchema."
+    assert hasattr(card_a, "articles"), "Card should have nested articles."
+    assert len(card_a.articles) == 1, "Card should have one article."
+    assert isinstance(
+        card_a.articles[0], ArticleSchema
+    ), "Article should be an instance of ArticleSchema."
+    assert (
+        card_a.articles[0].title == "Article 1"
+    ), "Article title should be 'Article 1'."

--- a/tests/sqlalchemy/crud/test_get_joined.py
+++ b/tests/sqlalchemy/crud/test_get_joined.py
@@ -11,6 +11,8 @@ from ...sqlalchemy.conftest import (
     BookingModel,
     BookingSchema,
     ReadSchemaTest,
+    Article,
+    Card,
 )
 
 
@@ -386,7 +388,7 @@ async def test_get_joined_with_unsupported_join_type_raises_value_error(
             join_type="unsupported_type",
         )
 
-    assert "Unsupported join type: unsupported_type." in str(excinfo.value)
+    assert "Unsupported join type" in str(excinfo.value)
 
 
 @pytest.mark.asyncio
@@ -524,3 +526,42 @@ async def test_get_joined_no_prefix_no_nesting(
     assert (
         "tier_name" not in result
     ), "Field 'tier_name' should not exist unless specifically prefixed or nested."
+
+
+@pytest.mark.asyncio
+async def test_get_joined_card_with_articles(async_session):
+    card = Card(title="Test Card")
+    async_session.add(card)
+    async_session.add_all(
+        [
+            Article(title="Article 1", card=card),
+            Article(title="Article 2", card=card),
+            Article(title="Article 3", card=card),
+        ]
+    )
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_joined(
+        db=async_session,
+        nest_joins=True,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "title" in result, "Card title should be present in the result."
+    assert "articles" in result, "Articles should be nested under 'articles'."
+    assert isinstance(result["articles"], list), "Articles should be a list."
+    assert len(result["articles"]) == 3, "There should be three articles."
+    assert all(
+        "title" in article for article in result["articles"]
+    ), "Each article should have a title."

--- a/tests/sqlalchemy/crud/test_get_multi_joined.py
+++ b/tests/sqlalchemy/crud/test_get_multi_joined.py
@@ -15,6 +15,10 @@ from ...sqlalchemy.conftest import (
     Project,
     Participant,
     ProjectsParticipantsAssociation,
+    Article,
+    Card,
+    ArticleSchema,
+    CardSchema,
 )
 
 
@@ -780,7 +784,6 @@ async def test_get_multi_joined_no_prefix_regular(
         limit=10,
     )
 
-    print(result)
     assert result and result["data"], "Expected data in the result."
     for item in result["data"]:
         assert "name" in item, "Expected user name in each item."
@@ -819,3 +822,255 @@ async def test_get_multi_joined_no_prefix_nested(
         assert (
             "name" in item[TierModel.__tablename__]
         ), f"Expected 'name' field inside nested '{TierModel.__tablename__}' dictionary."
+
+
+@pytest.mark.asyncio
+async def test_get_multi_joined_card_with_articles(async_session):
+    cards = [
+        Card(title="Test Card"),
+        Card(title="Test Card 2"),
+        Card(title="Test Card 3"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+        Article(title="Article 2", card_id=cards[1].id),
+        Article(title="Article 3", card_id=cards[1].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+    assert isinstance(data, list), "Result data should be a list."
+    assert len(data) == 3, "Expected three card records."
+
+    card1 = next((c for c in data if c["id"] == cards[0].id), None)
+    card2 = next((c for c in data if c["id"] == cards[1].id), None)
+    card3 = next((c for c in data if c["id"] == cards[2].id), None)
+
+    assert (
+        card1 is not None and "articles" in card1
+    ), "Card 1 should have nested articles."
+    assert len(card1["articles"]) == 1, "Card 1 should have one article."
+    assert (
+        card1["articles"][0]["title"] == "Article 1"
+    ), "Card 1's article title should be 'Article 1'."
+
+    assert (
+        card2 is not None and "articles" in card2
+    ), "Card 2 should have nested articles."
+    assert len(card2["articles"]) == 2, "Card 2 should have two articles."
+    assert (
+        card2["articles"][0]["title"] == "Article 2"
+    ), "Card 2's first article title should be 'Article 2'."
+    assert (
+        card2["articles"][1]["title"] == "Article 3"
+    ), "Card 2's second article title should be 'Article 3'."
+
+    assert (
+        card3 is not None and "articles" in card3
+    ), "Card 3 should have nested articles."
+    assert len(card3["articles"]) == 0, "Card 3 should have no articles."
+
+
+@pytest.mark.asyncio
+async def test_get_multi_joined_card_with_multiple_articles(async_session):
+    cards = [
+        Card(title="Card A"),
+        Card(title="Card B"),
+        Card(title="Card C"),
+        Card(title="Card D"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+        Article(title="Article 2", card_id=cards[0].id),
+        Article(title="Article 3", card_id=cards[1].id),
+        Article(title="Article 4", card_id=cards[1].id),
+        Article(title="Article 5", card_id=cards[2].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+    assert isinstance(data, list), "Result data should be a list."
+    assert len(data) == 4, "Expected four card records."
+
+    card_a = next((c for c in data if c["id"] == cards[0].id), None)
+    card_b = next((c for c in data if c["id"] == cards[1].id), None)
+    card_c = next((c for c in data if c["id"] == cards[2].id), None)
+    card_d = next((c for c in data if c["id"] == cards[3].id), None)
+
+    assert (
+        card_a is not None and "articles" in card_a
+    ), "Card A should have nested articles."
+    assert len(card_a["articles"]) == 2, "Card A should have two articles."
+    assert (
+        card_a["articles"][0]["title"] == "Article 1"
+    ), "Card A's first article title should be 'Article 1'."
+    assert (
+        card_a["articles"][1]["title"] == "Article 2"
+    ), "Card A's second article title should be 'Article 2'."
+
+    assert (
+        card_b is not None and "articles" in card_b
+    ), "Card B should have nested articles."
+    assert len(card_b["articles"]) == 2, "Card B should have two articles."
+    assert (
+        card_b["articles"][0]["title"] == "Article 3"
+    ), "Card B's first article title should be 'Article 3'."
+    assert (
+        card_b["articles"][1]["title"] == "Article 4"
+    ), "Card B's second article title should be 'Article 4'."
+
+    assert (
+        card_c is not None and "articles" in card_c
+    ), "Card C should have nested articles."
+    assert len(card_c["articles"]) == 1, "Card C should have one article."
+    assert (
+        card_c["articles"][0]["title"] == "Article 5"
+    ), "Card C's article title should be 'Article 5'."
+
+    assert (
+        card_d is not None and "articles" in card_d
+    ), "Card D should have nested articles."
+    assert len(card_d["articles"]) == 0, "Card D should have no articles."
+
+
+@pytest.mark.asyncio
+async def test_get_multi_joined_card_with_multiple_articles_as_models(async_session):
+    cards = [
+        Card(title="Card A"),
+        Card(title="Card B"),
+        Card(title="Card C"),
+        Card(title="Card D"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+        Article(title="Article 2", card_id=cards[0].id),
+        Article(title="Article 3", card_id=cards[1].id),
+        Article(title="Article 4", card_id=cards[1].id),
+        Article(title="Article 5", card_id=cards[2].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        return_as_model=True,
+        schema_to_select=CardSchema,
+        nested_schema_to_select={"articles_": ArticleSchema},
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+    assert isinstance(data, list), "Result data should be a list."
+    assert len(data) == 4, "Expected four card records."
+    assert all(
+        isinstance(card, CardSchema) for card in data
+    ), "All items should be instances of CardSchema."
+
+    card_a = next((c for c in data if c.id == cards[0].id), None)
+    card_b = next((c for c in data if c.id == cards[1].id), None)
+    card_c = next((c for c in data if c.id == cards[2].id), None)
+    card_d = next((c for c in data if c.id == cards[3].id), None)
+
+    assert card_a is not None and hasattr(
+        card_a, "articles"
+    ), "Card A should have nested articles."
+    assert len(card_a.articles) == 2, "Card A should have two articles."
+    assert (
+        card_a.articles[0].title == "Article 1"
+    ), "Card A's first article title should be 'Article 1'."
+    assert (
+        card_a.articles[1].title == "Article 2"
+    ), "Card A's second article title should be 'Article 2'."
+    assert all(
+        isinstance(article, ArticleSchema) for article in card_a.articles
+    ), "All articles in Card A should be instances of ArticleSchema."
+
+    assert card_b is not None and hasattr(
+        card_b, "articles"
+    ), "Card B should have nested articles."
+    assert len(card_b.articles) == 2, "Card B should have two articles."
+    assert (
+        card_b.articles[0].title == "Article 3"
+    ), "Card B's first article title should be 'Article 3'."
+    assert (
+        card_b.articles[1].title == "Article 4"
+    ), "Card B's second article title should be 'Article 4'."
+    assert all(
+        isinstance(article, ArticleSchema) for article in card_b.articles
+    ), "All articles in Card B should be instances of ArticleSchema."
+
+    assert card_c is not None and hasattr(
+        card_c, "articles"
+    ), "Card C should have nested articles."
+    assert len(card_c.articles) == 1, "Card C should have one article."
+    assert (
+        card_c.articles[0].title == "Article 5"
+    ), "Card C's article title should be 'Article 5'."
+    assert all(
+        isinstance(article, ArticleSchema) for article in card_c.articles
+    ), "All articles in Card C should be instances of ArticleSchema."
+
+    assert card_d is not None and hasattr(
+        card_d, "articles"
+    ), "Card D should have nested articles."
+    assert len(card_d.articles) == 0, "Card D should have no articles."

--- a/tests/sqlmodel/conftest.py
+++ b/tests/sqlmodel/conftest.py
@@ -90,6 +90,21 @@ class Participant(SQLModel, table=True):
     )
 
 
+class Card(SQLModel, table=True):
+    __tablename__ = "cards"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    articles: list["Article"] = Relationship(back_populates="card")
+
+
+class Article(SQLModel, table=True):
+    __tablename__ = "articles"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    card_id: int = Field(foreign_key="cards.id")
+    card: Optional[Card] = Relationship(back_populates="articles")
+
+
 class CreateSchemaTest(SQLModel):
     model_config = ConfigDict(extra="forbid")
     name: str
@@ -154,6 +169,18 @@ class MultiPkCreate(SQLModel):
 class MultiPkSchema(SQLModel):
     name: str
     test_id: int = None
+
+
+class ArticleSchema(SQLModel):
+    id: int
+    title: str
+    card_id: int
+
+
+class CardSchema(SQLModel):
+    id: int
+    title: str
+    articles: Optional[list[ArticleSchema]] = []
 
 
 async_engine = create_async_engine(

--- a/tests/sqlmodel/conftest.py
+++ b/tests/sqlmodel/conftest.py
@@ -101,7 +101,7 @@ class Article(SQLModel, table=True):
     __tablename__ = "articles"
     id: Optional[int] = Field(default=None, primary_key=True)
     title: str
-    card_id: int = Field(foreign_key="cards.id")
+    card_id: Optional[int] = Field(foreign_key="cards.id")
     card: Optional[Card] = Relationship(back_populates="articles")
 
 

--- a/tests/sqlmodel/conftest.py
+++ b/tests/sqlmodel/conftest.py
@@ -193,8 +193,10 @@ local_session = sessionmaker(
 )
 
 
-def get_session_local():
-    yield local_session()
+async def get_session_local():
+    async with local_session() as session:
+        yield session
+        await session.close()
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/tests/sqlmodel/core/test_nest_multi_join_data.py
+++ b/tests/sqlmodel/core/test_nest_multi_join_data.py
@@ -1,0 +1,365 @@
+import pytest
+
+from fastcrud.crud.fast_crud import FastCRUD, JoinConfig
+
+from ..conftest import (
+    Article,
+    Card,
+    ArticleSchema,
+    CardSchema,
+)
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_new_row_none(async_session):
+    cards = [
+        Card(title="Card A"),
+        Card(title="Card B"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+        Article(
+            title="Article 2", card_id=None
+        ),  # This should trigger new_row[key] = []
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    card_a = next((c for c in data if c["id"] == cards[0].id), None)
+    assert (
+        card_a is not None and "articles" in card_a
+    ), "Card A should have nested articles."
+    assert len(card_a["articles"]) == 1, "Card A should have one valid article."
+    assert (
+        card_a["articles"][0]["title"] == "Article 1"
+    ), "Card A's article title should be 'Article 1'."
+
+    card_b = next((c for c in data if c["id"] == cards[1].id), None)
+    assert (
+        card_b is not None and "articles" in card_b
+    ), "Card B should have nested articles."
+    assert (
+        len(card_b["articles"]) == 0
+    ), "Card B should have no articles due to None card_id in Article."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_existing_row_none(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+        Article(title="Article 2", card_id=cards[0].id),
+        Article(
+            title="Article 3", card_id=None
+        ),  # This will trigger existing_row[key] = []
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    card_a = next((c for c in data if c["id"] == cards[0].id), None)
+    assert (
+        card_a is not None and "articles" in card_a
+    ), "Card A should have nested articles."
+    assert len(card_a["articles"]) == 2, "Card A should have two valid articles."
+    assert (
+        card_a["articles"][0]["title"] == "Article 1"
+    ), "Card A's first article title should be 'Article 1'."
+    assert (
+        card_a["articles"][1]["title"] == "Article 2"
+    ), "Card A's second article title should be 'Article 2'."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_nested_schema(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        return_as_model=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                schema_to_select=ArticleSchema,
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    assert len(data) == 1, "Expected one card record."
+    card_a = data[0]
+    assert isinstance(card_a, CardSchema), "Card should be an instance of CardSchema."
+    assert hasattr(card_a, "articles"), "Card should have nested articles."
+    assert len(card_a.articles) == 1, "Card should have one article."
+    assert isinstance(
+        card_a.articles[0], ArticleSchema
+    ), "Article should be an instance of ArticleSchema."
+    assert (
+        card_a.articles[0].title == "Article 1"
+    ), "Article title should be 'Article 1'."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_prefix_in_item(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        return_as_model=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                schema_to_select=ArticleSchema,
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    assert len(data) == 1, "Expected one card record."
+    card_a = data[0]
+    assert isinstance(card_a, CardSchema), "Card should be an instance of CardSchema."
+    assert hasattr(card_a, "articles"), "Card should have nested articles."
+    assert len(card_a.articles) == 1, "Card should have one article."
+    assert isinstance(
+        card_a.articles[0], ArticleSchema
+    ), "Article should be an instance of ArticleSchema."
+    assert (
+        card_a.articles[0].title == "Article 1"
+    ), "Article title should be 'Article 1'."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_isinstance_list(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+        Article(title="Article 2", card_id=cards[0].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        return_as_model=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                schema_to_select=ArticleSchema,
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    assert len(data) == 1, "Expected one card record."
+    card_a = data[0]
+    assert isinstance(card_a, CardSchema), "Card should be an instance of CardSchema."
+    assert hasattr(card_a, "articles"), "Card should have nested articles."
+    assert len(card_a.articles) == 2, "Card should have two articles."
+    assert all(
+        isinstance(article, ArticleSchema) for article in card_a.articles
+    ), "All articles should be instances of ArticleSchema."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_convert_list_to_schema(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+        Article(title="Article 2", card_id=cards[0].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        return_as_model=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                schema_to_select=ArticleSchema,
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    assert len(data) == 1, "Expected one card record."
+    card_a = data[0]
+    assert isinstance(card_a, CardSchema), "Card should be an instance of CardSchema."
+    assert hasattr(card_a, "articles"), "Card should have nested articles."
+    assert len(card_a.articles) == 2, "Card should have two articles."
+    assert all(
+        isinstance(article, ArticleSchema) for article in card_a.articles
+    ), "All articles should be instances of ArticleSchema."
+
+
+@pytest.mark.asyncio
+async def test_nest_multi_join_data_convert_dict_to_schema(async_session):
+    cards = [
+        Card(title="Card A"),
+    ]
+    async_session.add_all(cards)
+    await async_session.flush()
+
+    articles = [
+        Article(title="Article 1", card_id=cards[0].id),
+    ]
+    async_session.add_all(articles)
+    await async_session.commit()
+
+    card_crud = FastCRUD(Card)
+
+    result = await card_crud.get_multi_joined(
+        db=async_session,
+        nest_joins=True,
+        return_as_model=True,
+        schema_to_select=CardSchema,
+        joins_config=[
+            JoinConfig(
+                model=Article,
+                join_on=Article.card_id == Card.id,
+                join_prefix="articles_",
+                join_type="left",
+                schema_to_select=ArticleSchema,
+                relationship_type="one-to-many",
+            )
+        ],
+    )
+
+    assert result is not None, "No data returned from the database."
+    assert "data" in result, "Result should contain 'data' key."
+    data = result["data"]
+
+    assert len(data) == 1, "Expected one card record."
+    card_a = data[0]
+    assert isinstance(card_a, CardSchema), "Card should be an instance of CardSchema."
+    assert hasattr(card_a, "articles"), "Card should have nested articles."
+    assert len(card_a.articles) == 1, "Card should have one article."
+    assert isinstance(
+        card_a.articles[0], ArticleSchema
+    ), "Article should be an instance of ArticleSchema."
+    assert (
+        card_a.articles[0].title == "Article 1"
+    ), "Article title should be 'Article 1'."


### PR DESCRIPTION
## One-to-many support in joins

This fixes #91. Btw I'm not completely satisfied with the implementation, but it's enough for now.

- [x] Assuming a card has multiple articles, articles in get_joined response should be a list of articles.
- [x] Assuming a card has multiple articles, articles in get_multi_joined response should be a list of articles.
- [x] Add a way to specify if one-to-many or one-to-one
- [x] Tests covering changes
- [x] Documentation updates

___

## Documentation
### Handling One-to-One and One-to-Many Joins in FastCRUD

FastCRUD provides flexibility in handling one-to-one and one-to-many relationships through `get_joined` and `get_multi_joined` methods, along with the ability to specify how joined data should be structured using both the `relationship_type` (default `one-to-one`) and the `nest_joins` (default `False`) parameters.

#### One-to-One Relationships
- **`get_joined`**: Fetch a single record and its directly associated record (e.g., a user and their profile).
- **`get_multi_joined`** (with `nest_joins=False`): Retrieve multiple records, each linked to a single related record from another table (e.g., users and their profiles).


##### Example

Let's define two tables:

```python
class User(Base):
    __tablename__ = "user"
    id = Column(Integer, primary_key=True)
    name = Column(String)
    tier_id = Column(Integer, ForeignKey("tier.id"))

class Tier(Base):
    __tablename__ = "tier"
    id = Column(Integer, primary_key=True)
    name = Column(String, unique=True)
```

Fetch a user and their tier:

```python
user_tier = await user_crud.get_joined(
    db=db,
    join_model=Tier,
    join_on=User.tier_id == Tier.id,
    join_type="left",
    join_prefix="tier_",
    id=1
)
```

The result will be:

```json
{
    "id": 1,
    "name": "Example",
    "tier_id": 1,
    "tier_name": "Free"
}
```

###### One-to-One Relationship with Nested Joins

To get the joined data in a nested dictionary:

```python
user_tier = await user_crud.get_joined(
    db=db,
    join_model=Tier,
    join_on=User.tier_id == Tier.id,
    join_type="left",
    join_prefix="tier_",
    nest_joins=True,
    id=1
)
```

The result will be:

```json
{
    "id": 1,
    "name": "Example",
    "tier": {
        "id": 1,
        "name": "Free"
    }
}
```


#### One-to-Many Relationships
- **`get_joined`** (with `nest_joins=True`): Retrieve a single record with all its related records nested within it (e.g., a user and all their blog posts).
- **`get_multi_joined`** (with `nest_joins=True`): Fetch multiple primary records, each with their related records nested (e.g., multiple users and all their blog posts).

> [!WARNING]
> When using `nest_joins=True`, the performance will always be a bit worse than when using `nest_joins=False`. For cases where more performance is necessary, consider using `nest_joins=False` and remodeling your database.


##### Example

To demonstrate a one-to-many relationship, let's assume `User` and `Post` tables:

```python
class User(Base):
    __tablename__ = "user"
    id = Column(Integer, primary key=True)
    name = Column(String)

class Post(Base):
    __tablename__ = "post"
    id = Column(Integer, primary key=True)
    user_id = Column(Integer, ForeignKey("user.id"))
    content = Column(String)
```

Fetch a user and all their posts:

```python
user_posts = await user_crud.get_joined(
    db=db,
    join_model=Post,
    join_on=User.id == Post.user_id,
    join_type="left",
    join_prefix="post_",
    nest_joins=True,
    id=1
)
```

The result will be:

```json
{
    "id": 1,
    "name": "Example User",
    "posts": [
        {
            "id": 101,
            "user_id": 1,
            "content": "First post content"
        },
        {
            "id": 102,
            "user_id": 1,
            "content": "Second post content"
        }
    ]
}
```
