### PR TITLE
[Concept] Drop reduntant model param

### DIFF
--- a/fastcrud/endpoint/crud_router.py
+++ b/fastcrud/endpoint/crud_router.py
@@ -298,7 +298,6 @@ def crud_router(
     endpoint_creator_class = endpoint_creator or EndpointCreator
     endpoint_creator_instance = endpoint_creator_class(
         session=session,
-        model=model,
         crud=crud,
         create_schema=create_schema,
         update_schema=update_schema,

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -208,7 +208,6 @@ class EndpointCreator:
     def __init__(
         self,
         session: Callable,
-        model: ModelType,
         create_schema: Type[CreateSchemaType],
         update_schema: Type[UpdateSchemaType],
         crud: Optional[FastCRUD] = None,
@@ -228,13 +227,8 @@ class EndpointCreator:
         }
         self.primary_key_names = [pk.name for pk in self._primary_keys]
         self.session = session
-        self.crud = crud or FastCRUD(
-            model=model,
-            is_deleted_column=is_deleted_column,
-            deleted_at_column=deleted_at_column,
-            updated_at_column=updated_at_column,
-        )
-        self.model = model
+        self.crud = crud
+        self.model = self.crud.model
         self.create_schema = create_schema
         self.update_schema = update_schema
         self.delete_schema = delete_schema


### PR DESCRIPTION
The idea is that if you use EndpointCreator, the model is passed twice: once to the corresponding FastCRUD and another time class itself. As the model is already required in FastCRUD, it should picked from there. 

This is a breaking change if somebody didn't pass explicit crud, but `EndpointCreator(crud=FastCRUD(MyModel))` or `EndpointCreator(crud=MyFastCRUD(MyModel))` looks a clean and consistent approach.

What are your thoughts? @igorbenav 