### PR TITLE
warning added to docs

### DIFF
--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -22,6 +22,12 @@ class User(Base):
     archived_at = Column(DateTime)
 ```
 
+!!! WARNING
+
+    Note that naive `datetime` such as `datetime.utcnow` is not supported by `FastCRUD` as it was [deprecated](https://github.com/python/cpython/pull/103858).
+    
+    Use timezone aware `datetime`, such as `datetime.now(UTC)` instead.
+
 You could just pass it to `FastCRUD`:
 
 ```python

--- a/docs/usage/crud.md
+++ b/docs/usage/crud.md
@@ -63,6 +63,12 @@ create(
 new_item = await item_crud.create(db, ItemCreateSchema(name="New Item"))
 ```
 
+!!! WARNING
+
+    Note that naive `datetime` such as `datetime.utcnow` is not supported by `FastCRUD` as it was [deprecated](https://github.com/python/cpython/pull/103858).
+    
+    Use timezone aware `datetime`, such as `datetime.now(UTC)` instead.
+
 ### 2. Get
 
 ```python


### PR DESCRIPTION
> [!WARNING]
> Note that naive `datetime` such as `datetime.utcnow` is not supported by `FastCRUD` as it was [deprecated](https://github.com/python/cpython/pull/103858). 
> Use timezone aware `datetime`, such as `datetime.now(UTC)` instead.


Closes #92 