### PR TITLE
Add upsert_multi

### DIFF
--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -253,6 +253,29 @@ items = await crud_items.get_multi(db=db, limit=None)
 
 To facilitate complex data relationships, `get_joined` and `get_multi_joined` can be configured to handle joins with multiple models. This is achieved using the `joins_config` parameter, where you can specify a list of `JoinConfig` instances, each representing a distinct join configuration.
 
+## Upserting multiple records using `upsert_multi`
+
+FastCRUD provides an `upsert_multi` method to efficiently upsert multiple records in a single operation. This method is particularly useful when you need to insert new records or update existing ones based on a unique constraint.
+
+```python
+from fastcrud import FastCRUD
+
+from .models.item import Item
+from .schemas.item import ItemCreateSchema
+from .database import session as db
+
+crud_items = FastCRUD(Item)
+items = await crud_items.upsert_multi(
+    db=db,
+    instances=[
+        ItemCreateSchema(price=9.99),
+    ],
+    schema_to_select=ItemSchema,
+    return_as_model=True,
+)
+# this will return the upserted data in the form of ItemSchema
+```
+
 #### Example: Joining `User`, `Tier`, and `Department` Models
 
 Consider a scenario where you want to retrieve users along with their associated tier and department information. Here's how you can achieve this using `get_multi_joined`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ SQLAlchemy = "^2.0.0"
 pydantic = "^2.0.0"
 SQLAlchemy-Utils = "^0.41.1"
 fastapi = ">=0.100.0,<0.112.0"
+psycopg = "^3.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.4"
@@ -44,7 +45,13 @@ sqlmodel = "^0.0.14"
 mypy = "^1.9.0"
 ruff = "^0.3.4"
 coverage = "^7.4.4"
+testcontainers = "^4.7.1"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+markers = [
+    "dialect(name): mark test to run only on specific SQL dialect",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ coverage = "^7.4.4"
 testcontainers = "^4.7.1"
 psycopg = "^3.2.1"
 aiomysql = "^0.2.0"
+cryptography = "^36.0.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ SQLAlchemy = "^2.0.0"
 pydantic = "^2.0.0"
 SQLAlchemy-Utils = "^0.41.1"
 fastapi = ">=0.100.0,<0.112.0"
-psycopg = "^3.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.4"
@@ -46,6 +45,8 @@ mypy = "^1.9.0"
 ruff = "^0.3.4"
 coverage = "^7.4.4"
 testcontainers = "^4.7.1"
+psycopg = "^3.2.1"
+aiomysql = "^0.2.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -5,7 +5,15 @@ from datetime import datetime
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import Column, Integer, String, ForeignKey, Boolean, DateTime
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    ForeignKey,
+    Boolean,
+    DateTime,
+    make_url,
+)
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker, DeclarativeBase, relationship
 from pydantic import BaseModel, ConfigDict
@@ -13,6 +21,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.sql import func
 from testcontainers.postgres import PostgresContainer
+from testcontainers.mysql import MySqlContainer
 
 from fastcrud.crud.fast_crud import FastCRUD
 from fastcrud.endpoint.crud_router import crud_router
@@ -27,7 +36,7 @@ class MultiPkModel(Base):
     __tablename__ = "multi_pk"
     id = Column(Integer, primary_key=True)
     uuid = Column(String(32), primary_key=True)
-    name = Column(String, unique=True)
+    name = Column(String(32), unique=True)
     test_id = Column(Integer, ForeignKey("test.id"))
     test = relationship("ModelTest", back_populates="multi_pk")
 
@@ -36,13 +45,13 @@ class CategoryModel(Base):
     __tablename__ = "category"
     tests = relationship("ModelTest", back_populates="category")
     id = Column(Integer, primary_key=True)
-    name = Column(String, unique=True)
+    name = Column(String(32), unique=True)
 
 
 class ModelTest(Base):
     __tablename__ = "test"
     id = Column(Integer, primary_key=True)
-    name = Column(String)
+    name = Column(String(32))
     tier_id = Column(Integer, ForeignKey("tier.id"))
     category_id = Column(
         Integer, ForeignKey("category.id"), nullable=True, default=None
@@ -57,7 +66,7 @@ class ModelTest(Base):
 class ModelTestWithTimestamp(Base):
     __tablename__ = "model_test_with_timestamp"
     id = Column(Integer, primary_key=True)
-    name = Column(String)
+    name = Column(String(32))
     tier_id = Column(Integer, ForeignKey("tier.id"))
     category_id = Column(
         Integer, ForeignKey("category.id"), nullable=True, default=None
@@ -72,7 +81,7 @@ class ModelTestWithTimestamp(Base):
 class TierModel(Base):
     __tablename__ = "tier"
     id = Column(Integer, primary_key=True)
-    name = Column(String, unique=True)
+    name = Column(String(32), unique=True)
     tests = relationship("ModelTest", back_populates="tier")
 
 
@@ -89,8 +98,8 @@ class BookingModel(Base):
 class Project(Base):
     __tablename__ = "projects"
     id = Column(Integer, primary_key=True)
-    name = Column(String, nullable=False)
-    description = Column(String)
+    name = Column(String(32), nullable=False)
+    description = Column(String(32))
     participants = relationship(
         "Participant",
         secondary="projects_participants_association",
@@ -101,8 +110,8 @@ class Project(Base):
 class Participant(Base):
     __tablename__ = "participants"
     id = Column(Integer, primary_key=True)
-    name = Column(String, nullable=False)
-    role = Column(String)
+    name = Column(String(32), nullable=False)
+    role = Column(String(32))
     projects = relationship(
         "Project",
         secondary="projects_participants_association",
@@ -119,13 +128,13 @@ class ProjectsParticipantsAssociation(Base):
 class Card(Base):
     __tablename__ = "cards"
     id = Column(Integer, primary_key=True)
-    title = Column(String)
+    title = Column(String(32))
 
 
 class Article(Base):
     __tablename__ = "articles"
     id = Column(Integer, primary_key=True)
-    title = Column(String)
+    title = Column(String(32))
     card_id = Column(Integer, ForeignKey("cards.id"))
     card = relationship("Card", back_populates="articles")
 
@@ -136,26 +145,26 @@ Card.articles = relationship("Article", order_by=Article.id, back_populates="car
 class Client(Base):
     __tablename__ = "clients"
     id = Column(Integer, primary_key=True)
-    name = Column(String, nullable=False)
-    contact = Column(String, nullable=False)
-    phone = Column(String, nullable=False)
-    email = Column(String, nullable=False)
+    name = Column(String(32), nullable=False)
+    contact = Column(String(32), nullable=False)
+    phone = Column(String(32), nullable=False)
+    email = Column(String(32), nullable=False)
 
 
 class Department(Base):
     __tablename__ = "departments"
     id = Column(Integer, primary_key=True)
-    name = Column(String, nullable=False)
+    name = Column(String(32), nullable=False)
 
 
 class User(Base):
     __tablename__ = "users"
     id = Column(Integer, primary_key=True)
-    name = Column(String, nullable=False)
-    username = Column(String, nullable=False, unique=True)
-    email = Column(String, nullable=False, unique=True)
-    phone = Column(String, nullable=True)
-    profile_image_url = Column(String, nullable=True)
+    name = Column(String(32), nullable=False)
+    username = Column(String(32), nullable=False, unique=True)
+    email = Column(String(32), nullable=False, unique=True)
+    phone = Column(String(32), nullable=True)
+    profile_image_url = Column(String(32), nullable=True)
     department_id = Column(Integer, ForeignKey("departments.id"), nullable=True)
     company_id = Column(Integer, ForeignKey("clients.id"), nullable=True)
     department = relationship("Department", backref="users")
@@ -165,8 +174,8 @@ class User(Base):
 class Task(Base):
     __tablename__ = "tasks"
     id = Column(Integer, primary_key=True)
-    name = Column(String, nullable=False)
-    description = Column(String, nullable=True)
+    name = Column(String(32), nullable=False)
+    description = Column(String(32), nullable=True)
     client_id = Column(Integer, ForeignKey("clients.id"), nullable=True)
     department_id = Column(Integer, ForeignKey("departments.id"), nullable=True)
     assignee_id = Column(Integer, ForeignKey("users.id"), nullable=True)
@@ -306,6 +315,14 @@ async def async_session(request: pytest.FixtureRequest) -> AsyncGenerator[AsyncS
     elif dialect == "sqlite":
         async with _async_session(url="sqlite+aiosqlite:///:memory:") as session:
             yield session
+    elif dialect == "mysql":
+        with MySqlContainer() as mysql:
+            async with _async_session(
+                url=make_url(name_or_url=mysql.get_connection_url())._replace(
+                    drivername="mysql+aiomysql"
+                )
+            ) as session:
+                yield session
     else:
         raise ValueError(f"Unsupported dialect: {dialect}")
 

--- a/tests/sqlalchemy/crud/test_upsert.py
+++ b/tests/sqlalchemy/crud/test_upsert.py
@@ -1,6 +1,7 @@
 import pytest
 
 from fastcrud.crud.fast_crud import FastCRUD
+from tests.sqlalchemy.conftest import CategoryModel, ReadSchemaTest, TierModel
 
 
 @pytest.mark.asyncio
@@ -14,3 +15,125 @@ async def test_upsert_successful(async_session, test_model, read_schema):
 
     updated_fetched_record = await crud.upsert(async_session, fetched_record)
     assert read_schema.model_validate(updated_fetched_record) == fetched_record
+
+
+@pytest.mark.parametrize(
+    ["insert", "update"],
+    [
+        pytest.param(
+            {
+                "kwargs": {},
+                "expected_result": None,
+            },
+            {
+                "kwargs": {},
+                "expected_result": None,
+            },
+            id="none",
+        ),
+        pytest.param(
+            {
+                "kwargs": {"return_columns": ["id", "name"]},
+                "expected_result": {
+                    "data": [
+                        {
+                            "id": 1,
+                            "name": "New Record",
+                        }
+                    ]
+                },
+            },
+            {
+                "kwargs": {"return_columns": ["id", "name"]},
+                "expected_result": {
+                    "data": [
+                        {
+                            "id": 1,
+                            "name": "New name",
+                        }
+                    ]
+                },
+            },
+            id="dict",
+        ),
+        pytest.param(
+            {
+                "kwargs": {"return_columns": ["id", "name"]},
+                "expected_result": {
+                    "data": [
+                        {
+                            "id": 1,
+                            "name": "New Record",
+                        }
+                    ]
+                },
+            },
+            {
+                "kwargs": {
+                    "return_columns": ["id", "name"],
+                    "name__match": "NewRecord",
+                },
+                "expected_result": {"data": []},
+            },
+            id="dict-filtered",
+        ),
+        pytest.param(
+            {
+                "kwargs": {
+                    "schema_to_select": ReadSchemaTest,
+                    "return_as_model": True,
+                },
+                "expected_result": {
+                    "data": [
+                        ReadSchemaTest(
+                            id=1, name="New Record", tier_id=1, category_id=1
+                        )
+                    ]
+                },
+            },
+            {
+                "kwargs": {
+                    "schema_to_select": ReadSchemaTest,
+                    "return_as_model": True,
+                },
+                "expected_result": {
+                    "data": [
+                        ReadSchemaTest(id=1, name="New name", tier_id=1, category_id=1)
+                    ]
+                },
+            },
+            id="model",
+        ),
+    ],
+)
+@pytest.mark.dialect("postgresql")
+@pytest.mark.asyncio
+async def test_upsert_multi_successful(
+    async_session,
+    test_model,
+    read_schema,
+    test_data_tier,
+    test_data_category,
+    insert,
+    update,
+):
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    for category_item in test_data_category:
+        async_session.add(CategoryModel(**category_item))
+    await async_session.commit()
+
+    crud = FastCRUD(test_model)
+    new_data = read_schema(id=1, name="New Record", tier_id=1, category_id=1)
+    fetched_records = await crud.upsert_multi(
+        async_session, [new_data], **insert["kwargs"]
+    )
+
+    assert fetched_records == insert["expected_result"]
+
+    updated_new_data = new_data.model_copy(update={"name": "New name"})
+    updated_fetched_records = await crud.upsert_multi(
+        async_session, [updated_new_data], **update["kwargs"]
+    )
+
+    assert updated_fetched_records == update["expected_result"]


### PR DESCRIPTION
## Description

This is about enabling users to upsert multiple models/rows.

## Changes

- add `upsert_multi` to `FastCRUD` using dialect-optimized sql
- add `psycopg` dependency for executing postgres statements via sqlalchemy
- add `testcontainers` to run tests in a ephemeral postgres container

closes: #110 

## Tests

- add postgres-specific `upsert_multi` test
- add sqlite-specific `upsert_multi` test
- add mysql-specific `upsert_multi` test

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.
