### PR TITLE
Add returning clause to update

### DIFF
--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -178,6 +178,46 @@ await crud_items.delete(
 # this will not actually delete until you run a db.commit()
 ```
 
+## Returning clause in `update`
+
+In `update` method, you can pass `return_columns` parameter containing a list of columns you want to return after the update.
+
+```python
+from fastcrud import FastCRUD
+
+from .models.item import Item
+from .database import session as db
+
+crud_items = FastCRUD(Item)
+item = await crud_items.update(
+    db=db,
+    object={"price": 9.99},
+    price__lt=10
+    return_columns=["price"]
+)
+# this will return the updated price
+```
+
+You can also pass `schema_to_select` parameter and `return_as_model` to return the updated data in the form of a Pydantic schema.
+
+```python
+from fastcrud import FastCRUD
+
+from .models.item import Item
+from .schemas.item import ItemSchema
+from .database import session as db
+
+crud_items = FastCRUD(Item)
+item = await crud_items.update(
+    db=db,
+    object={"price": 9.99},
+    price__lt=10
+    schema_to_select=ItemSchema,
+    return_as_model=True
+)
+# this will return the updated data in the form of ItemSchema
+```
+
 ## Unpaginated `get_multi` and `get_multi_joined`
 
 If you pass `None` to `limit` in `get_multi` and `get_multi_joined`, you get the whole unpaginated set of data that matches the filters. Use this with caution.

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -1618,7 +1618,7 @@ class FastCRUD(
             **kwargs: Filters to identify the record(s) to update, supporting advanced comparison operators for refined querying.
 
         Returns:
-            The updated record(s) as a dictionary or Pydantic model instance or None, depending on the value of `return_as_model` and `returning`.
+            The updated record(s) as a dictionary or Pydantic model instance or None, depending on the value of `return_as_model` and `return_columns`.
 
         Raises:
             MultipleResultsFound: If `allow_multiple` is False and more than one record matches the filters.

--- a/tests/sqlalchemy/crud/test_update.py
+++ b/tests/sqlalchemy/crud/test_update.py
@@ -221,14 +221,10 @@ async def test_update_auto_updates_updated_at(async_session, test_data):
     ["update_kwargs", "expected_result"],
     [
         pytest.param(
-            {},
+            {"return_columns": ["id", "name"]},
             {
                 "id": 1,
                 "name": "Updated Name",
-                "tier_id": 1,
-                "category_id": 1,
-                "is_deleted": False,
-                "deleted_at": None,
             },
             id="dict",
         ),
@@ -238,16 +234,12 @@ async def test_update_auto_updates_updated_at(async_session, test_data):
             id="model",
         ),
         pytest.param(
-            {"allow_multiple": True},
+            {"allow_multiple": True, "return_columns": ["id", "name"]},
             {
                 "data": [
                     {
                         "id": 1,
                         "name": "Updated Name",
-                        "tier_id": 1,
-                        "category_id": 1,
-                        "is_deleted": False,
-                        "deleted_at": None,
                     }
                 ]
             },
@@ -280,7 +272,6 @@ async def test_update_with_returning(
         db=async_session,
         object=updated_data,
         id=target_id,
-        returning=True,
         **update_kwargs,
     )
 


### PR DESCRIPTION
## Description

This change allows CRUD users to retrieve the updated record after performing an `update` operation by passing `return_columns` and optionally the model to load the response into.

## Changes

closes: #106

- add `return_columns` arg to the `update` function
- add `schema_to_select` arg to the `update` function
- add `return_as_model` arg to the `update` function
- add `one_or_none` arg to the `update` function
- add `Optional[Union[dict, BaseModel]]` return type as it now can return data

We use the same args that we also use in other CRUD API functions to make it easier for users to understand and use them.

## Tests

I have added tests for update operations returning a single row, multiple rows, with model and without (i.e. `dict`).

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.
