### PR TITLE
Add type-checking support for SQLModel types.

### DIFF
--- a/docs/usage/crud.md
+++ b/docs/usage/crud.md
@@ -234,7 +234,7 @@ items = await item_crud.get_multi(db, offset=0, limit=10, sort_columns=['name'],
 ```python
 get_joined(
     db: AsyncSession,
-    join_model: Optional[type[DeclarativeBase]] = None,
+    join_model: Optional[type[Union[DeclarativeBase, SQLModel]]] = None,
     join_prefix: Optional[str] = None,
     join_on: Optional[Union[Join, BinaryExpression]] = None,
     schema_to_select: Optional[type[BaseModel]] = None,

--- a/docs/usage/crud.md
+++ b/docs/usage/crud.md
@@ -234,7 +234,7 @@ items = await item_crud.get_multi(db, offset=0, limit=10, sort_columns=['name'],
 ```python
 get_joined(
     db: AsyncSession,
-    join_model: Optional[type[Union[DeclarativeBase, SQLModel]]] = None,
+    join_model: Optional[ModelType] = None,
     join_prefix: Optional[str] = None,
     join_on: Optional[Union[Join, BinaryExpression]] = None,
     schema_to_select: Optional[type[BaseModel]] = None,

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Generic, TypeVar, Union, Optional, Callable
+from typing import Any, Dict, Generic, Union, Optional, Callable
 from datetime import datetime, timezone
 
 from pydantic import BaseModel, ValidationError
@@ -7,11 +7,17 @@ from sqlalchemy.exc import ArgumentError, MultipleResultsFound, NoResultFound
 from sqlalchemy.sql import Join
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.engine.row import Row
-from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.sql.elements import BinaryExpression, ColumnElement
 from sqlalchemy.sql.selectable import Select
-from sqlmodel import SQLModel
+
+from fastcrud.types import (
+    CreateSchemaType,
+    DeleteSchemaType,
+    ModelType,
+    UpdateSchemaInternalType,
+    UpdateSchemaType,
+)
 
 from .helper import (
     _extract_matching_columns_from_schema,
@@ -23,12 +29,6 @@ from .helper import (
 )
 
 from ..endpoint.helper import _get_primary_keys
-
-ModelType = TypeVar("ModelType", bound=DeclarativeBase)
-CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
-UpdateSchemaType = TypeVar("UpdateSchemaType", bound=BaseModel)
-UpdateSchemaInternalType = TypeVar("UpdateSchemaInternalType", bound=BaseModel)
-DeleteSchemaType = TypeVar("DeleteSchemaType", bound=BaseModel)
 
 
 class FastCRUD(
@@ -831,7 +831,7 @@ class FastCRUD(
         self,
         db: AsyncSession,
         schema_to_select: Optional[type[BaseModel]] = None,
-        join_model: Optional[type[Union[DeclarativeBase, SQLModel]]] = None,
+        join_model: Optional[ModelType] = None,
         join_on: Optional[Union[Join, BinaryExpression]] = None,
         join_prefix: Optional[str] = None,
         join_schema_to_select: Optional[type[BaseModel]] = None,

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.sql.elements import BinaryExpression, ColumnElement
 from sqlalchemy.sql.selectable import Select
+from sqlmodel import SQLModel
 
 from .helper import (
     _extract_matching_columns_from_schema,
@@ -830,7 +831,7 @@ class FastCRUD(
         self,
         db: AsyncSession,
         schema_to_select: Optional[type[BaseModel]] = None,
-        join_model: Optional[type[DeclarativeBase]] = None,
+        join_model: Optional[type[Union[DeclarativeBase, SQLModel]]] = None,
         join_on: Optional[Union[Join, BinaryExpression]] = None,
         join_prefix: Optional[str] = None,
         join_schema_to_select: Optional[type[BaseModel]] = None,

--- a/fastcrud/crud/helper.py
+++ b/fastcrud/crud/helper.py
@@ -1,12 +1,12 @@
 from typing import Any, Optional, Union, Sequence, cast
 
 from sqlalchemy import inspect
-from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.sql import ColumnElement
 from pydantic import BaseModel, ConfigDict
 from pydantic.functional_validators import field_validator
-from sqlmodel import SQLModel
+
+from fastcrud.types import ModelType
 
 from ..endpoint.helper import _get_primary_key
 
@@ -39,7 +39,7 @@ class JoinConfig(BaseModel):
 
 
 def _extract_matching_columns_from_schema(
-    model: Union[type[Union[DeclarativeBase, SQLModel]], AliasedClass],
+    model: Union[ModelType, AliasedClass],
     schema: Optional[type[BaseModel]],
     prefix: Optional[str] = None,
     alias: Optional[AliasedClass] = None,
@@ -100,8 +100,8 @@ def _extract_matching_columns_from_schema(
 
 
 def _auto_detect_join_condition(
-    base_model: type[Union[DeclarativeBase, SQLModel]],
-    join_model: type[Union[DeclarativeBase, SQLModel]],
+    base_model: ModelType,
+    join_model: ModelType,
 ) -> Optional[ColumnElement]:
     """
     Automatically detects the join condition for SQLAlchemy models based on foreign key relationships.

--- a/fastcrud/endpoint/crud_router.py
+++ b/fastcrud/endpoint/crud_router.py
@@ -1,23 +1,22 @@
-from typing import Type, TypeVar, Optional, Union, Sequence, Callable
+from typing import Type, Optional, Union, Sequence, Callable
 from enum import Enum
 
 from fastapi import APIRouter
-from sqlalchemy.orm import DeclarativeBase
-from pydantic import BaseModel
-from sqlmodel import SQLModel
 
+from fastcrud.crud.fast_crud import FastCRUD
+from fastcrud.types import (
+    CreateSchemaType,
+    DeleteSchemaType,
+    ModelType,
+    UpdateSchemaType,
+)
 from .endpoint_creator import EndpointCreator
-from ..crud.fast_crud import FastCRUD
 from .helper import FilterConfig
-
-CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
-UpdateSchemaType = TypeVar("UpdateSchemaType", bound=BaseModel)
-DeleteSchemaType = TypeVar("DeleteSchemaType", bound=BaseModel)
 
 
 def crud_router(
     session: Callable,
-    model: type[Union[DeclarativeBase, SQLModel]],
+    model: ModelType,
     create_schema: Type[CreateSchemaType],
     update_schema: Type[UpdateSchemaType],
     crud: Optional[FastCRUD] = None,
@@ -288,6 +287,7 @@ def crud_router(
         # Example GET request: /mymodel/get_multi?id=1&name=example
         ```
     """
+
     crud = crud or FastCRUD(
         model=model,
         is_deleted_column=is_deleted_column,

--- a/fastcrud/endpoint/crud_router.py
+++ b/fastcrud/endpoint/crud_router.py
@@ -4,6 +4,7 @@ from enum import Enum
 from fastapi import APIRouter
 from sqlalchemy.orm import DeclarativeBase
 from pydantic import BaseModel
+from sqlmodel import SQLModel
 
 from .endpoint_creator import EndpointCreator
 from ..crud.fast_crud import FastCRUD
@@ -16,7 +17,7 @@ DeleteSchemaType = TypeVar("DeleteSchemaType", bound=BaseModel)
 
 def crud_router(
     session: Callable,
-    model: type[DeclarativeBase],
+    model: type[Union[DeclarativeBase, SQLModel]],
     create_schema: Type[CreateSchemaType],
     update_schema: Type[UpdateSchemaType],
     crud: Optional[FastCRUD] = None,

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -5,6 +5,7 @@ from fastapi import Depends, Body, Query, APIRouter
 from pydantic import BaseModel, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import DeclarativeBase
+from sqlmodel import SQLModel
 
 from ..crud.fast_crud import FastCRUD
 from ..exceptions.http_exceptions import DuplicateValueException, NotFoundException
@@ -207,7 +208,7 @@ class EndpointCreator:
     def __init__(
         self,
         session: Callable,
-        model: type[DeclarativeBase],
+        model: type[Union[DeclarativeBase, SQLModel]],
         create_schema: Type[CreateSchemaType],
         update_schema: Type[UpdateSchemaType],
         crud: Optional[FastCRUD] = None,

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -1,13 +1,17 @@
-from typing import Type, TypeVar, Optional, Callable, Sequence, Union
+from typing import Type, Optional, Callable, Sequence, Union
 from enum import Enum
 
 from fastapi import Depends, Body, Query, APIRouter
-from pydantic import BaseModel, ValidationError
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import DeclarativeBase
-from sqlmodel import SQLModel
 
-from ..crud.fast_crud import FastCRUD
+from fastcrud.crud.fast_crud import FastCRUD
+from fastcrud.types import (
+    CreateSchemaType,
+    DeleteSchemaType,
+    ModelType,
+    UpdateSchemaType,
+)
 from ..exceptions.http_exceptions import DuplicateValueException, NotFoundException
 from ..paginated.helper import compute_offset
 from ..paginated.response import paginated_response
@@ -22,11 +26,6 @@ from .helper import (
     _create_dynamic_filters,
     _get_column_types,
 )
-
-CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
-UpdateSchemaType = TypeVar("UpdateSchemaType", bound=BaseModel)
-UpdateSchemaInternalType = TypeVar("UpdateSchemaInternalType", bound=BaseModel)
-DeleteSchemaType = TypeVar("DeleteSchemaType", bound=BaseModel)
 
 
 class EndpointCreator:
@@ -208,7 +207,7 @@ class EndpointCreator:
     def __init__(
         self,
         session: Callable,
-        model: type[Union[DeclarativeBase, SQLModel]],
+        model: ModelType,
         create_schema: Type[CreateSchemaType],
         update_schema: Type[UpdateSchemaType],
         crud: Optional[FastCRUD] = None,

--- a/fastcrud/endpoint/helper.py
+++ b/fastcrud/endpoint/helper.py
@@ -5,11 +5,11 @@ import warnings
 from pydantic import BaseModel, Field
 from pydantic.functional_validators import field_validator
 from fastapi import Depends, Query, params
-from sqlmodel import SQLModel
 
 from sqlalchemy import Column, inspect as sa_inspect
-from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.sql.elements import KeyedColumnElement
+
+from fastcrud.types import ModelType
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -72,14 +72,14 @@ class FilterConfig(BaseModel):
 
 
 def _get_primary_key(
-    model: type[Union[DeclarativeBase, SQLModel]],
+    model: ModelType,
 ) -> Union[str, None]:  # pragma: no cover
     key: Optional[str] = _get_primary_keys(model)[0].name
     return key
 
 
 def _get_primary_keys(
-    model: type[Union[DeclarativeBase, SQLModel]],
+    model: ModelType,
 ) -> Sequence[Column]:
     """Get the primary key of a SQLAlchemy model."""
     inspector_result = sa_inspect(model)
@@ -105,7 +105,7 @@ def _get_python_type(column: Column) -> Optional[type]:
 
 
 def _get_column_types(
-    model: type[Union[DeclarativeBase, SQLModel]],
+    model: ModelType,
 ) -> dict[str, Union[type, None]]:
     """Get a dictionary of column names and their corresponding Python types from a SQLAlchemy model."""
     inspector_result = sa_inspect(model)
@@ -118,7 +118,7 @@ def _get_column_types(
 
 
 def _extract_unique_columns(
-    model: type[Union[DeclarativeBase, SQLModel]],
+    model: ModelType,
 ) -> Sequence[KeyedColumnElement]:
     """Extracts columns from a SQLAlchemy model that are marked as unique."""
     if not hasattr(model, "__table__"):

--- a/fastcrud/endpoint/helper.py
+++ b/fastcrud/endpoint/helper.py
@@ -5,6 +5,7 @@ import warnings
 from pydantic import BaseModel, Field
 from pydantic.functional_validators import field_validator
 from fastapi import Depends, Query, params
+from sqlmodel import SQLModel
 
 from sqlalchemy import Column, inspect as sa_inspect
 from sqlalchemy.orm import DeclarativeBase
@@ -71,16 +72,20 @@ class FilterConfig(BaseModel):
 
 
 def _get_primary_key(
-    model: type[DeclarativeBase],
+    model: type[Union[DeclarativeBase, SQLModel]],
 ) -> Union[str, None]:  # pragma: no cover
     key: Optional[str] = _get_primary_keys(model)[0].name
     return key
 
 
-def _get_primary_keys(model: type[DeclarativeBase]) -> Sequence[Column]:
+def _get_primary_keys(
+    model: type[Union[DeclarativeBase, SQLModel]],
+) -> Sequence[Column]:
     """Get the primary key of a SQLAlchemy model."""
-    inspector = sa_inspect(model).mapper
-    primary_key_columns: Sequence[Column] = inspector.primary_key
+    inspector_result = sa_inspect(model)
+    if inspector_result is None:
+        raise ValueError("Model inspection failed, resulting in None.")
+    primary_key_columns: Sequence[Column] = inspector_result.mapper.primary_key
 
     return primary_key_columns
 
@@ -99,19 +104,25 @@ def _get_python_type(column: Column) -> Optional[type]:
             )
 
 
-def _get_column_types(model: type[DeclarativeBase]) -> dict[str, Union[type, None]]:
+def _get_column_types(
+    model: type[Union[DeclarativeBase, SQLModel]],
+) -> dict[str, Union[type, None]]:
     """Get a dictionary of column names and their corresponding Python types from a SQLAlchemy model."""
-    inspector = sa_inspect(model).mapper
+    inspector_result = sa_inspect(model)
+    if inspector_result is None or inspector_result.mapper is None:
+        raise ValueError("Model inspection failed, resulting in None.")
     column_types = {}
-    for column in inspector.columns:
+    for column in inspector_result.mapper.columns:
         column_types[column.name] = _get_python_type(column)
     return column_types
 
 
 def _extract_unique_columns(
-    model: type[DeclarativeBase],
+    model: type[Union[DeclarativeBase, SQLModel]],
 ) -> Sequence[KeyedColumnElement]:
     """Extracts columns from a SQLAlchemy model that are marked as unique."""
+    if not hasattr(model, "__table__"):
+        raise AttributeError(f"{model.__name__} does not have a '__table__' attribute.")
     unique_columns = [column for column in model.__table__.columns if column.unique]
     return unique_columns
 

--- a/fastcrud/types.py
+++ b/fastcrud/types.py
@@ -1,0 +1,10 @@
+from typing import TypeVar, Any
+
+from pydantic import BaseModel
+
+ModelType = TypeVar("ModelType", bound=Any)
+
+CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
+UpdateSchemaType = TypeVar("UpdateSchemaType", bound=BaseModel)
+UpdateSchemaInternalType = TypeVar("UpdateSchemaInternalType", bound=BaseModel)
+DeleteSchemaType = TypeVar("DeleteSchemaType", bound=BaseModel)

--- a/tests/sqlalchemy/endpoint/test_endpoint_custom_names.py
+++ b/tests/sqlalchemy/endpoint/test_endpoint_custom_names.py
@@ -4,17 +4,23 @@ from fastapi.testclient import TestClient
 from fastcrud import crud_router
 
 
-@pytest.mark.parametrize('custom_endpoint_names, endpoint_paths', [
-    (
+@pytest.mark.parametrize(
+    "custom_endpoint_names, endpoint_paths",
+    [
+        (
             {"create": "", "read": "", "read_multi": ""},
-            ["/test_custom_names", "/test_custom_names",
-             "/test_custom_names"]
-    ),
-    (
+            ["/test_custom_names", "/test_custom_names", "/test_custom_names"],
+        ),
+        (
             {"create": "add", "read": "fetch", "read_multi": "fetch_multi"},
-            ["/test_custom_names/add", "/test_custom_names/fetch",
-             "/test_custom_names/fetch_multi"]),
-])
+            [
+                "/test_custom_names/add",
+                "/test_custom_names/fetch",
+                "/test_custom_names/fetch_multi",
+            ],
+        ),
+    ],
+)
 @pytest.mark.asyncio
 async def test_endpoint_custom_names(
     client: TestClient,
@@ -54,19 +60,19 @@ async def test_endpoint_custom_names(
 
     item_id = create_response.json()["id"]
 
-    fetch_response = client.get(f'{read_path}/{item_id}')
+    fetch_response = client.get(f"{read_path}/{item_id}")
     assert (
         fetch_response.status_code == 200
     ), "Failed to fetch item with custom endpoint name"
-    assert (
-        fetch_response.json()["id"] == item_id
-    ), (f"Fetched item ID does not match created item ID:"
-        f" {fetch_response.json()['id']} != {item_id}")
+    assert fetch_response.json()["id"] == item_id, (
+        f"Fetched item ID does not match created item ID:"
+        f" {fetch_response.json()['id']} != {item_id}"
+    )
 
     fetch_multi_response = client.get(read_multi_path)
     assert (
         fetch_multi_response.status_code == 200
     ), "Failed to fetch multi items with custom endpoint name"
     assert (
-        len(fetch_multi_response.json()['data']) == 12
+        len(fetch_multi_response.json()["data"]) == 12
     ), "Fetched item list has incorrect length"

--- a/tests/sqlalchemy/endpoint/test_get_paginated.py
+++ b/tests/sqlalchemy/endpoint/test_get_paginated.py
@@ -91,7 +91,9 @@ async def test_read_paginated_with_filters(
 
 # ------ the following tests will completely replace the current ones in the next version of fastcrud ------
 @pytest.mark.asyncio
-async def test_read_items_with_pagination(client: TestClient, async_session, test_model, test_data):
+async def test_read_items_with_pagination(
+    client: TestClient, async_session, test_model, test_data
+):
     for data in test_data:
         new_item = test_model(**data)
         async_session.add(new_item)
@@ -100,9 +102,7 @@ async def test_read_items_with_pagination(client: TestClient, async_session, tes
     page = 1
     items_per_page = 5
 
-    response = client.get(
-        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}"
-    )
+    response = client.get(f"/test/get_multi?page={page}&itemsPerPage={items_per_page}")
 
     assert response.status_code == 200
 
@@ -125,7 +125,9 @@ async def test_read_items_with_pagination(client: TestClient, async_session, tes
 
 
 @pytest.mark.asyncio
-async def test_read_items_with_pagination_and_filters(filtered_client: TestClient, async_session, test_model, test_data):
+async def test_read_items_with_pagination_and_filters(
+    filtered_client: TestClient, async_session, test_model, test_data
+):
     for data in test_data:
         new_item = test_model(**data)
         async_session.add(new_item)

--- a/tests/sqlmodel/endpoint/test_get_paginated.py
+++ b/tests/sqlmodel/endpoint/test_get_paginated.py
@@ -91,7 +91,9 @@ async def test_read_paginated_with_filters(
 
 # ------ the following tests will completely replace the current ones in the next version of fastcrud ------
 @pytest.mark.asyncio
-async def test_read_items_with_pagination(client: TestClient, async_session, test_model, test_data):
+async def test_read_items_with_pagination(
+    client: TestClient, async_session, test_model, test_data
+):
     for data in test_data:
         new_item = test_model(**data)
         async_session.add(new_item)
@@ -100,9 +102,7 @@ async def test_read_items_with_pagination(client: TestClient, async_session, tes
     page = 1
     items_per_page = 5
 
-    response = client.get(
-        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}"
-    )
+    response = client.get(f"/test/get_multi?page={page}&itemsPerPage={items_per_page}")
 
     assert response.status_code == 200
 
@@ -125,7 +125,9 @@ async def test_read_items_with_pagination(client: TestClient, async_session, tes
 
 
 @pytest.mark.asyncio
-async def test_read_items_with_pagination_and_filters(filtered_client: TestClient, async_session, test_model, test_data):
+async def test_read_items_with_pagination_and_filters(
+    filtered_client: TestClient, async_session, test_model, test_data
+):
     for data in test_data:
         new_item = test_model(**data)
         async_session.add(new_item)


### PR DESCRIPTION
# Added Type Checking Support for SQLModel Classes

## Description
My changes solve #58 and allow users to directly use SQLModel without type-issues. It passes all tests and shows no typing issues.

## Changes
I made many none-obtrusive type changes such as replacing instances of `type[DeclarativeBase]` with `type[Union[DeclarativeBase, SQLModel]]`. This alone caused mypy errors do to __table__ not being present on SQLModel which doesn't make sense as it does, so I think this is just poor typing on SQLModel's side. To deal with this wherever model.__title__ is being referenced I explicitly checked if that field was available and raised a ValueError if it was not. Doing this allowed my changes to pass all linting checks.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.
