### PR TITLE
Simplified endpoints

### DIFF
--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -135,7 +135,7 @@ items = await item_crud.get_multi(
 - __in - included in
 - __not_in - not included in
 
-### OR parameter filters
+### OR clauses
 
 More complex OR filters are supported. They must be passed as dictionary, where each key is a library-supported operator to be used in OR expression and values is what get's passed as the parameter.
 
@@ -146,6 +146,16 @@ items = await item_crud.get_multi(
     price__or={'lt': 5, 'gt': 20},
 )
 ```
+
+### AND clauses
+And clauses can be achieved by chaining multiple filters together.
+
+# Fetch items priced under $20 and over 2 years of warranty.
+items = await item_crud.get_multi(
+    db=db,
+    price__lt=20,
+    warranty_years__gt=2,
+)
 
 
 #### Counting Records

--- a/docs/advanced/endpoint.md
+++ b/docs/advanced/endpoint.md
@@ -73,6 +73,17 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
   "items_per_page": 3
 }
 ```
+!!! WARNING
+
+        _read_paginated endpoint is getting deprecated and mixed into _read_items in the next major release.
+        Please use _read_items with optional page and items_per_pagequery params instead, to achieve pagination as before.
+        Simple _read_items behaviour persists with no breaking changes.
+
+        Read items paginated:
+        curl -X 'GET'   'http://localhost:8000/users/get_multi?page=2&itemsPerPage=10'   -H 'accept: application/json'
+
+        Read items unpaginated:
+        url -X 'GET'   'http://localhost:8000/users/get_multi?offset=0&limit=100'   -H 'accept: application/json'
 
 ### Update
 
@@ -225,6 +236,12 @@ app.include_router(endpoint_creator.router)
 !!! TIP
 
     You only need to pass the names of the endpoints you want to change in the endpoint_names dict.
+
+!!! WARNING
+
+    default_endpoint_names for EndpointCreator are going to be changed to empty strings in the next major release.
+    See:  https://github.com/igorbenav/fastcrud/issues/67
+
 
 ## Extending EndpointCreator
 

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Type, TypeVar, Optional, Callable, Sequence, Union
 from enum import Enum
 
@@ -254,6 +255,15 @@ class EndpointCreator:
             "read_paginated": "get_paginated",
         }
         self.endpoint_names = {**self.default_endpoint_names, **(endpoint_names or {})}
+        if self.endpoint_names == self.default_endpoint_names:
+            warnings.warn(
+                "Old default_endpoint_names are deprecated. "
+                "Default values are going to be replaced by empty strings, "
+                "resulting in plain endpoint names. "
+                "For details see:"
+                " https://github.com/igorbenav/fastcrud/issues/67",
+                DeprecationWarning
+            )
         if filter_config:
             if isinstance(filter_config, dict):
                 filter_config = FilterConfig(**filter_config)
@@ -321,6 +331,12 @@ class EndpointCreator:
     def _read_paginated(self):
         """Creates an endpoint for reading multiple items from the database with pagination."""
         dynamic_filters = _create_dynamic_filters(self.filter_config, self.column_types)
+        warnings.warn(
+            "_read_paginated endpoint is going to dropped and unified"
+            "with _read_items one, so that items there can be optionally "
+            "paginated.",
+            DeprecationWarning
+        )
 
         async def endpoint(
             db: AsyncSession = Depends(self.session),

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -348,9 +348,10 @@ class EndpointCreator:
         dynamic_filters = _create_dynamic_filters(self.filter_config, self.column_types)
         warnings.warn(
             "_read_paginated endpoint is getting deprecated and mixed "
-            "into _read_items. You can keep using _read_items without changes "
-            "or add optional page and items_per_page query params to achieve "
-            "pagination as before.",
+            "into _read_items in the next major release. "
+            "Please use _read_items with optional page and items_per_page "
+            "query params instead, to achieve pagination as before."
+            "Simple _read_items behaviour persists with no breaking changes.",
             DeprecationWarning
         )
 

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -320,10 +320,10 @@ class EndpointCreator:
 
         async def endpoint(
             db: AsyncSession = Depends(self.session),
-            page: int | None = Query(
+            page: Optional[int] = Query(
                 None, alias="page", description="Page number"
             ),
-            items_per_page: int | None = Query(
+            items_per_page: Optional[int] = Query(
                 None, alias="itemsPerPage", description="Number of items per page"
             ),
             filters: dict = Depends(dynamic_filters),

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -388,17 +388,15 @@ class EndpointCreator:
         endpoint_name = self.endpoint_names.get(
             operation, self.default_endpoint_names.get(operation, operation)
         )
-
-        _primary_keys_path_suffix = "/".join(
-            f"{{{n}}}" for n in self.primary_key_names
-        )
+        path = f"{self.path}/{endpoint_name}" if endpoint_name else self.path
 
         if operation in {'read', 'update', 'delete', 'db_delete'}:
-            return f"{self.path}/{endpoint_name}/{_primary_keys_path_suffix}" \
-                if endpoint_name \
-                else f"{self.path}/{_primary_keys_path_suffix}"
-        else:
-            return f"{self.path}/{endpoint_name}" if endpoint_name else self.path
+            _primary_keys_path_suffix = "/".join(
+                f"{{{n}}}" for n in self.primary_key_names
+            )
+            path = f'{path}/{_primary_keys_path_suffix}'
+
+        return path
 
     def add_routes_to_router(
         self,

--- a/tests/sqlalchemy/endpoint/test_endpoint_custom_names.py
+++ b/tests/sqlalchemy/endpoint/test_endpoint_custom_names.py
@@ -4,6 +4,17 @@ from fastapi.testclient import TestClient
 from fastcrud import crud_router
 
 
+@pytest.mark.parametrize('custom_endpoint_names, endpoint_paths', [
+    (
+            {"create": "", "read": "", "read_multi": ""},
+            ["/test_custom_names", "/test_custom_names",
+             "/test_custom_names"]
+    ),
+    (
+            {"create": "add", "read": "fetch", "read_multi": "fetch_multi"},
+            ["/test_custom_names/add", "/test_custom_names/fetch",
+             "/test_custom_names/fetch_multi"]),
+])
 @pytest.mark.asyncio
 async def test_endpoint_custom_names(
     client: TestClient,
@@ -12,15 +23,12 @@ async def test_endpoint_custom_names(
     test_model,
     create_schema,
     update_schema,
+    custom_endpoint_names,
+    endpoint_paths,
 ):
     for item in test_data:
         async_session.add(test_model(**item))
     await async_session.commit()
-
-    custom_endpoint_names = {
-        "create": "add",
-        "read": "fetch",
-    }
 
     custom_router = crud_router(
         session=lambda: async_session,
@@ -34,19 +42,31 @@ async def test_endpoint_custom_names(
 
     client.app.include_router(custom_router)
 
+    create_path, read_path, read_multi_path = endpoint_paths
+
     create_response = client.post(
-        "/test_custom_names/add", json={"name": "Custom Endpoint Item", "tier_id": 1}
+        create_path, json={"name": "Custom Endpoint Item", "tier_id": 1}
     )
+
     assert (
         create_response.status_code == 200
     ), "Failed to create item with custom endpoint name"
 
     item_id = create_response.json()["id"]
 
-    fetch_response = client.get(f"/test_custom_names/fetch/{item_id}")
+    fetch_response = client.get(f'{read_path}/{item_id}')
     assert (
         fetch_response.status_code == 200
     ), "Failed to fetch item with custom endpoint name"
     assert (
         fetch_response.json()["id"] == item_id
-    ), "Fetched item ID does not match created item ID"
+    ), (f"Fetched item ID does not match created item ID:"
+        f" {fetch_response.json()['id']} != {item_id}")
+
+    fetch_multi_response = client.get(read_multi_path)
+    assert (
+        fetch_multi_response.status_code == 200
+    ), "Failed to fetch multi items with custom endpoint name"
+    assert (
+        len(fetch_multi_response.json()['data']) == 12
+    ), "Fetched item list has incorrect length"


### PR DESCRIPTION
# Pull Request Template for FastCRUD

## Description
This PR implements https://github.com/igorbenav/fastcrud/issues/67. It covers 2 issues:

1. It provides support for passing empty endpoint_names to fastcrud.crud_router() without redundant `//` in generated paths
```
endpoint_names = {
    "create": "",
    "read": "",
    "update": "",
    "delete": "",
    "db_delete": "",
    "read_multi": "",
    "read_paginated": "get_paginated",
}
```

2. It mixes existing _read_paginated endpoint logic into _read_items. Now "page" and "items_per_page" query parameters can be passed to _read_paginated resulting in same behavour. I also confirmed that old-style request for _read_items persist it's functinality. Default:


```curl -X 'GET' \
  'http://localhost:8000/users/get_multi?offset=0&limit=100' \
  -H 'accept: application/json'
```

works for both and new _read_items.



3. Appropriate warning have been added as needed.

4. I've added small update to advanced filters AND clauses documentation.


## Tests
Describe the tests you added or modified to cover your changes, if applicable.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.

## Additional Notes
Include any additional information that you think is important for reviewers to know.
