### PR TITLE
Doc formatting cleanup

### DIFF
--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -1,4 +1,3 @@
-
 # Advanced Use of FastCRUD
 
 FastCRUD offers a flexible and powerful approach to handling CRUD operations in FastAPI applications, leveraging the SQLAlchemy ORM. Beyond basic CRUD functionality, FastCRUD provides advanced features like `allow_multiple` for updates and deletes, and support for advanced filters (e.g., less than, greater than). These features enable more complex and fine-grained data manipulation and querying capabilities.
@@ -46,7 +45,7 @@ from .schemas.user import UserCreate, UserUpdate, UserUpdateInternal, UserDelete
 CRUDUser = FastCRUD[User, UserCreate, UserUpdate, UserUpdateInternal, UserDelete]
 ```
 
-Then you can initialize CRUDUser like you would any FastCRUD instance, but with the relevant types:
+Then you can initialize `CRUDUser` like you would any `FastCRUD` instance, but with the relevant types:
 
 ```python
 from .models.user import User
@@ -70,7 +69,7 @@ await item_crud.update(
     db=db,
     object={"price": 9.99},
     allow_multiple=True,
-    price__lt=10
+    price__lt=10,
 )
 ```
 
@@ -83,7 +82,7 @@ Similarly, you can delete multiple records by using the `allow_multiple=True` pa
 await item_crud.delete(
     db=db,
     allow_multiple=True,
-    last_sold__lt=datetime.datetime.now() - datetime.timedelta(days=365)
+    last_sold__lt=datetime.datetime.now() - datetime.timedelta(days=365),
 )
 ```
 
@@ -104,21 +103,22 @@ items = await item_crud.get_multi(
 ```
 
 Currently supported single parameter filters are:
-- __gt - greater than
-- __lt - less than
-- __gte - greater than or equal to
-- __lte - less than or equal to
-- __ne - not equal
-- __is - used to test True, False and None identity
-- __is_not - negation of "is"
-- __like - SQL "like" search for specific text pattern
-- __notlike - negation of "like"
-- __ilike - case insensitive "like"
-- __notilike - case insensitive "notlike"
-- __startswith - text starts with given string
-- __endswith - text ends with given string
-- __contains - text contains given string
-- __match - database-specific match expression
+
+- `__gt` - greater than
+- `__lt` - less than
+- `__gte` - greater than or equal to
+- `__lte` - less than or equal to
+- `__ne` - not equal
+- `__is` - used to test True, False and None identity
+- `__is_not` - negation of "is"
+- `__like` - SQL "like" search for specific text pattern
+- `__notlike` - negation of "like"
+- `__ilike` - case insensitive "like"
+- `__notilike` - case insensitive "notlike"
+- `__startswith` - text starts with given string
+- `__endswith` - text ends with given string
+- `__contains` - text contains given string
+- `__match` - database-specific match expression
 
 ### Complex parameter filters
 
@@ -131,9 +131,10 @@ items = await item_crud.get_multi(
     price__between=(5, 20),
 )
 ```
-- __between - between 2 numeric values
-- __in - included in
-- __not_in - not included in
+
+- `__between` - between 2 numeric values
+- `__in` - included in
+- `__not_in` - not included in
 
 ### OR clauses
 
@@ -148,15 +149,16 @@ items = await item_crud.get_multi(
 ```
 
 ### AND clauses
-And clauses can be achieved by chaining multiple filters together.
+AND clauses can be achieved by chaining multiple filters together.
 
+```python
 # Fetch items priced under $20 and over 2 years of warranty.
 items = await item_crud.get_multi(
     db=db,
     price__lt=20,
     warranty_years__gt=2,
 )
-
+```
 
 #### Counting Records
 
@@ -164,7 +166,7 @@ items = await item_crud.get_multi(
 # Count items added in the last month
 item_count = await item_crud.count(
     db=db,
-    added_at__gte=datetime.datetime.now() - datetime.timedelta(days=30)
+    added_at__gte=datetime.datetime.now() - datetime.timedelta(days=30),
 )
 ```
 
@@ -183,7 +185,7 @@ crud_items = FastCRUD(Item)
 await crud_items.delete(
     db=db, 
     commit=False, 
-    id=1
+    id=1,
 )
 # this will not actually delete until you run a db.commit()
 ```
@@ -203,7 +205,7 @@ item = await crud_items.update(
     db=db,
     object={"price": 9.99},
     price__lt=10
-    return_columns=["price"]
+    return_columns=["price"],
 )
 # this will return the updated price
 ```
@@ -223,7 +225,7 @@ item = await crud_items.update(
     object={"price": 9.99},
     price__lt=10
     schema_to_select=ItemSchema,
-    return_as_model=True
+    return_as_model=True,
 )
 # this will return the updated data in the form of ItemSchema
 ```
@@ -244,13 +246,14 @@ items = await crud_items.get_multi(db=db, limit=None)
 ```
 
 !!! CAUTION
-    Be cautious when returning all the data in your database, and you should almost never allow your API user to do this.
+
+    Be cautious when returning all the data in your database, and you should almost never allow your user API to do this.
 
 ## Using `get_joined` and `get_multi_joined` for multiple models
 
 To facilitate complex data relationships, `get_joined` and `get_multi_joined` can be configured to handle joins with multiple models. This is achieved using the `joins_config` parameter, where you can specify a list of `JoinConfig` instances, each representing a distinct join configuration.
 
-#### Example: Joining User, Tier, and Department Models
+#### Example: Joining `User`, `Tier`, and `Department` Models
 
 Consider a scenario where you want to retrieve users along with their associated tier and department information. Here's how you can achieve this using `get_multi_joined`.
 
@@ -274,23 +277,23 @@ joins_config = [
         join_prefix="dept_",
         schema_to_select=DepartmentSchema,
         join_type="inner",
-    )
+    ),
 ]
 
 users = await user_crud.get_multi_joined(
     db=session,
     schema_to_select=UserSchema,
-    joins_config=joins_config,
     offset=0,
     limit=10,
     sort_columns='username',
-    sort_orders='asc'
+    sort_orders='asc',
+    joins_config=joins_config,
 )
 ```
 
-Then just pass this list to joins_config:
+Then just pass this list to `joins_config`:
 
-```python hl_lines="10" title="Passing to get_multi_joined"
+```python hl_lines="14" title="Passing to get_multi_joined"
 from fastcrud import JoinConfig
 
 joins_config = [
@@ -300,11 +303,11 @@ joins_config = [
 users = await user_crud.get_multi_joined(
     db=session,
     schema_to_select=UserSchema,
-    joins_config=joins_config,
     offset=0,
     limit=10,
     sort_columns='username',
-    sort_orders='asc'
+    sort_orders='asc',
+    joins_config=joins_config,
 )
 ```
 
@@ -319,9 +322,11 @@ In this example, users are joined with the `Tier` and `Department` models. The `
 FastCRUD provides flexibility in handling one-to-one and one-to-many relationships through its `get_joined` and `get_multi_joined` methods, along with the ability to specify how joined data should be structured using both the `relationship_type` (default `one-to-one`) and the `nest_joins` (default `False`) parameters.
 
 #### One-to-One Joins
+
 **One-to-one** relationships can be efficiently managed using either `get_joined` or `get_multi_joined`. The `get_joined` method is typically used when you want to fetch a single record from the database along with its associated record from another table, such as a user and their corresponding profile details. If you're retrieving multiple records, `get_multi_joined` can also be used for one-to-one joins. The parameter that deals with it, `relationship_type`, defaults to `one-on-one`.
 
 #### One-to-Many Joins
+
 For **one-to-many** relationships, where a single record can be associated with multiple records in another table, `get_joined` can be used with `nest_joins` set to `True`. This setup allows the primary record to include a nested list of associated records, making it suitable for scenarios such as retrieving a user and all their blog posts. Alternatively, `get_multi_joined` is also applicable here for fetching multiple primary records, each with their nested lists of related records.
 
 !!! WARNING
@@ -329,10 +334,12 @@ For **one-to-many** relationships, where a single record can be associated with 
     When using `nested_joins=True`, the performance will always be a bit worse than when using `nested_joins=False`. For cases where more performance is necessary, consider using `nested_joins=False` and remodeling your database.
 
 #### One-to-One Relationships
+
 - **`get_joined`**: Fetch a single record and its directly associated record (e.g., a user and their profile).
 - **`get_multi_joined`** (with `nest_joins=False`): Retrieve multiple records, each linked to a single related record from another table (e.g., users and their profiles).
 
 #### One-to-Many Relationships
+
 - **`get_joined`** (with `nest_joins=True`): Retrieve a single record with all its related records nested within it (e.g., a user and all their blog posts).
 - **`get_multi_joined`** (with `nest_joins=True`): Fetch multiple primary records, each with their related records nested (e.g., multiple users and all their blog posts).
 
@@ -342,7 +349,7 @@ For a more detailed explanation, you may check the [joins docs](joins.md#handlin
 
 In complex query scenarios, particularly when you need to join a table to itself or perform multiple joins on the same table for different purposes, aliasing becomes crucial. Aliasing allows you to refer to the same table in different contexts with unique identifiers, avoiding conflicts and ambiguity in your queries.
 
-For both `get_joined` and `get_multi_joined` methods, when you need to join the same model multiple times, you can utilize the `alias` parameter within your `JoinConfig` to differentiate between the joins. This parameter expects an instance of `AliasedClass`, which can be created using the `aliased` function from SQLAlchemy (also in fastcrud for convenience).
+For both `get_joined` and `get_multi_joined` methods, when you need to join the same model multiple times, you can utilize the `alias` parameter within your `JoinConfig` to differentiate between the joins. This parameter expects an instance of `AliasedClass`, which can be created using the `aliased` function from SQLAlchemy (also in FastCRUD for convenience).
 
 #### Example: Joining the Same Model Multiple Times
 
@@ -365,7 +372,7 @@ joins_config = [
         join_prefix="owner_",
         schema_to_select=UserSchema,
         join_type="inner",
-        alias=owner_alias  # Pass the aliased class instance
+        alias=owner_alias,  # Pass the aliased class instance
     ),
     JoinConfig(
         model=UserModel,
@@ -373,8 +380,8 @@ joins_config = [
         join_prefix="assigned_",
         schema_to_select=UserSchema,
         join_type="inner",
-        alias=assigned_user_alias  # Pass the aliased class instance
-    )
+        alias=assigned_user_alias,  # Pass the aliased class instance
+    ),
 ]
 
 # Initialize your FastCRUD instance for TaskModel
@@ -384,15 +391,15 @@ task_crud = FastCRUD(TaskModel)
 tasks = await task_crud.get_multi_joined(
     db=session,
     schema_to_select=TaskSchema,
-    joins_config=joins_config,
     offset=0,
-    limit=10
+    limit=10,
+    joins_config=joins_config,
 )
 ```
 
-Then just pass this joins_config to `get_multi_joined`:
+Then just pass this `joins_config` to `get_multi_joined`:
 
-```python hl_lines="17" title="Passing joins_config to get_multi_joined"
+```python hl_lines="19" title="Passing joins_config to get_multi_joined"
 from fastcrud import FastCRUD, JoinConfig, aliased
 
 ...
@@ -409,9 +416,9 @@ task_crud = FastCRUD(TaskModel)
 tasks = await task_crud.get_multi_joined(
     db=session,
     schema_to_select=TaskSchema,
-    joins_config=joins_config,
     offset=0,
-    limit=10
+    limit=10,
+    joins_config=joins_config,
 )
 ```
 
@@ -441,15 +448,15 @@ joins_config = [
     JoinConfig(
         model=ProjectsParticipantsAssociation,
         join_on=Project.id == ProjectsParticipantsAssociation.project_id,
+        join_prefix="pp_",
         join_type="inner",
-        join_prefix="pp_"
     ),
     JoinConfig(
         model=Participant,
         join_on=ProjectsParticipantsAssociation.participant_id == Participant.id,
+        join_prefix="participant_",
         join_type="inner",
-        join_prefix="participant_"
-    )
+    ),
 ]
 
 crud_project = FastCRUD(Project)
@@ -457,12 +464,11 @@ crud_project = FastCRUD(Project)
 projects_with_participants = await project_crud.get_multi_joined(
     db=db,
     schema_to_select=ProjectSchema,
-    joins_config=joins_config
+    joins_config=joins_config,
 )
 ```
 
 For a more detailed explanation, read [this part of the docs](joins.md#many-to-many-relationships-with-get_multi_joined).
-
 
 ## Enhanced Query Capabilities with Method Chaining
 
@@ -492,12 +498,16 @@ This method constructs a SQL Alchemy `Select` statement, offering optional colum
 #### Usage Example:
 
 ```python
-stmt = await my_model_crud.select(schema_to_select=MySchema, sort_columns='name', name__like='%example%')
+stmt = await my_model_crud.select(
+    schema_to_select=MySchema,
+    sort_columns='name',
+    name__like='%example%',
+)
 stmt = stmt.where(additional_conditions).limit(10)
 results = await db.execute(stmt)
 ```
 
-This example demonstrates selecting a subset of columns, applying a filter, and chaining additional conditions like `where` and `limit`. Note that `select` returns a `Selectable` object, allowing for further modifications before execution.
+This example demonstrates selecting a subset of columns, applying a filter, and chaining additional conditions like `where` and `limit`. Note that `select` returns a `Select` object, allowing for further modifications before execution.
 
 ## Conclusion
 

--- a/docs/advanced/endpoint.md
+++ b/docs/advanced/endpoint.md
@@ -33,8 +33,8 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
 - **Method**: `GET`
 - **Description**: Retrieves multiple items with optional pagination.
 - **Query Parameters**:
-  - `offset` (optional): The offset from where to start fetching items.
-  - `limit` (optional): The maximum number of items to return.
+    - `offset` (optional): The offset from where to start fetching items.
+    - `limit` (optional): The maximum number of items to return.
 - **Example Request**: `GET /yourmodel/get_multi?offset=3&limit=4`.
 - **Example Return**:
 ```javascript
@@ -56,8 +56,8 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
 - **Method**: `GET`
 - **Description**: Retrieves multiple items with pagination.
 - **Query Parameters**:
-  - `page`: The page number, starting from 1.
-  - `itemsPerPage`: The number of items per page.
+    - `page`: The page number, starting from 1.
+    - `itemsPerPage`: The number of items per page.
 - **Example Request**: `GET /yourmodel/get_paginated?page=1&itemsPerPage=3`.
 - **Example Return**:
 ```javascript
@@ -73,17 +73,26 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
   "items_per_page": 3
 }
 ```
+
 !!! WARNING
 
-        _read_paginated endpoint is getting deprecated and mixed into _read_items in the next major release.
-        Please use _read_items with optional page and items_per_pagequery params instead, to achieve pagination as before.
-        Simple _read_items behaviour persists with no breaking changes.
+    `_read_paginated` endpoint is getting deprecated and mixed into `_read_items` in the next major release.
+    Please use `_read_items` with optional `page` and `items_per_page` query params instead, to achieve pagination as before.
+    Simple `_read_items` behaviour persists with no breaking changes.
 
-        Read items paginated:
-        curl -X 'GET'   'http://localhost:8000/users/get_multi?page=2&itemsPerPage=10'   -H 'accept: application/json'
+    Read items paginated:
+    ```sh
+    $ curl -X 'GET' \
+      'http://localhost:8000/users/get_multi?page=2&itemsPerPage=10' \
+      -H 'accept: application/json'
+    ```
 
-        Read items unpaginated:
-        url -X 'GET'   'http://localhost:8000/users/get_multi?offset=0&limit=100'   -H 'accept: application/json'
+    Read items unpaginated:
+    ```sh
+    $ curl -X 'GET' \
+      'http://localhost:8000/users/get_multi?offset=0&limit=100' \
+      -H 'accept: application/json'
+    ```
 
 ### Update
 
@@ -126,12 +135,12 @@ Using `included_methods` you may define exactly the methods you want to be inclu
 my_router = crud_router(
     session=get_session,
     model=MyModel,
-    crud=FastCRUD(MyModel),
     create_schema=CreateMyModel,
     update_schema=UpdateMyModel,
+    crud=FastCRUD(MyModel),
     path="/mymodel",
     tags=["MyModel"],
-    included_methods=["create", "read", "update"]  # Only these methods will be included
+    included_methods=["create", "read", "update"],  # Only these methods will be included
 )
 
 app.include_router(my_router)
@@ -146,12 +155,12 @@ Using `deleted_methods` you define the methods that will not be included.
 my_router = crud_router(
     session=get_session,
     model=MyModel,
-    crud=FastCRUD(MyModel),
     create_schema=CreateMyModel,
     update_schema=UpdateMyModel,
+    crud=FastCRUD(MyModel),
     path="/mymodel",
     tags=["MyModel"],
-    deleted_methods=["update", "delete"]  # All but these methods will be included
+    deleted_methods=["update", "delete"],  # All but these methods will be included
 )
 
 app.include_router(my_router)
@@ -159,7 +168,7 @@ app.include_router(my_router)
 
 !!! WARNING
 
-        If `included_methods` and `deleted_methods` are both provided, a ValueError will be raised.
+    If `included_methods` and `deleted_methods` are both provided, a `ValueError` will be raised.
 
 ## Customizing Endpoint Names
 
@@ -185,7 +194,7 @@ custom_endpoint_names = {
     "update": "modify",
     "delete": "remove",
     "read_multi": "list",
-    "read_paginated": "paginate"
+    "read_paginated": "paginate",
 }
 
 # Setup CRUD router with custom endpoint names
@@ -196,7 +205,7 @@ app.include_router(crud_router(
     update_schema=UpdateYourModelSchema,
     path="/yourmodel",
     tags=["YourModel"],
-    endpoint_names=custom_endpoint_names
+    endpoint_names=custom_endpoint_names,
 ))
 ```
 
@@ -215,7 +224,7 @@ custom_endpoint_names = {
     "delete": "erase",
     "db_delete": "hard_erase",
     "read_multi": "get_all",
-    "read_paginated": "get_page"
+    "read_paginated": "get_page",
 }
 
 # Initialize and use the custom EndpointCreator
@@ -226,7 +235,7 @@ endpoint_creator = EndpointCreator(
     update_schema=UpdateYourModelSchema,
     path="/yourmodel",
     tags=["YourModel"],
-    endpoint_names=custom_endpoint_names
+    endpoint_names=custom_endpoint_names,
 )
 
 endpoint_creator.add_routes_to_router()
@@ -235,19 +244,19 @@ app.include_router(endpoint_creator.router)
 
 !!! TIP
 
-    You only need to pass the names of the endpoints you want to change in the endpoint_names dict.
+    You only need to pass the names of the endpoints you want to change in the `endpoint_names` `dict`.
 
 !!! WARNING
 
-    default_endpoint_names for EndpointCreator are going to be changed to empty strings in the next major release.
-    See:  https://github.com/igorbenav/fastcrud/issues/67
+    `default_endpoint_names` for `EndpointCreator` are going to be changed to empty strings in the next major release.
+    See [this issue](https://github.com/igorbenav/fastcrud/issues/67) for more details.
 
 
-## Extending EndpointCreator
+## Extending `EndpointCreator`
 
 You can create a subclass of `EndpointCreator` and override or add new methods to define custom routes. Here's an example:
 
-### Creating a Custom EndpointCreator
+### Creating a Custom `EndpointCreator`
 
 ```python hl_lines="3 4"
 from fastcrud import EndpointCreator
@@ -339,7 +348,7 @@ class MyCustomEndpointCreator(EndpointCreator):
 
 ### Using the Custom EndpointCreator
 
-```python hl_lines="6 12 18"
+```python hl_lines="6 15 18"
 # Assuming MyCustomEndpointCreator was created
 
 ...
@@ -348,13 +357,13 @@ class MyCustomEndpointCreator(EndpointCreator):
 my_router = crud_router(
     session=get_session,
     model=MyModel,
-    crud=FastCRUD(MyModel),
     create_schema=CreateMyModel,
     update_schema=UpdateMyModel,
-    endpoint_creator=MyCustomEndpointCreator,
+    crud=FastCRUD(MyModel),
     path="/mymodel",
     tags=["MyModel"],
-    included_methods=["create", "read", "update"]  # Including selective methods
+    included_methods=["create", "read", "update"],  # Including selective methods
+    endpoint_creator=MyCustomEndpointCreator,
 )
 
 app.include_router(my_router)
@@ -391,7 +400,7 @@ When initializing `crud_router` or creating a custom `EndpointCreator`, you can 
 
 Here's an example of using `crud_router` with custom soft delete columns:
 
-```python hl_lines="11-14 20"
+```python hl_lines="11-15 23"
 from fastapi import FastAPI
 from fastcrud import FastCRUD, crud_router
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -402,25 +411,26 @@ app = FastAPI()
 # and MyModel is your SQLAlchemy model
 
 # Initialize FastCRUD with custom soft delete columns
-my_model_crud = FastCRUD(MyModel,
-                         is_deleted_column='archived',  # Custom 'is_deleted' column name
-                         deleted_at_column='archived_at'  # Custom 'deleted_at' column name
-                        )
+my_model_crud = FastCRUD(
+    MyModel,
+    is_deleted_column='archived',  # Custom 'is_deleted' column name
+    deleted_at_column='archived_at',  # Custom 'deleted_at' column name
+)
 
 # Setup CRUD router with the FastCRUD instance
 app.include_router(crud_router(
     session=async_session,
     model=MyModel,
-    crud=my_model_crud,
     create_schema=CreateMyModelSchema,
     update_schema=UpdateMyModelSchema,
+    crud=my_model_crud,
     delete_schema=DeleteMyModelSchema,
     path="/mymodel",
-    tags=["MyModel"]
+    tags=["MyModel"],
 ))
 ```
 
-You may also directly pass the names of the columns to crud_router or EndpointCreator:
+You may also directly pass the names of the columns to `crud_router` or `EndpointCreator`:
 
 ```python hl_lines="9 10"
 app.include_router(endpoint_creator(
@@ -432,13 +442,17 @@ app.include_router(endpoint_creator(
     path="/mymodel",
     tags=["MyModel"],
     is_deleted_column='archived',
-    deleted_at_column='archived_at'
+    deleted_at_column='archived_at',
 ))
 ```
 
+This setup ensures that the soft delete functionality within your application utilizes the `archived` and `archived_at` columns for marking records as deleted, rather than the default `is_deleted` and `deleted_at` fields.
+
+By specifying custom column names for soft deletion, you can adapt FastCRUD to fit the design of your database models, providing a flexible solution for handling deleted records in a way that best suits your application's needs.
+
 You can also customize your `updated_at` column:
 
-```python hl_lines="9"
+```python hl_lines="11"
 app.include_router(endpoint_creator(
     session=async_session,
     model=MyModel,
@@ -447,13 +461,11 @@ app.include_router(endpoint_creator(
     delete_schema=DeleteMyModelSchema,
     path="/mymodel",
     tags=["MyModel"],
-    updated_at_column='date_updated'
+    is_deleted_column='archived',
+    deleted_at_column='archived_at',
+    updated_at_column='date_updated',
 ))
 ```
-
-This setup ensures that the soft delete functionality within your application utilizes the `archived` and `archived_at` columns for marking records as deleted, rather than the default `is_deleted` and `deleted_at` fields.
-
-By specifying custom column names for soft deletion, you can adapt FastCRUD to fit the design of your database models, providing a flexible solution for handling deleted records in a way that best suits your application's needs.
 
 ## Using Filters in FastCRUD
 
@@ -469,7 +481,7 @@ from fastcrud import FilterConfig
 # Define filter configuration for a model
 filter_config = FilterConfig(
     tier_id=None,  # Default filter value for tier_id
-    name=None  # Default filter value for name
+    name=None,  # Default filter value for name
 )
 ```
 
@@ -489,9 +501,10 @@ You can apply filters to your endpoints by passing the `filter_config` to the `c
 
 ```python
 from fastcrud import crud_router
-from yourapp.models import YourModel
-from yourapp.schemas import CreateYourModelSchema, UpdateYourModelSchema
-from yourapp.database import async_session
+
+from .database import async_session
+from .yourmodel.model import YourModel
+from .yourmodel.schemas import CreateYourModelSchema, UpdateYourModelSchema
 
 # Apply filters using crud_router
 app.include_router(
@@ -500,10 +513,10 @@ app.include_router(
         model=YourModel,
         create_schema=CreateYourModelSchema,
         update_schema=UpdateYourModelSchema,
-        filter_config=filter_config,  # Apply the filter configuration
         path="/yourmodel",
-        tags=["YourModel"]
-    )
+        tags=["YourModel"],
+        filter_config=filter_config,  # Apply the filter configuration
+    ),
 )
 ```
 
@@ -549,7 +562,6 @@ try:
 except ValueError as e:
     print(e)  # Output: Invalid filter column 'non_existent_column': not found in model
 ```
-
 
 ## Conclusion
 

--- a/docs/advanced/joins.md
+++ b/docs/advanced/joins.md
@@ -1,4 +1,3 @@
-
 # Comprehensive Guide to Joins in FastCRUD
 
 FastCRUD simplifies CRUD operations while offering capabilities for handling complex data relationships. This guide thoroughly explores the use of `JoinConfig` for executing join operations in FastCRUD methods such as `count`, `get_joined`, and `get_multi_joined`, alongside simplified join techniques for straightforward scenarios.
@@ -11,15 +10,14 @@ FastCRUD simplifies CRUD operations while offering capabilities for handling com
 - **`join_on`**: The condition defining how the join connects to other models.
 - **`join_prefix`**: An optional prefix for the joined columns to avoid column name conflicts.
 - **`schema_to_select`**: An optional Pydantic schema for selecting specific columns from the joined model.
-- **`join_type`**: The type of join (e.g., "left", "inner").
+- **`join_type`**: The type of join (e.g., `"left"`, `"inner"`).
 - **`alias`**: An optional SQLAlchemy `AliasedClass` for complex scenarios like self-referential joins or multiple joins on the same model.
 - **`filters`**: An optional dictionary to apply filters directly to the joined model.
-- **`relationship_type`**: Specifies the relationship type, such as `one-to-one` or `one-to-many`. Default is `one-to-one`.
+- **`relationship_type`**: Specifies the relationship type, such as `"one-to-one"` or `"one-to-many"`. Default is `"one-to-one"`.
 
 !!! TIP
 
-    For `many-to-many`, you don't need to pass a `relationship_type`.
-
+    For `"many-to-many"`, you don't need to pass a `relationship_type`.
 
 ## Applying Joins in FastCRUD Methods
 
@@ -39,14 +37,14 @@ task_count = await task_crud.count(
     joins_config=[
         JoinConfig(
             model=User, 
-            join_on=Task.assigned_user_id == User.id
+            join_on=Task.assigned_user_id == User.id,
         ),
         JoinConfig(
             model=Department, 
             join_on=User.department_id == Department.id, 
-            filters={"name": "Engineering"}
-        )
-    ]
+            filters={"name": "Engineering"},
+        ),
+    ],
 )
 ```
 
@@ -58,12 +56,13 @@ These methods are essential for retrieving records from a primary model while in
 
 For simpler join requirements, FastCRUD allows specifying join parameters directly:
 
-- **`model`**: The target model to join.
+- **`join_model`**: The target model to join.
 - **`join_on`**: The join condition.
-- **`join_type`**: Specifies the SQL join type.
 - **`join_prefix`**: Optional prefix for columns from the joined model.
+- **`join_schema_to_select`**: An optional Pydantic schema for selecting specific columns from the joined model.
+- **`join_type`**: Specifies the SQL join type.
 - **`alias`**: An optional SQLAlchemy `AliasedClass` for complex scenarios like self-referential joins or multiple joins on the same model.
-- **`filters`**: Additional filters for the joined model.
+- **`join_filters`**: Additional filters for the joined model.
 
 #### Examples of Simple Joining
 
@@ -73,14 +72,16 @@ tasks_with_users = await task_crud.get_joined(
     db=db,
     join_model=User,
     join_on=Task.user_id == User.id,
-    join_type="left"
+    join_type="left",
 )
 ```
 
 #### Getting Joined Data Nested
 
 Note that by default, `FastCRUD` joins all the data and returns it in a single dictionary.
+
 Let's define two tables:
+
 ```python
 class User(Base):
     __tablename__ = "user"
@@ -102,9 +103,9 @@ user_tier = await user_crud.get_joined(
     db=db,
     join_model=Tier,
     join_on=User.tier_id == Tier.id,
+    join_prefix="tier_",
     join_type="left",
-    join_prefix="tier_",,
-    id=1
+    id=1,
 )
 ```
 
@@ -126,8 +127,8 @@ user_tier = await user_crud.get_joined(
     db=db,
     join_model=Tier,
     join_on=User.tier_id == Tier.id,
-    join_type="left",
     join_prefix="tier_",
+    join_type="left",
     nest_joins=True,
     id=1,
 )
@@ -142,13 +143,14 @@ And you will get:
     "tier": {
         "id": 1,
         "name": "Free",
-    },
+    }
 }
 ```
 
 This works for both `get_joined` and `get_multi_joined`.
 
 !!! WARNING
+
     Note that the final `"_"` in the passed `"tier_"` is stripped.
 
 ### Complex Joins Using `JoinConfig`
@@ -169,32 +171,32 @@ users = await user_crud.get_multi_joined(
         JoinConfig(
             model=Department, 
             join_on=User.department_id == Department.id, 
-            join_prefix="dept_"
+            join_prefix="dept_",
         ),
         JoinConfig(
             model=Role, 
             join_on=User.role_id == Role.id, 
-            join_prefix="role_"
+            join_prefix="role_",
         ),
         JoinConfig(
             model=User, 
             alias=manager_alias, 
             join_on=User.manager_id == manager_alias.id, 
-            join_prefix="manager_"
-        )
-    ]
+            join_prefix="manager_",
+        ),
+    ],
 )
 ```
 
 
 ### Handling One-to-One and One-to-Many Joins in FastCRUD
 
-FastCRUD provides flexibility in handling one-to-one and one-to-many relationships through `get_joined` and `get_multi_joined` methods, along with the ability to specify how joined data should be structured using both the `relationship_type` (default `one-to-one`) and the `nest_joins` (default `False`) parameters.
+FastCRUD provides flexibility in handling one-to-one and one-to-many relationships through `get_joined` and `get_multi_joined` methods, along with the ability to specify how joined data should be structured using both the `relationship_type` (default `"one-to-one"`) and the `nest_joins` (default `False`) parameters.
 
 #### One-to-One Relationships
+
 - **`get_joined`**: Fetch a single record and its directly associated record (e.g., a user and their profile).
 - **`get_multi_joined`** (with `nest_joins=False`): Retrieve multiple records, each linked to a single related record from another table (e.g., users and their profiles).
-
 
 ##### Example
 
@@ -220,9 +222,9 @@ user_tier = await user_crud.get_joined(
     db=db,
     join_model=Tier,
     join_on=User.tier_id == Tier.id,
-    join_type="left",
     join_prefix="tier_",
-    id=1
+    join_type="left",
+    id=1,
 )
 ```
 
@@ -246,10 +248,10 @@ user_tier = await user_crud.get_joined(
     db=db,
     join_model=Tier,
     join_on=User.tier_id == Tier.id,
-    join_type="left",
     join_prefix="tier_",
+    join_type="left",
     nest_joins=True,
-    id=1
+    id=1,
 )
 ```
 
@@ -266,15 +268,14 @@ The result will be:
 }
 ```
 
-
 #### One-to-Many Relationships
+
 - **`get_joined`** (with `nest_joins=True`): Retrieve a single record with all its related records nested within it (e.g., a user and all their blog posts).
 - **`get_multi_joined`** (with `nest_joins=True`): Fetch multiple primary records, each with their related records nested (e.g., multiple users and all their blog posts).
 
 !!! WARNING
 
     When using `nest_joins=True`, the performance will always be a bit worse than when using `nest_joins=False`. For cases where more performance is necessary, consider using `nest_joins=False` and remodeling your database.
-
 
 ##### Example
 
@@ -300,10 +301,10 @@ user_posts = await user_crud.get_joined(
     db=db,
     join_model=Post,
     join_on=User.id == Post.user_id,
-    join_type="left",
     join_prefix="post_",
+    join_type="left",
     nest_joins=True,
-    id=1
+    id=1,
 )
 ```
 
@@ -356,10 +357,12 @@ Our models include `Project`, `Participant`, and an association model `ProjectsP
 
 ```python
 from sqlalchemy import Column, Integer, String, ForeignKey, Table
-from sqlalchemy.orm import relationship
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base, relationship
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    pass
+
 
 class Project(Base):
     __tablename__ = 'projects'
@@ -369,6 +372,7 @@ class Project(Base):
     # Relationship to Participant through the association table
     participants = relationship("Participant", secondary=projects_participants_association)
 
+
 class Participant(Base):
     __tablename__ = 'participants'
     id = Column(Integer, primary_key=True)
@@ -376,6 +380,7 @@ class Participant(Base):
     role = Column(String)
     # Relationship to Project through the association table
     projects = relationship("Project", secondary=projects_participants_association)
+
 
 # Association table for the many-to-many relationship
 class ProjectsParticipantsAssociation(Base):
@@ -399,21 +404,21 @@ joins_config = [
     JoinConfig(
         model=ProjectsParticipantsAssociation,
         join_on=Project.id == ProjectsParticipantsAssociation.project_id,
+        join_prefix="pp_",
         join_type="inner",
-        join_prefix="pp_"
     ),
     JoinConfig(
         model=Participant,
         join_on=ProjectsParticipantsAssociation.participant_id == Participant.id,
+        join_prefix="participant_",
         join_type="inner",
-        join_prefix="participant_"
-    )
+    ),
 ]
 
 # Fetch projects with their participants
 projects_with_participants = await crud_project.get_multi_joined(
     db_session, 
-    joins_config=joins_config
+    joins_config=joins_config,
 )
 
 # Now, `projects_with_participants['data']` will contain projects along with their participant information.
@@ -433,12 +438,14 @@ class Project(Base):
     description = Column(String)
     participants = relationship("Participant", secondary=projects_participants_association)
 
+
 class Participant(Base):
     __tablename__ = 'participants'
     id = Column(Integer, primary key=True)
     name = Column(String)
     role = Column(String)
     projects = relationship("Project", secondary=projects_participants_association)
+
 
 class ProjectsParticipantsAssociation(Base):
     __tablename__ = "projects_participants_association"
@@ -457,20 +464,20 @@ joins_config = [
     JoinConfig(
         model=ProjectsParticipantsAssociation,
         join_on=Project.id == ProjectsParticipantsAssociation.project_id,
+        join_prefix="pp_",
         join_type="inner",
-        join_prefix="pp_"
     ),
     JoinConfig(
         model=Participant,
         join_on=ProjectsParticipantsAssociation.participant_id == Participant.id,
+        join_prefix="participant_",
         join_type="inner",
-        join_prefix="participant_"
     )
 ]
 
 projects_with_participants = await crud_project.get_multi_joined(
     db_session, 
-    joins_config=joins_config
+    joins_config=joins_config,
 )
 ```
 

--- a/docs/advanced/overview.md
+++ b/docs/advanced/overview.md
@@ -5,44 +5,53 @@ The Advanced section of our documentation delves into the sophisticated capabili
 ## Key Topics
 
 ### 1. Advanced Filtering and Searching
+
 Explore how to implement advanced filtering and searching capabilities in your application. This guide covers the use of comparison operators (such as greater than, less than, etc.), pattern matching, and more to perform complex queries.
 
 - [Advanced Filtering Guide](crud.md#advanced-filters)
 
 ### 2. Bulk Operations and Batch Processing
+
 Learn how to efficiently handle bulk operations and batch processing. This section provides insights into performing mass updates, deletes, and inserts, optimizing performance for large datasets.
 
 - [Bulk Operations Guide](crud.md#allow-multiple-updates-and-deletes)
 
 ### 3. Soft Delete Mechanisms and Strategies
+
 Understand the implementation of soft delete mechanisms within our application. This guide covers configuring and using custom columns for soft deletes, restoring deleted records, and filtering queries to exclude soft-deleted entries.
 
 - [Soft Delete Strategies Guide](endpoint.md#custom-soft-delete)
 
 ### 4. Advanced Use of EndpointCreator and crud_router
+
 This topic extends the use of `EndpointCreator` and `crud_router` for advanced endpoint management, including creating custom routes, selective method exposure, and integrating soft delete functionalities.
 
 - [Advanced Endpoint Management Guide](endpoint.md#advanced-use-of-endpointcreator)
 
 ### 5. Using `get_joined` and `get_multi_joined` for multiple models
+
 Explore the use of `get_joined` and `get_multi_joined` functions for complex queries that involve joining multiple models, including self-joins and scenarios requiring multiple joins on the same model.
 
 - [Joining Multiple Models Guide](crud.md#using-get_joined-and-get_multi_joined-for-multiple-models)
 
 ### 6. Method Chaining with `select`
+
 FastCRUD's `select` method introduces method chaining, allowing for the construction of detailed queries with a focus on precision. It simplifies the process of dynamically applying filters, sorting, and conditions, making it easier to manage complex query requirements.
 
 - [Method Chaining Guide](crud.md#enhanced-query-capabilities-with-method-chaining)
 
 ### 7. In depth explanation of Joined methods
+
 Explore different ways of joining models in FastCRUD with examples and tips.
 
 - [Joining Models](joins.md#applying-joins-in-fastcrud-methods)
 
 ### 8. Filters in Automatic Endpoints
+
 Learn how to add query parameters to your `get_multi` and `get_paginated` endpoints.
 
 - [Filters in Endpoints](endpoint.md#defining-filters)
 
 ## Prerequisites
+
 Advanced usage assumes a solid understanding of the basic features and functionalities of our application. Knowledge of FastAPI, SQLAlchemy, and Pydantic is highly recommended to fully grasp the concepts discussed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,13 +103,12 @@ And it's all done, just go to `/docs` and the crud endpoints are created.
 
 ## Requirements
 
-<p>Before installing FastCRUD, ensure you have the following prerequisites:</p>
-<ul>
-  <li><b>Python:</b> Version 3.9 or newer.</li>
-  <li><b>FastAPI:</b> FastCRUD is built to work with FastAPI, so having FastAPI in your project is essential.</li>
-  <li><b>SQLAlchemy or SQLModel:</b> FastCRUD uses SQLAlchemy 2.0 for database operations, so you need SQLAlchemy 2.0 or newer or SQLModel 0.14 or newer.</li>
-  <li><b>Pydantic V2 or SQLModel:</b> FastCRUD leverages Pydantic models for data validation and serialization, so you need Pydantic 2.0 or newer or SQLModel 0.14 or newer.</li>
-</ul>
+Before installing FastCRUD, ensure you have the following prerequisites:
+
+* **Python:** Version 3.9 or newer.
+* **FastAPI:** FastCRUD is built to work with FastAPI, so having FastAPI in your project is essential.
+* **SQLAlchemy or SQLModel:** FastCRUD uses SQLAlchemy 2.0 for database operations, so you need SQLAlchemy 2.0 or newer or SQLModel 0.14 or newer.
+* **Pydantic V2 or SQLModel:** FastCRUD leverages Pydantic models for data validation and serialization, so you need Pydantic 2.0 or newer or SQLModel 0.14 or newer.
 
 ## Installing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,7 +134,7 @@ FastCRUD offers two primary ways to use its functionalities:
 
 Below are examples demonstrating both approaches:
 
-### Using crud_router for Automatic Endpoint Creation
+### Using `crud_router` for Automatic Endpoint Creation
 
 Here's a quick example to get you started:
 

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,18 +1,19 @@
 ## Requirements
-<p>Before installing FastCRUD, ensure you have the following prerequisites:</p>
-<ul>
-  <li><b>Python:</b> Version 3.9 or newer.</li>
-  <li><b>FastAPI:</b> FastCRUD is built to work with FastAPI, so having FastAPI in your project is essential.</li>
-  <li><b>SQLAlchemy or SQLModel:</b> FastCRUD uses SQLAlchemy 2.0 for database operations, so you need SQLAlchemy 2.0 or newer or SQLModel 0.14 or newer.</li>
-  <li><b>Pydantic V2 or SQLModel:</b> FastCRUD leverages Pydantic models for data validation and serialization, so you need Pydantic 2.0 or newer or SQLModel 0.14 or newer.</li>
-</ul>
+
+Before installing FastCRUD, ensure you have the following prerequisites:
+
+* **Python:** Version 3.9 or newer.
+* **FastAPI:** FastCRUD is built to work with FastAPI, so having FastAPI in your project is essential.
+* **SQLAlchemy or SQLModel:** FastCRUD uses SQLAlchemy 2.0 for database operations, so you need SQLAlchemy 2.0 or newer or SQLModel 0.14 or newer.
+* **Pydantic V2 or SQLModel:** FastCRUD leverages Pydantic models for data validation and serialization, so you need Pydantic 2.0 or newer or SQLModel 0.14 or newer.
 
 ## Installing
 
- To install, just run:
- ```sh
- pip install fastcrud
- ```
+To install, just run:
+
+```sh
+pip install fastcrud
+```
 
 Or, if using poetry:
 

--- a/docs/usage/crud.md
+++ b/docs/usage/crud.md
@@ -20,7 +20,7 @@ Define your SQLAlchemy models and Pydantic schemas for data representation.
 
 ### Step 2: Initialize FastCRUD
 
-Create a FastCRUD instance for your model to handle CRUD operations.
+Create a `FastCRUD` instance for your model to handle CRUD operations.
 
 ```python
 from fastcrud import FastCRUD
@@ -52,12 +52,12 @@ FastCRUD offers a comprehensive suite of methods for CRUD operations, each desig
 create(
     db: AsyncSession,
     object: CreateSchemaType,
-    commit: bool = True
+    commit: bool = True,
 ) -> ModelType
 ```
 
 **Purpose**: To create a new record in the database.  
-**Usage Example**: Creates an item with name 'New Item'.
+**Usage Example**: Creates an item with name `"New Item"`.
 
 ```python
 new_item = await item_crud.create(db, ItemCreateSchema(name="New Item"))
@@ -77,12 +77,12 @@ get(
     schema_to_select: Optional[type[BaseModel]] = None,
     return_as_model: bool = False,
     one_or_none: bool = False,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> Optional[Union[dict, BaseModel]]
 ```
 
 **Purpose**: To fetch a single record based on filters, with an option to select specific columns using a Pydantic schema.  
-**Usage Example**: Fetches the item with item_id as its id.
+**Usage Example**: Fetches the item with `item_id` as its `id`.
 
 ```python
 item = await item_crud.get(db, id=item_id)
@@ -93,12 +93,12 @@ item = await item_crud.get(db, id=item_id)
 ```python
 exists(
     db: AsyncSession,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> bool
 ```
 
 **Purpose**: To check if a record exists based on provided filters.  
-**Usage Example**: Checks whether an item with name 'Existing Item' exists.
+**Usage Example**: Checks whether an item with name `"Existing Item"` exists.
 
 ```python
 exists = await item_crud.exists(db, name="Existing Item")
@@ -110,12 +110,12 @@ exists = await item_crud.exists(db, name="Existing Item")
 count(
     db: AsyncSession,
     joins_config: Optional[list[JoinConfig]] = None,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> int
 ```
 
 **Purpose**: To count the number of records matching provided filters.  
-**Usage Example**: Counts the number of items with the 'Books' category.
+**Usage Example**: Counts the number of items with the `"Books"` category.
 
 ```python
 count = await item_crud.count(db, category="Books")
@@ -133,7 +133,7 @@ get_multi(
     sort_orders: Optional[Union[str, list[str]]] = None,
     return_as_model: bool = False,
     return_total_count: bool = True,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> dict[str, Any]
 ```
 
@@ -152,12 +152,16 @@ update(
     object: Union[UpdateSchemaType, dict[str, Any]], 
     allow_multiple: bool = False,
     commit: bool = True,
-    **kwargs: Any
-) -> None
+    return_columns: Optional[list[str]] = None,
+    schema_to_select: Optional[type[BaseModel]] = None,
+    return_as_model: bool = False,
+    one_or_none: bool = False,
+    **kwargs: Any,
+) -> Optional[Union[dict, BaseModel]]
 ```
 
 **Purpose**: To update an existing record in the database.  
-**Usage Example**: Updates the description of the item with item_id as its id.
+**Usage Example**: Updates the description of the item with `item_id` as its `id`.
 
 ```python
 await item_crud.update(db, ItemUpdateSchema(description="Updated"), id=item_id)
@@ -171,12 +175,12 @@ delete(
     db_row: Optional[Row] = None, 
     allow_multiple: bool = False,
     commit: bool = True,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> None
 ```
 
 **Purpose**: To delete a record from the database, with support for soft delete.  
-**Usage Example**: Deletes the item with item_id as its id, performs a soft delete if the model has the 'is_deleted' column.
+**Usage Example**: Deletes the item with `item_id` as its `id`, performs a soft delete if the model has the `is_deleted` column.
 
 ```python
 await item_crud.delete(db, id=item_id)
@@ -189,12 +193,12 @@ db_delete(
     db: AsyncSession, 
     allow_multiple: bool = False,
     commit: bool = True,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> None
 ```
 
 **Purpose**: To hard delete a record from the database.  
-**Usage Example**: Hard deletes the item with item_id as its id.
+**Usage Example**: Hard deletes the item with `item_id` as its `id`.
 
 ```python
 await item_crud.db_delete(db, id=item_id)
@@ -218,15 +222,21 @@ get_multi(
     sort_orders: Optional[Union[str, list[str]]] = None,
     return_as_model: bool = False,
     return_total_count: bool = True,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> dict[str, Any]
 ```
 
 **Purpose**: To fetch multiple records based on specified filters, with options for sorting and pagination.  
-**Usage Example**: Gets the first 10 items sorted by 'name' in ascending order.
+**Usage Example**: Gets the first 10 items sorted by `name` in ascending order.
 
 ```python
-items = await item_crud.get_multi(db, offset=0, limit=10, sort_columns=['name'], sort_orders=['asc'])
+items = await item_crud.get_multi(
+    db,
+    offset=0,
+    limit=10,
+    sort_columns=['name'],
+    sort_orders=['asc'],
+)
 ```
 
 ### 2. Get Joined
@@ -234,12 +244,13 @@ items = await item_crud.get_multi(db, offset=0, limit=10, sort_columns=['name'],
 ```python
 get_joined(
     db: AsyncSession,
-    join_model: Optional[ModelType] = None,
-    join_prefix: Optional[str] = None,
-    join_on: Optional[Union[Join, BinaryExpression]] = None,
     schema_to_select: Optional[type[BaseModel]] = None,
+    join_model: Optional[ModelType] = None,
+    join_on: Optional[Union[Join, BinaryExpression]] = None,
+    join_prefix: Optional[str] = None,
     join_schema_to_select: Optional[type[BaseModel]] = None,
     join_type: str = "left",
+    alias: Optional[AliasedClass] = None,
     join_filters: Optional[dict] = None,
     joins_config: Optional[list[JoinConfig]] = None,
     nest_joins: bool = False,
@@ -248,8 +259,8 @@ get_joined(
 ) -> Optional[dict[str, Any]]
 ```
 
-**Purpose**: To fetch a single record with one or multiple joins on other models.
-**Usage Example**: Fetches order details for a specific order by joining with the Customer table, selecting specific columns as defined in OrderSchema and CustomerSchema.
+**Purpose**: To fetch a single record with one or multiple joins on other models.  
+**Usage Example**: Fetches order details for a specific order by joining with the `Customer` table, selecting specific columns as defined in `OrderSchema` and `CustomerSchema`.
 
 ```python
 order_details = await order_crud.get_joined(
@@ -257,7 +268,7 @@ order_details = await order_crud.get_joined(
     join_model=Customer,
     schema_to_select=OrderSchema,
     join_schema_to_select=CustomerSchema,
-    id=order_id
+    id=order_id,
 )
 ```
 
@@ -266,13 +277,13 @@ order_details = await order_crud.get_joined(
 ```python
 get_multi_joined(
     db: AsyncSession,
-    join_model: Optional[type[ModelType]] = None,
-    join_prefix: Optional[str] = None,
-    join_on: Optional[Any] = None,
     schema_to_select: Optional[type[BaseModel]] = None,
+    join_model: Optional[type[ModelType]] = None,
+    join_on: Optional[Any] = None,
+    join_prefix: Optional[str] = None,
     join_schema_to_select: Optional[type[BaseModel]] = None,
     join_type: str = "left",
-    alias: Optional[str] = None,
+    alias: Optional[AliasedClass[Any]] = None,
     join_filters: Optional[dict] = None,
     nest_joins: bool = False,
     offset: int = 0,
@@ -288,16 +299,16 @@ get_multi_joined(
 ```
 
 **Purpose**: Similar to `get_joined`, but for fetching multiple records.  
-**Usage Example**: Retrieves a paginated list of orders (up to 5), joined with the Customer table, using specified schemas for selective column retrieval from both tables.
+**Usage Example**: Retrieves a paginated list of orders (up to 5), joined with the `Customer` table, using specified schemas for selective column retrieval from both tables.
 
 ```python
 orders = await order_crud.get_multi_joined(
     db,
+    schema_to_select=OrderSchema,
     join_model=Customer,
+    join_schema_to_select=CustomerSchema,
     offset=0,
     limit=5,
-    schema_to_select=OrderSchema,
-    join_schema_to_select=CustomerSchema
 )
 ```
 
@@ -311,7 +322,7 @@ get_multi_by_cursor(
     schema_to_select: Optional[type[BaseModel]] = None,
     sort_column: str = "id",
     sort_order: str = "asc",
-    **kwargs: Any
+    **kwargs: Any,
 ) -> dict[str, Any]
 ```
 
@@ -324,7 +335,7 @@ paginated_items = await item_crud.get_multi_by_cursor(
     cursor=last_cursor,
     limit=10,
     sort_column='created_at',
-    sort_order='desc'
+    sort_order='desc',
 )
 ```
 
@@ -336,16 +347,20 @@ async def select(
     schema_to_select: Optional[type[BaseModel]] = None,
     sort_columns: Optional[Union[str, list[str]]] = None,
     sort_orders: Optional[Union[str, list[str]]] = None,
-    **kwargs: Any
-) -> Selectable
+    **kwargs: Any,
+) -> Select
 ```
 
-**Purpose**: Constructs a SQL Alchemy Select statement with optional column selection, filtering, and sorting.
-**Usage Example**: Selects all items, filtering by 'name' and sorting by 'id'. Returns the `select` statement.
+**Purpose**: Constructs a SQL Alchemy `Select` statement with optional column selection, filtering, and sorting.
+**Usage Example**: Selects all items, filtering by `name` and sorting by `id`. Returns the `Select` statement.
 
 ```python
-stmt = await item_crud.select(schema_to_select=ItemSchema, sort_columns='id', name='John')
-# Note: This method returns a SQL Alchemy Selectable object, not the actual query result.
+stmt = await item_crud.select(
+    schema_to_select=ItemSchema,
+    sort_columns='id',
+    name='John',
+)
+# Note: This method returns a SQL Alchemy Select object, not the actual query result.
 ```
 
 ### 6. Count for Joined Models
@@ -354,12 +369,12 @@ stmt = await item_crud.select(schema_to_select=ItemSchema, sort_columns='id', na
 count(
     db: AsyncSession,
     joins_config: Optional[list[JoinConfig]] = None,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> int
 ```
 
-**Purpose**: To count records that match specified filters, especially useful in scenarios involving joins between models. This method supports counting unique entities across relationships, a common requirement in many-to-many or complex relationships.
-**Usage Example**: Count the number of unique projects a participant is involved in, considering a many-to-many relationship between Project and Participant models.
+**Purpose**: To count records that match specified filters, especially useful in scenarios involving joins between models. This method supports counting unique entities across relationships, a common requirement in many-to-many or complex relationships.  
+**Usage Example**: Count the number of unique projects a participant is involved in, considering a many-to-many relationship between `Project` and `Participant` models.
 
 ```python
 # Assuming a Project model related to a Participant model through a many-to-many relationship
@@ -369,10 +384,10 @@ projects_count = await project_crud.count(
         JoinConfig(
             model=Participant,
             join_on=ProjectsParticipantsAssociation.project_id == Project.id,
-            join_type="inner"
-        )
+            join_type="inner",
+        ),
     ],
-    participant_id=specific_participant_id
+    participant_id=specific_participant_id,
 )
 ```
 

--- a/docs/usage/endpoint.md
+++ b/docs/usage/endpoint.md
@@ -1,4 +1,4 @@
-# Automatic Endpoint Creation with crud_router
+# Automatic Endpoint Creation with `crud_router`
 
 This section of the documentation explains how to use the `crud_router` utility function from the FastCRUD package for automatic endpoint creation in a FastAPI application. The `crud_router` simplifies the process of creating standard CRUD (Create, Read, Update, Delete) endpoints for your models.
 
@@ -8,7 +8,7 @@ Before proceeding, ensure you have FastAPI and FastCRUD installed in your enviro
 
 !!! WARNING
 
-        For now, your primary column in the database model must be named `id`.
+    For now, your primary column in the database model must be named `id`.
 
 ---
 
@@ -83,7 +83,7 @@ item_router = crud_router(
     create_schema=ItemCreateSchema,
     update_schema=ItemUpdateSchema,
     path="/items",
-    tags=["Items"]
+    tags=["Items"],
 )
 
 app.include_router(item_router)
@@ -95,7 +95,7 @@ For a comprehensive list of all available endpoints, read the [advanced section]
 
 ## Usage and Testing
 
-Once the application is running, you can test the automatically created endpoints using tools like Swagger UI, which FastAPI provides by default. The endpoints for creating, reading, updating, and deleting Item instances are now accessible at /items.
+Once the application is running, you can test the automatically created endpoints using tools like Swagger UI, which FastAPI provides by default. The endpoints for creating, reading, updating, and deleting Item instances are now accessible at `/items`.
 
 ---
 
@@ -167,7 +167,7 @@ crud = FastCRUD(Item)
 
 ### Step 3: Initialize `EndpointCreator`
 
-Create an instance of EndpointCreator by passing the necessary parameters, including your model, session, CRUD instance, and schemas.
+Create an instance of `EndpointCreator` by passing the necessary parameters, including your model, session, CRUD instance, and schemas.
 
 ```python
 from fastcrud import EndpointCreator
@@ -178,28 +178,29 @@ endpoint_creator = EndpointCreator(
     model=YourModel,
     create_schema=YourCreateSchema,
     update_schema=YourUpdateSchema,
+    crud=crud,
     delete_schema=YourDeleteSchema,
     path="/yourmodelpath",
-    tags=["YourModelTag"]
+    tags=["YourModelTag"],
 )
 ```
 
 ### Step 4: Add Custom Endpoints
 
-Add custom endpoints using EndpointCreator. You can inject dependencies as needed.
+Add custom endpoints using `EndpointCreator`. You can inject dependencies as needed.
 
 ```python
 # Example of adding custom dependencies
 endpoint_creator.add_routes_to_router(
     read_deps=[custom_dependency],
-    update_deps=[another_custom_dependency]
+    update_deps=[another_custom_dependency],
 )
 
 ```
 
 ### Step 5: Include the Router in Your Application
 
-Finally, include the router from the EndpointCreator in your FastAPI application.
+Finally, include the router from the `EndpointCreator` in your FastAPI application.
 
 ```python
 app.include_router(endpoint_creator.router)
@@ -208,8 +209,8 @@ app.include_router(endpoint_creator.router)
 
 ## Advanced Customization
 
-You can override the default methods in EndpointCreator for more control over the CRUD operations. You can also specify the operations you want to include. Read more in the [advanced section](../advanced/endpoint.md).
+You can override the default methods in `EndpointCreator` for more control over the CRUD operations. You can also specify the operations you want to include. Read more in the [advanced section](../advanced/endpoint.md).
 
 ## Conclusion
 
-By following these steps, you can quickly set up CRUD endpoints for your models in a FastAPI application using crud_router or EndpointCreator. This utility function reduces boilerplate code and increases development efficiency by automating the creation of standard API endpoints.
+By following these steps, you can quickly set up CRUD endpoints for your models in a FastAPI application using `crud_router` or `EndpointCreator`. This utility function reduces boilerplate code and increases development efficiency by automating the creation of standard API endpoints.

--- a/docs/usage/overview.md
+++ b/docs/usage/overview.md
@@ -1,22 +1,25 @@
-
 # Usage Overview
 
 The Usage section of our documentation provides comprehensive guides on how to effectively use key features of our application. This section is divided into various topics, each focusing on a specific aspect of usage, ensuring that you have all the information you need to leverage the full potential of our tools and functionalities.
 
 ## Key Topics
 
-### 1. Automatic Endpoint Creation with crud_router
+### 1. Automatic Endpoint Creation with `crud_router`
+
 This guide covers the use of `crud_router` for automatic endpoint creation in FastAPI applications. It provides a step-by-step approach to streamline the creation of standard CRUD endpoints.
 
 - [Automatic Endpoint Creation Guide](endpoint.md)
 
 ### 2. Enhanced CRUD Operations with FastCRUD
+
 Learn how to use the `FastCRUD` class for enhanced CRUD operations. This guide delves into the functionalities offered by `FastCRUD`, including advanced query capabilities, pagination, and error handling.
 
 - [FastCRUD Usage Guide](crud.md)
 
 ## Getting Started
+
 To make the most out of these guides, we recommend familiarizing yourself with FastAPI and SQLAlchemy basics, as our application leverages these frameworks extensively.
 
 ## Contribution
+
 If you have suggestions or contributions to these guides, please refer to our [Contributing Guidelines](../community/CONTRIBUTING.md). We appreciate your input in improving our documentation.

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -2,7 +2,18 @@ from typing import Any, Dict, Generic, Union, Optional, Callable
 from datetime import datetime, timezone
 
 from pydantic import BaseModel, ValidationError
-from sqlalchemy import Result, select, update, delete, func, inspect, asc, desc, or_, column
+from sqlalchemy import (
+    Result,
+    select,
+    update,
+    delete,
+    func,
+    inspect,
+    asc,
+    desc,
+    or_,
+    column,
+)
 from sqlalchemy.exc import ArgumentError, MultipleResultsFound, NoResultFound
 from sqlalchemy.sql import Join
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -48,9 +48,9 @@ class FastCRUD(
 
     Args:
         model: The SQLAlchemy model type.
-        is_deleted_column: Optional column name to use for indicating a soft delete. Defaults to "is_deleted".
-        deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to "deleted_at".
-        updated_at_column: Optional column name to use for storing the timestamp of an update. Defaults to "updated_at".
+        is_deleted_column: Optional column name to use for indicating a soft delete. Defaults to `"is_deleted"`.
+        deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to `"deleted_at"`.
+        updated_at_column: Optional column name to use for storing the timestamp of an update. Defaults to `"updated_at"`.
 
     Methods:
         create:
@@ -60,7 +60,7 @@ class FastCRUD(
             Generates a SQL Alchemy `Select` statement with optional filtering and sorting.
 
         get:
-            Retrieves a single record based on filters. Supports advanced filtering through comparison operators like '__gt', '__lt', etc.
+            Retrieves a single record based on filters. Supports advanced filtering through comparison operators like `__gt`, `__lt`, etc.
 
         exists:
             Checks if a record exists based on the provided filters.
@@ -87,12 +87,12 @@ class FastCRUD(
             Hard deletes a record or multiple records from the database based on provided filters.
 
         delete:
-            Soft deletes a record if it has an "is_deleted" attribute; otherwise, performs a hard delete.
+            Soft deletes a record if it has an `"is_deleted"` attribute (or other attribute as defined by `is_deleted_column`); otherwise, performs a hard delete.
 
     Examples:
         Example 1: Basic Usage
         ----------------------
-        Create a FastCRUD instance for a User model and perform basic CRUD operations.
+        Create a FastCRUD instance for a `User` model and perform basic CRUD operations.
         ```python
         # Assuming you have a User model (either SQLAlchemy or SQLModel)
         # pydantic schemas for creation, update and deletion and an async session `db`
@@ -134,12 +134,12 @@ class FastCRUD(
         order_crud = FastCRUD(Order)
         orders = await order_crud.get_multi_joined(
             db,
-            offset=0,
-            limit=5,
+            schema_to_select=OrderReadSchema,
             join_model=Product,
             join_prefix="product_",
-            schema_to_select=OrderReadSchema,
             join_schema_to_select=ProductReadSchema,
+            offset=0,
+            limit=5,
         )
         ```
 
@@ -161,22 +161,22 @@ class FastCRUD(
         task_crud = FastCRUD(Task)
         completed_tasks = await task_crud.get_multi(
             db,
-            status='completed'
+            status='completed',
         )
         high_priority_task_count = await task_crud.count(
             db,
-            priority='high'
+            priority='high',
         )
         ```
 
         Example 6: Using Custom Column Names for Soft Delete
         ----------------------------------------------------
-        If your model uses different column names for indicating a soft delete and its timestamp, you can specify these when creating the FastCRUD instance.
+        If your model uses different column names for indicating a soft delete and its timestamp, you can specify these when creating the `FastCRUD` instance.
         ```python
         custom_user_crud = FastCRUD(
             User,
             is_deleted_column="archived",
-            deleted_at_column="archived_at"
+            deleted_at_column="archived_at",
         )
         # Now 'archived' and 'archived_at' will be used for soft delete operations.
         ```
@@ -272,18 +272,18 @@ class FastCRUD(
         Apply sorting to a SQLAlchemy query based on specified column names and sort orders.
 
         Args:
-            stmt: The SQLAlchemy Select statement to which sorting will be applied.
+            stmt: The SQLAlchemy `Select` statement to which sorting will be applied.
             sort_columns: A single column name or a list of column names on which to apply sorting.
-            sort_orders: A single sort order ('asc' or 'desc') or a list of sort orders corresponding
-                to the columns in sort_columns. If not provided, defaults to 'asc' for each column.
+            sort_orders: A single sort order (`"asc"` or `"desc"`) or a list of sort orders corresponding
+                to the columns in `sort_columns`. If not provided, defaults to `"asc"` for each column.
 
         Raises:
             ValueError: Raised if sort orders are provided without corresponding sort columns,
-                or if an invalid sort order is provided (not 'asc' or 'desc').
+                or if an invalid sort order is provided (not `"asc"` or `"desc"`).
             ArgumentError: Raised if an invalid column name is provided that does not exist in the model.
 
         Returns:
-            The modified Select statement with sorting applied.
+            The modified `Select` statement with sorting applied.
 
         Examples:
             Applying ascending sort on a single column:
@@ -299,7 +299,7 @@ class FastCRUD(
             >>> stmt = _apply_sorting(stmt, ['name', 'age'])
 
         Note:
-            This method modifies the passed Select statement in-place by applying the order_by clause
+            This method modifies the passed `Select` statement in-place by applying the `order_by` clause
             based on the provided column names and sort orders.
         """
         if sort_orders and not sort_columns:
@@ -344,15 +344,15 @@ class FastCRUD(
         use_temporary_prefix: bool = False,
     ):
         """
-        Applies joins to the given SQL statement based on a list of JoinConfig objects.
+        Applies joins to the given SQL statement based on a list of `JoinConfig` objects.
 
         Args:
             stmt: The initial SQL statement.
             joins_config: Configurations for all joins.
-            use_temporary_prefix: Whether to use or not an aditional prefix for joins. Default False.
+            use_temporary_prefix: Whether to use or not an additional prefix for joins. Default `False`.
 
         Returns:
-            Select: The modified SQL statement with joins applied.
+            The modified SQL statement with joins applied.
         """
         for join in joins_config:
             model = join.alias or join.model
@@ -387,7 +387,7 @@ class FastCRUD(
         Args:
             db: The SQLAlchemy async session.
             object: The Pydantic schema containing the data to be saved.
-            commit: If True, commits the transaction immediately. Default is True.
+            commit: If `True`, commits the transaction immediately. Default is `True`.
 
         Returns:
             The created database object.
@@ -408,17 +408,19 @@ class FastCRUD(
     ) -> Select:
         """
         Constructs a SQL Alchemy `Select` statement with optional column selection, filtering, and sorting.
+
         This method allows for advanced filtering through comparison operators, enabling queries to be refined beyond simple equality checks.
-        For filtering details see:
-        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+
+        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
 
         Args:
             schema_to_select: Pydantic schema to determine which columns to include in the selection. If not provided, selects all columns of the model.
-            sort_columns: A single column name or list of column names to sort the query results by. Must be used in conjunction with sort_orders.
-            sort_orders: A single sort order ('asc' or 'desc') or a list of sort orders, corresponding to each column in sort_columns. If not specified, defaults to ascending order for all sort_columns.
+            sort_columns: A single column name or list of column names to sort the query results by. Must be used in conjunction with `sort_orders`.
+            sort_orders: A single sort order (`"asc"` or `"desc"`) or a list of sort orders, corresponding to each column in `sort_columns`. If not specified, defaults to ascending order for all `sort_columns`.
+            **kwargs: Filters to apply to the query, including advanced comparison operators for more detailed querying.
 
         Returns:
-            Selectable: An SQL Alchemy `Select` statement object that can be executed or further modified.
+            An SQL Alchemy `Select` statement object that can be executed or further modified.
 
         Examples:
             Selecting specific columns with filtering and sorting:
@@ -427,7 +429,7 @@ class FastCRUD(
                 schema_to_select=UserReadSchema,
                 sort_columns=['age', 'name'],
                 sort_orders=['asc', 'desc'],
-                age__gt=18
+                age__gt=18,
             )
             ```
 
@@ -436,12 +438,12 @@ class FastCRUD(
             stmt = await crud.select()
             ```
 
-            Selecting users with a specific role, ordered by name:
+            Selecting users with a specific `role`, ordered by `name`:
             ```python
             stmt = await crud.select(
                 schema_to_select=UserReadSchema,
                 sort_columns='name',
-                role='admin'
+                role='admin',
             )
             ```
         Note:
@@ -468,22 +470,23 @@ class FastCRUD(
     ) -> Optional[Union[dict, BaseModel]]:
         """
         Fetches a single record based on specified filters.
+
         This method allows for advanced filtering through comparison operators, enabling queries to be refined beyond simple equality checks.
-        For filtering details see:
-        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+
+        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.
             schema_to_select: Optional Pydantic schema for selecting specific columns.
-            return_as_model: If True, converts the fetched data to Pydantic models based on schema_to_select. Defaults to False.
+            return_as_model: If `True`, converts the fetched data to Pydantic models based on `schema_to_select`. Defaults to `False`.
             one_or_none: Flag to get strictly one or no result. Multiple results are not allowed.
             **kwargs: Filters to apply to the query, using field names for direct matches or appending comparison operators for advanced queries.
 
         Raises:
-            ValueError: If return_as_model is True but schema_to_select is not provided.
+            ValueError: If `return_as_model` is `True` but `schema_to_select` is not provided.
 
         Returns:
-            A dictionary or a Pydantic model instance of the fetched database row, or None if no match is found.
+            A dictionary or a Pydantic model instance of the fetched database row, or `None` if no match is found.
 
         Examples:
             Fetch a user by ID:
@@ -532,16 +535,17 @@ class FastCRUD(
         return_as_model: bool = False,
     ) -> Union[BaseModel, Dict[str, Any], None]:
         """Update the instance or create it if it doesn't exists.
+
         Note: This method will perform two transactions to the database (get and create or update).
 
         Args:
-            db (AsyncSession): The database session to use for the operation.
-            instance (Union[UpdateSchemaType, type[BaseModel]]): A Pydantic schema representing the instance.
-            schema_to_select (Optional[type[BaseModel]], optional): Optional Pydantic schema for selecting specific columns. Defaults to None.
-            return_as_model (bool, optional): If True, converts the fetched data to Pydantic models based on schema_to_select. Defaults to False.
+            db: The database session to use for the operation.
+            instance: A Pydantic schema representing the instance.
+            schema_to_select: Optional Pydantic schema for selecting specific columns. Defaults to `None`.
+            return_as_model: If `True`, converts the fetched data to Pydantic models based on `schema_to_select`. Defaults to `False`.
 
         Returns:
-            BaseModel: the created or updated instance
+            The created or updated instance
         """
         _pks = self._get_pk_dict(instance)
         schema_to_select = schema_to_select or type(instance)
@@ -570,18 +574,18 @@ class FastCRUD(
     async def exists(self, db: AsyncSession, **kwargs: Any) -> bool:
         """
         Checks if any records exist that match the given filter conditions.
-        For filtering details see:
-        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+
+        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.
             **kwargs: Filters to apply to the query, supporting both direct matches and advanced comparison operators for refined search criteria.
 
         Returns:
-            True if at least one record matches the filter conditions, False otherwise.
+            `True` if at least one record matches the filter conditions, `False` otherwise.
 
         Examples:
-            Fetch a user by ID exists:
+            Check if a user with a specific ID exists:
             ```python
             exists = await crud.exists(db, id=1)
             ```
@@ -591,12 +595,12 @@ class FastCRUD(
             exists = await crud.exists(db, age__gt=30)
             ```
 
-            Check if any user registered before Jan 1, 2020:
+            Check if any user was registered before Jan 1, 2020:
             ```python
             exists = await crud.exists(db, registration_date__lt=datetime(2020, 1, 1))
             ```
 
-            Check if a username other than 'admin' exists:
+            Check if a username other than `admin` exists:
             ```python
             exists = await crud.exists(db, username__ne='admin')
             ```
@@ -614,8 +618,9 @@ class FastCRUD(
         **kwargs: Any,
     ) -> int:
         """
-        Counts records that match specified filters. For filtering details see:
-        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+        Counts records that match specified filters.
+
+        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
 
         Can also count records based on a configuration of joins, useful for complex queries involving relationships.
 
@@ -638,7 +643,7 @@ class FastCRUD(
             count = await crud.count(db, age__gt=30)
             ```
 
-            Count users with a username other than 'admin':
+            Count users with a username other than `admin`:
             ```python
             count = await crud.count(db, username__ne='admin')
             ```
@@ -649,13 +654,13 @@ class FastCRUD(
                 JoinConfig(
                     model=ProjectsParticipantsAssociation,
                     join_on=Project.id == ProjectsParticipantsAssociation.project_id,
-                    join_type="inner"
+                    join_type="inner",
                 ),
                 JoinConfig(
                     model=Participant,
                     join_on=ProjectsParticipantsAssociation.participant_id == Participant.id,
-                    join_type="inner"
-                )
+                    join_type="inner",
+                ),
             ]
             count = await crud.count(db, joins_config=joins_config)
             ```
@@ -666,14 +671,14 @@ class FastCRUD(
                 JoinConfig(
                     model=ProjectsParticipantsAssociation,
                     join_on=Project.id == ProjectsParticipantsAssociation.project_id,
-                    join_type="inner"
+                    join_type="inner",
                 ),
                 JoinConfig(
                     model=Participant,
                     join_on=ProjectsParticipantsAssociation.participant_id == Participant.id,
                     join_type="inner",
-                    filters={'name': 'Jane Doe'}
-                )
+                    filters={'name': 'Jane Doe'},
+                ),
             ]
             count = await crud.count(db, joins_config=joins_config)
             ```
@@ -737,8 +742,8 @@ class FastCRUD(
     ) -> dict[str, Any]:
         """
         Fetches multiple records based on filters, supporting sorting, pagination.
-        For filtering details see:
-        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+
+        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.
@@ -746,46 +751,82 @@ class FastCRUD(
             limit: Maximum number of records to fetch in one call. Use `None` for "no limit", fetching all matching rows. Note that in order to use `limit=None`, you'll have to provide a custom endpoint to facilitate it, which you should only do if you really seriously want to allow the user to get all the data at once.
             schema_to_select: Optional Pydantic schema for selecting specific columns. Required if `return_as_model` is True.
             sort_columns: Column names to sort the results by.
-            sort_orders: Corresponding sort orders ('asc', 'desc') for each column in sort_columns.
-            return_as_model: If True, returns data as instances of the specified Pydantic model.
-            return_total_count: If True, also returns the total count of rows with the selected filters. Useful for pagination.
+            sort_orders: Corresponding sort orders (`"asc"`, `"desc"`) for each column in `sort_columns`.
+            return_as_model: If `True`, returns data as instances of the specified Pydantic model.
+            return_total_count: If `True`, also returns the total count of rows with the selected filters. Useful for pagination.
             **kwargs: Filters to apply to the query, including advanced comparison operators for more detailed querying.
 
         Returns:
-            A dictionary containing 'data' with fetched records and 'total_count' indicating the total number of records matching the filters.
+            A dictionary containing `"data"` with fetched records and `"total_count"` indicating the total number of records matching the filters.
 
         Raises:
-            ValueError: If limit or offset is negative, or if schema_to_select is required but not provided or invalid.
+            ValueError: If `limit` or `offset` is negative, or if `schema_to_select` is required but not provided or invalid.
 
         Examples:
             Fetch the first 10 users:
             ```python
-            users = await crud.get_multi(db, 0, 10)
+            users = await crud.get_multi(
+                db,
+                0,
+                10,
+            )
             ```
 
             Fetch next 10 users with sorted by username:
             ```python
-            users = await crud.get_multi(db, 10, 10, sort_columns='username', sort_orders='desc')
+            users = await crud.get_multi(
+                db,
+                10,
+                10,
+                sort_columns='username',
+                sort_orders='desc',
+            )
             ```
 
             Fetch 10 users older than 30, sorted by age in descending order:
             ```python
-            get_multi(db, offset=0, limit=10, age__gt=30, sort_columns='age', sort_orders='desc')
+            get_multi(
+                db,
+                offset=0,
+                limit=10,
+                sort_columns='age',
+                sort_orders='desc',
+                age__gt=30,
+            )
             ```
 
             Fetch 10 users with a registration date before Jan 1, 2020:
             ```python
-            get_multi(db, offset=0, limit=10, registration_date__lt=datetime(2020, 1, 1))
+            get_multi(
+                db,
+                offset=0,
+                limit=10,
+                registration_date__lt=datetime(2020, 1, 1),
+            )
             ```
 
-            Fetch 10 users with a username other than 'admin', returning as model instances (ensure appropriate schema is passed):
+            Fetch 10 users with a username other than `admin`, returning as model instances (ensure appropriate schema is passed):
             ```python
-            get_multi(db, offset=0, limit=10, username__ne='admin', schema_to_select=UserSchema, return_as_model=True)
+            get_multi(
+                db,
+                offset=0,
+                limit=10,
+                schema_to_select=UserSchema,
+                return_as_model=True,
+                username__ne='admin',
+            )
             ```
 
             Fetch users with filtering and multiple column sorting:
             ```python
-            users = await crud.get_multi(db, 0, 10, is_active=True, sort_columns=['username', 'email'], sort_orders=['asc', 'desc'])
+            users = await crud.get_multi(
+                db,
+                0,
+                10,
+                sort_columns=['username', 'email'],
+                sort_orders=['asc', 'desc'],
+                is_active=True,
+            )
             ```
         """
         if (limit is not None and limit < 0) or offset < 0:
@@ -844,58 +885,77 @@ class FastCRUD(
         **kwargs: Any,
     ) -> Optional[dict[str, Any]]:
         """
-        Fetches a single record with one or multiple joins on other models. If 'join_on' is not provided, the method attempts
-        to automatically detect the join condition using foreign key relationships. For multiple joins, use 'joins_config' to
-        specify each join configuration. For filtering details see:
-        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+        Fetches a single record with one or multiple joins on other models. If `join_on` is not provided, the method attempts
+        to automatically detect the join condition using foreign key relationships. For multiple joins, use `joins_config` to
+        specify each join configuration.
+
+        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
 
         Args:
             db: The SQLAlchemy async session.
             schema_to_select: Pydantic schema for selecting specific columns from the primary model. Required if `return_as_model` is True.
             join_model: The model to join with.
-            join_on: SQLAlchemy Join object for specifying the ON clause of the join. If None, the join condition is auto-detected based on foreign keys.
-            join_prefix: Optional prefix to be added to all columns of the joined model. If None, no prefix is added.
+            join_on: SQLAlchemy Join object for specifying the `ON` clause of the join. If `None`, the join condition is auto-detected based on foreign keys.
+            join_prefix: Optional prefix to be added to all columns of the joined model. If `None`, no prefix is added.
             join_schema_to_select: Pydantic schema for selecting specific columns from the joined model.
-            join_type: Specifies the type of join operation to perform. Can be "left" for a left outer join or "inner" for an inner join.
+            join_type: Specifies the type of join operation to perform. Can be `"left"` for a left outer join or `"inner"` for an inner join.
             alias: An instance of `AliasedClass` for the join model, useful for self-joins or multiple joins on the same model. Result of `aliased(join_model)`.
             join_filters: Filters applied to the joined model, specified as a dictionary mapping column names to their expected values.
-            joins_config: A list of JoinConfig instances, each specifying a model to join with, join condition, optional prefix for column names, schema for selecting specific columns, and the type of join. This parameter enables support for multiple joins.
-            nest_joins: If True, nested data structures will be returned where joined model data are nested under the join_prefix as a dictionary.
-            relationship_type: Specifies the relationship type, such as 'one-to-one' or 'one-to-many'. Used to determine how to nest the joined data. If None, uses one-to-one.
+            joins_config: A list of `JoinConfig` instances, each specifying a model to join with, join condition, optional prefix for column names, schema for selecting specific columns, and the type of join. This parameter enables support for multiple joins.
+            nest_joins: If `True`, nested data structures will be returned where joined model data are nested under the `join_prefix` as a dictionary.
+            relationship_type: Specifies the relationship type, such as `"one-to-one"` or `"one-to-many"`. Used to determine how to nest the joined data. If `None`, uses `"one-to-one"`.
             **kwargs: Filters to apply to the primary model query, supporting advanced comparison operators for refined searching.
 
         Returns:
-            A dictionary representing the joined record, or None if no record matches the criteria.
+            A dictionary representing the joined record, or `None` if no record matches the criteria.
 
         Raises:
-            ValueError: If both single join parameters and 'joins_config' are used simultaneously.
-            ArgumentError: If any provided model in 'joins_config' is not recognized or invalid.
+            ValueError: If both single join parameters and `joins_config` are used simultaneously.
+            ArgumentError: If any provided model in `joins_config` is not recognized or invalid.
             NoResultFound: If no record matches the criteria with the provided filters.
 
         Examples:
-            Simple example: Joining User and Tier models without explicitly providing join_on
+            Simple example: Joining `User` and `Tier` models without explicitly providing `join_on`
             ```python
             result = await crud_user.get_joined(
                 db=session,
-                join_model=Tier,
                 schema_to_select=UserSchema,
-                join_schema_to_select=TierSchema
+                join_model=Tier,
+                join_schema_to_select=TierSchema,
             )
             ```
 
             Fetch a user and their associated tier, filtering by user ID:
             ```python
-            get_joined(db, User, Tier, schema_to_select=UserSchema, join_schema_to_select=TierSchema, id=1)
+            result = await crud_user.get_joined(
+                db,
+                schema_to_select=UserSchema,
+                join_model=Tier,
+                join_schema_to_select=TierSchema,
+                id=1,
+            )
             ```
 
             Fetch a user and their associated tier, where the user's age is greater than 30:
             ```python
-            get_joined(db, User, Tier, schema_to_select=UserSchema, join_schema_to_select=TierSchema, age__gt=30)
+            result = await crud_user.get_joined(
+                db,
+                schema_to_select=UserSchema,
+                join_model=Tier,
+                join_schema_to_select=TierSchema,
+                age__gt=30,
+            )
             ```
 
-            Fetch a user and their associated tier, excluding users with the 'admin' username:
+            Fetch a user and their associated tier, excluding users with the `admin` username:
             ```python
-            get_joined(db, User, Tier, schema_to_select=UserSchema, join_schema_to_select=TierSchema, username__ne='admin')
+            result = await crud_user.get_joined(
+                db,
+                schema_to_select=UserSchema,
+                join_model=Tier,
+                join_schema_to_select=TierSchema,
+                username__ne='admin',
+            )
             ```
 
             Complex example: Joining with a custom join condition, additional filter parameters, and a prefix
@@ -903,16 +963,16 @@ class FastCRUD(
             from sqlalchemy import and_
             result = await crud_user.get_joined(
                 db=session,
-                join_model=Tier,
-                join_prefix="tier_",
-                join_on=and_(User.tier_id == Tier.id, User.is_superuser == True),
                 schema_to_select=UserSchema,
+                join_model=Tier,
+                join_on=and_(User.tier_id == Tier.id, User.is_superuser == True),
+                join_prefix="tier_",
                 join_schema_to_select=TierSchema,
-                username="john_doe"
+                username="john_doe",
             )
             ```
 
-            Example of using 'joins_config' for multiple joins:
+            Example of using `joins_config` for multiple joins:
             ```python
             from fastcrud import JoinConfig
 
@@ -933,8 +993,8 @@ class FastCRUD(
                         join_prefix="dept_",
                         schema_to_select=DepartmentSchema,
                         join_type="inner",
-                    )
-                ]
+                    ),
+                ],
             )
             ```
 
@@ -954,17 +1014,17 @@ class FastCRUD(
                         join_on=BookingModel.owner_id == owner_alias.id,
                         join_prefix="owner_",
                         alias=owner_alias,
-                        schema_to_select=UserSchema
+                        schema_to_select=UserSchema,
                     ),
                     JoinConfig(
                         model=ModelTest,
                         join_on=BookingModel.user_id == user_alias.id,
                         join_prefix="user_",
                         alias=user_alias,
-                        schema_to_select=UserSchema
-                    )
+                        schema_to_select=UserSchema,
+                    ),
                 ],
-                id=1
+                id=1,
             )
             ```
 
@@ -974,23 +1034,23 @@ class FastCRUD(
                 JoinConfig(
                     model=ProjectsParticipantsAssociation,
                     join_on=Project.id == ProjectsParticipantsAssociation.project_id,
-                    join_type="inner"
+                    join_type="inner",
                 ),
                 JoinConfig(
                     model=Participant,
                     join_on=ProjectsParticipantsAssociation.participant_id == Participant.id,
                     join_type="inner",
-                    filters={'role': 'Designer'}
-                )
+                    filters={'role': 'Designer'},
+                ),
             ]
             project = await crud.get_joined(
                 db=session,
                 schema_to_select=ProjectSchema,
-                joins_config=joins_config
+                joins_config=joins_config,
             )
             ```
 
-            Example of using 'joins_config' for multiple joins with nested joins enabled:
+            Example of using `joins_config` for multiple joins with nested joins enabled:
             ```python
             from fastcrud import JoinConfig
 
@@ -1011,9 +1071,9 @@ class FastCRUD(
                         join_prefix="dept_",
                         schema_to_select=DepartmentSchema,
                         join_type="inner",
-                    )
+                    ),
                 ],
-                nest_joins=True
+                nest_joins=True,
             )
             # Expect 'result' to have 'tier' and 'dept' as nested dictionaries
             ```
@@ -1022,11 +1082,11 @@ class FastCRUD(
             ```python
             result = await crud_user.get_joined(
                 db=session,
+                schema_to_select=UserSchema,
                 join_model=Profile,
                 join_on=User.profile_id == Profile.id,
-                schema_to_select=UserSchema,
                 join_schema_to_select=ProfileSchema,
-                relationship_type='one-to-one' # note that this is the default behavior
+                relationship_type='one-to-one', # note that this is the default behavior
             )
             # Expect 'result' to have 'profile' as a nested dictionary
             ```
@@ -1035,14 +1095,15 @@ class FastCRUD(
             ```python
             result = await crud_user.get_joined(
                 db=session,
+                schema_to_select=UserSchema,
                 join_model=Post,
                 join_on=User.id == Post.user_id,
-                schema_to_select=UserSchema,
                 join_schema_to_select=PostSchema,
                 relationship_type='one-to-many',
-                nest_joins=True
+                nest_joins=True,
             )
             # Expect 'result' to have 'posts' as a nested list of dictionaries
+            ```
         """
         if joins_config and (
             join_model or join_prefix or join_on or join_schema_to_select or alias
@@ -1134,75 +1195,73 @@ class FastCRUD(
     ) -> dict[str, Any]:
         """
         Fetch multiple records with a join on another model, allowing for pagination, optional sorting, and model conversion.
-        For filtering details see:
-        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+
+        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
 
         Args:
             db: The SQLAlchemy async session.
             schema_to_select: Pydantic schema for selecting specific columns from the primary model. Required if `return_as_model` is True.
             join_model: The model to join with.
-            join_on: SQLAlchemy Join object for specifying the ON clause of the join. If None, the join condition is auto-detected based on foreign keys.
-            join_prefix: Optional prefix to be added to all columns of the joined model. If None, no prefix is added.
+            join_on: SQLAlchemy Join object for specifying the `ON` clause of the join. If `None`, the join condition is auto-detected based on foreign keys.
+            join_prefix: Optional prefix to be added to all columns of the joined model. If `None`, no prefix is added.
             join_schema_to_select: Pydantic schema for selecting specific columns from the joined model.
-            join_type: Specifies the type of join operation to perform. Can be "left" for a left outer join or "inner" for an inner join.
+            join_type: Specifies the type of join operation to perform. Can be `"left"` for a left outer join or `"inner"` for an inner join.
             alias: An instance of `AliasedClass` for the join model, useful for self-joins or multiple joins on the same model. Result of `aliased(join_model)`.
             join_filters: Filters applied to the joined model, specified as a dictionary mapping column names to their expected values.
-            nest_joins: If True, nested data structures will be returned where joined model data are nested under the join_prefix as a dictionary.
+            nest_joins: If `True`, nested data structures will be returned where joined model data are nested under the `join_prefix` as a dictionary.
             offset: The offset (number of records to skip) for pagination.
             limit: Maximum number of records to fetch in one call. Use `None` for "no limit", fetching all matching rows. Note that in order to use `limit=None`, you'll have to provide a custom endpoint to facilitate it, which you should only do if you really seriously want to allow the user to get all the data at once.
             sort_columns: A single column name or a list of column names on which to apply sorting.
-            sort_orders: A single sort order ('asc' or 'desc') or a list of sort orders corresponding to the columns in sort_columns. If not provided, defaults to 'asc' for each column.
-            return_as_model: If True, converts the fetched data to Pydantic models based on schema_to_select. Defaults to False.
-            joins_config: List of JoinConfig instances for specifying multiple joins. Each instance defines a model to join with, join condition, optional prefix for column names, schema for selecting specific columns, and join type.
-            return_total_count: If True, also returns the total count of rows with the selected filters. Useful for pagination.
-            relationship_type: Specifies the relationship type, such as 'one-to-one' or 'one-to-many'. Used to determine how to nest the joined data. If None, uses one-to-one.
+            sort_orders: A single sort order (`"asc"` or `"desc"`) or a list of sort orders corresponding to the columns in `sort_columns`. If not provided, defaults to `"asc"` for each column.
+            return_as_model: If `True`, converts the fetched data to Pydantic models based on `schema_to_select`. Defaults to `False`.
+            joins_config: List of `JoinConfig` instances for specifying multiple joins. Each instance defines a model to join with, join condition, optional prefix for column names, schema for selecting specific columns, and join type.
+            return_total_count: If `True`, also returns the total count of rows with the selected filters. Useful for pagination.
+            relationship_type: Specifies the relationship type, such as `"one-to-one"` or `"one-to-many"`. Used to determine how to nest the joined data. If `None`, uses `"one-to-one"`.
             **kwargs: Filters to apply to the primary query, including advanced comparison operators for refined searching.
 
         Returns:
-            A dictionary containing the fetched rows under 'data' key and total count under 'total_count'.
+            A dictionary containing the fetched rows under `"data"` key and total count under `"total_count"`.
 
         Raises:
-            ValueError: If limit or offset is negative, or if schema_to_select is required but not provided or invalid.
-                        Also if both 'joins_config' and any of the single join parameters are provided or none of 'joins_config' and 'join_model' is provided.
+            ValueError: If either `limit` or `offset` are negative, or if `schema_to_select` is required but not provided or invalid.
+                        Also if both `joins_config` and any of the single join parameters are provided or none of `joins_config` and `join_model` is provided.
 
         Examples:
-            Fetching multiple User records joined with Tier records, using left join, returning raw data:
+            Fetching multiple `User` records joined with `Tier` records, using left join, returning raw data:
             ```python
             users = await crud_user.get_multi_joined(
                 db=session,
+                schema_to_select=UserSchema,
                 join_model=Tier,
                 join_prefix="tier_",
-                schema_to_select=UserSchema,
                 join_schema_to_select=TierSchema,
                 offset=0,
-                limit=10
+                limit=10,
             )
             ```
 
             Fetch users joined with their tiers, sorted by username, where user's age is greater than 30:
             ```python
-            users = get_multi_joined(
+            users = await crud_user.get_multi_joined(
                 db,
-                User,
-                Tier,
                 schema_to_select=UserSchema,
+                join_model=Tier,
                 join_schema_to_select=TierSchema,
-                age__gt=30,
                 sort_columns='username',
-                sort_orders='asc'
+                sort_orders='asc',
+                age__gt=30,
             )
             ```
 
-            Fetch users joined with their tiers, excluding users with 'admin' username, returning as model instances:
+            Fetch users joined with their tiers, excluding users with `admin` username, returning as model instances:
             ```python
-            users = get_multi_joined(
+            users = await crud_user.get_multi_joined(
                 db,
-                User,
-                Tier,
                 schema_to_select=UserSchema,
+                join_model=Tier,
                 join_schema_to_select=TierSchema,
+                return_as_model=True,
                 username__ne='admin',
-                return_as_model=True
             )
             ```
 
@@ -1210,15 +1269,15 @@ class FastCRUD(
             ```python
             users = await crud_user.get_multi_joined(
                 db=session,
+                schema_to_select=UserSchema,
                 join_model=Tier,
                 join_prefix="tier_",
-                schema_to_select=UserSchema,
                 join_schema_to_select=TierSchema,
                 offset=0,
                 limit=10,
                 sort_columns=['username'],
                 sort_orders=['desc'],
-                return_as_model=True
+                return_as_model=True,
             )
             ```
 
@@ -1226,19 +1285,19 @@ class FastCRUD(
             ```python
             users = await crud_user.get_multi_joined(
                 db=session,
-                join_model=Tier,
-                join_prefix="tier_",
-                join_on=User.tier_id == Tier.id,
                 schema_to_select=UserSchema,
+                join_model=Tier,
+                join_on=User.tier_id == Tier.id,
+                join_prefix="tier_",
                 join_schema_to_select=TierSchema,
                 offset=0,
                 limit=10,
+                return_as_model=True,
                 is_active=True,
-                return_as_model=True
             )
             ```
 
-            Example using 'joins_config' for multiple joins:
+            Example using `joins_config` for multiple joins:
             ```python
             from fastcrud import JoinConfig
 
@@ -1259,12 +1318,12 @@ class FastCRUD(
                         join_prefix="dept_",
                         schema_to_select=DepartmentSchema,
                         join_type="inner",
-                    )
+                    ),
                 ],
                 offset=0,
                 limit=10,
                 sort_columns='username',
-                sort_orders='asc'
+                sort_orders='asc',
             )
             ```
 
@@ -1287,21 +1346,21 @@ class FastCRUD(
                         model=ModelTest,
                         join_on=BookingModel.owner_id == owner_alias.id,
                         join_prefix="owner_",
+                        schema_to_select=UserSchema,  # Schema for the joined model
                         alias=owner_alias,
-                        schema_to_select=UserSchema  # Schema for the joined model
                     ),
                     JoinConfig(
                         model=ModelTest,
                         join_on=BookingModel.user_id == user_alias.id,
                         join_prefix="user_",
+                        schema_to_select=UserSchema,
                         alias=user_alias,
-                        schema_to_select=UserSchema
                     )
                 ],
                 offset=10,  # Skip the first 10 records
                 limit=5,  # Fetch up to 5 records
                 sort_columns=['booking_date'],  # Sort by booking_date
-                sort_orders=['desc']  # In descending order
+                sort_orders=['desc'],  # In descending order
             )
             ```
 
@@ -1311,20 +1370,20 @@ class FastCRUD(
                 JoinConfig(
                     model=ProjectsParticipantsAssociation,
                     join_on=Project.id == ProjectsParticipantsAssociation.project_id,
-                    join_type="inner"
+                    join_type="inner",
                 ),
                 JoinConfig(
                     model=Participant,
                     join_on=ProjectsParticipantsAssociation.participant_id == Participant.id,
                     join_type="inner",
-                    filters={'role': 'Developer'}
-                )
+                    filters={'role': 'Developer'},
+                ),
             ]
             projects = await crud.get_multi_joined(
                 db=session,
                 schema_to_select=ProjectSchema,
                 joins_config=joins_config,
-                limit=10
+                limit=10,
             )
             ```
 
@@ -1347,28 +1406,28 @@ class FastCRUD(
                         join_prefix="creator_",
                         schema_to_select=UserSchema,
                         join_type="left",
-                        alias=aliased(User, name="task_creator")
-                    )
+                        alias=aliased(User, name="task_creator"),
+                    ),
                 ],
                 nest_joins=True,
                 offset=0,
                 limit=5,
                 sort_columns='project_name',
-                sort_orders='asc'
+                sort_orders='asc',
             )
-        ```
+            ```
 
         Example using one-to-one relationship:
         ```python
         users = await crud_user.get_multi_joined(
             db=session,
+            schema_to_select=UserSchema,
             join_model=Profile,
             join_on=User.profile_id == Profile.id,
-            schema_to_select=UserSchema,
             join_schema_to_select=ProfileSchema,
-            relationship_type='one-to-one', # note that this is the default behavior
             offset=0,
-            limit=10
+            limit=10,
+            relationship_type='one-to-one', # note that this is the default behavior
         )
         # Expect 'profile' to be nested as a dictionary under each user
         ```
@@ -1377,14 +1436,14 @@ class FastCRUD(
         ```python
         users = await crud_user.get_multi_joined(
             db=session,
+            schema_to_select=UserSchema,
             join_model=Post,
             join_on=User.id == Post.user_id,
-            schema_to_select=UserSchema,
             join_schema_to_select=PostSchema,
-            relationship_type='one-to-many',
             nest_joins=True,
             offset=0,
-            limit=10
+            limit=10,
+            relationship_type='one-to-many',
         )
         # Expect 'posts' to be nested as a list of dictionaries under each user
         ```
@@ -1517,39 +1576,62 @@ class FastCRUD(
     ) -> dict[str, Any]:
         """
         Implements cursor-based pagination for fetching records. This method is designed for efficient data retrieval in large datasets and is ideal for features like infinite scrolling.
-        For filtering details see:
-        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+
+        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
 
         Args:
             db: The SQLAlchemy async session.
-            cursor: The cursor value to start fetching records from. Defaults to None.
+            cursor: The cursor value to start fetching records from. Defaults to `None`.
             limit: Maximum number of rows to fetch.
             schema_to_select: Pydantic schema for selecting specific columns.
             sort_column: Column name to use for sorting and cursor pagination.
-            sort_order: Sorting direction, either 'asc' or 'desc'.
+            sort_order: Sorting direction, either `"asc"` or `"desc"`.
             **kwargs: Filters to apply to the query, including advanced comparison operators for detailed querying.
 
         Returns:
-            A dictionary containing the fetched rows under 'data' key and the next cursor value under 'next_cursor'.
+            A dictionary containing the fetched rows under `"data"` key and the next cursor value under `"next_cursor"`.
 
         Examples:
             Fetch the first set of records (e.g., the first page in an infinite scrolling scenario)
             ```python
-            first_page = await crud.get_multi_by_cursor(db, limit=10, sort_column='created_at', sort_order='desc')
+            first_page = await crud.get_multi_by_cursor(
+                db,
+                limit=10,
+                sort_column='created_at',
+                sort_order='desc',
+            )
 
-            Fetch the next set of records using the cursor from the first page
+            # Fetch the next set of records using the cursor from the first page
             next_cursor = first_page['next_cursor']
-            second_page = await crud.get_multi_by_cursor(db, cursor=next_cursor, limit=10, sort_column='created_at', sort_order='desc')
+            second_page = await crud.get_multi_by_cursor(
+                db,
+                cursor=next_cursor,
+                limit=10,
+                sort_column='created_at',
+                sort_order='desc',
+            )
             ```
 
             Fetch records with age greater than 30 using cursor-based pagination:
             ```python
-            get_multi_by_cursor(db, limit=10, sort_column='age', sort_order='asc', age__gt=30)
+            first_page = await crud.get_multi_by_cursor(
+                db,
+                limit=10,
+                sort_column='age',
+                sort_order='asc',
+                age__gt=30,
+            )
             ```
 
             Fetch records excluding a specific username using cursor-based pagination:
             ```python
-            get_multi_by_cursor(db, limit=10, sort_column='username', sort_order='asc', username__ne='admin')
+            first_page = await crud.get_multi_by_cursor(
+                db,
+                limit=10,
+                sort_column='username',
+                sort_order='asc',
+                username__ne='admin',
+            )
             ```
 
         Note:
@@ -1604,52 +1686,73 @@ class FastCRUD(
     ) -> Optional[Union[dict, BaseModel]]:
         """
         Updates an existing record or multiple records in the database based on specified filters. This method allows for precise targeting of records to update.
-        For filtering details see:
-        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+
+        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.
             object: A Pydantic schema or dictionary containing the update data.
-            allow_multiple: If True, allows updating multiple records that match the filters. If False, raises an error if more than one record matches the filters.
-            commit: If True, commits the transaction immediately. Default is True.
-            return_columns: A list of column names to return after the update. If return_as_model is True, all columns are returned.
-            schema_to_select: Pydantic schema for selecting specific columns from the updated record(s). Required if `return_as_model` is True.
-            return_as_model: If True, returns the updated record(s) as Pydantic model instances based on `schema_to_select`. Default is False.
-            one_or_none: If True, returns a single record if only one record matches the filters. Default is False.
+            allow_multiple: If `True`, allows updating multiple records that match the filters. If `False`, raises an error if more than one record matches the filters.
+            commit: If `True`, commits the transaction immediately. Default is `True`.
+            return_columns: A list of column names to return after the update. If `return_as_model` is True, all columns are returned.
+            schema_to_select: Pydantic schema for selecting specific columns from the updated record(s). Required if `return_as_model` is `True`.
+            return_as_model: If `True`, returns the updated record(s) as Pydantic model instances based on `schema_to_select`. Default is False.
+            one_or_none: If `True`, returns a single record if only one record matches the filters. Default is `False`.
             **kwargs: Filters to identify the record(s) to update, supporting advanced comparison operators for refined querying.
 
         Returns:
-            The updated record(s) as a dictionary or Pydantic model instance or None, depending on the value of `return_as_model` and `return_columns`.
+            The updated record(s) as a dictionary or Pydantic model instance or `None`, depending on the value of `return_as_model` and `return_columns`.
 
         Raises:
-            MultipleResultsFound: If `allow_multiple` is False and more than one record matches the filters.
+            MultipleResultsFound: If `allow_multiple` is `False` and more than one record matches the filters.
             ValueError: If extra fields not present in the model are provided in the update data.
-            ValueError: If `return_as_model` is True but `schema_to_select` is not provided.
+            ValueError: If `return_as_model` is `True` but `schema_to_select` is not provided.
 
         Examples:
             Update a user's email based on their ID:
             ```python
-            update(db, {'email': 'new_email@example.com'}, id=1)
+            await user_crud.update(db, {'email': 'new_email@example.com'}, id=1)
             ```
 
-            Update users' statuses to 'inactive' where age is greater than 30 and allow updates to multiple records:
+            Update users' statuses to `"inactive"` where age is greater than 30 and allow updates to multiple records:
             ```python
-            update(db, {'status': 'inactive'}, allow_multiple=True, age__gt=30)
+            await user_crud.update(
+                db,
+                {'status': 'inactive'},
+                allow_multiple=True,
+                age__gt=30,
+            )
             ```
 
             Update a user's username excluding specific user ID and prevent multiple updates:
             ```python
-            update(db, {'username': 'new_username'}, id__ne=1, allow_multiple=False)
+            await user_crud.update(
+                db,
+                {'username': 'new_username'},
+                allow_multiple=False,
+                id__ne=1,
+            )
             ```
 
             Update a user's email and return the updated record as a Pydantic model instance:
             ```python
-            update(db, {'email': 'new_email@example.com'}, id=1, schema_to_select=UserSchema, return_as_model=True)
+            await user_crud.update(
+                db,
+                {'email': 'new_email@example.com'},
+                schema_to_select=UserSchema,
+                return_as_model=True,
+                id=1,
+            )
             ```
 
             Update a user's email and return the updated record as a dictionary:
             ```python
-            update(db, {'email': 'new_email@example.com'}, id=1, return_columns=['id', 'email'])
+            await user_crud.update(
+                db,
+                {'email': 'new_email@example.com'},
+                return_columns=['id', 'email'],
+                id=1,
+            )
             ```
         """
         if not allow_multiple and (total_count := await self.count(db, **kwargs)) > 1:
@@ -1753,35 +1856,43 @@ class FastCRUD(
     ) -> None:
         """
         Deletes a record or multiple records from the database based on specified filters.
-        For filtering details see:
-        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+
+        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.
-            allow_multiple: If True, allows deleting multiple records that match the filters. If False, raises an error if more than one record matches the filters.
-            commit: If True, commits the transaction immediately. Default is True.
+            allow_multiple: If `True`, allows deleting multiple records that match the filters. If `False`, raises an error if more than one record matches the filters.
+            commit: If `True`, commits the transaction immediately. Default is `True`.
             **kwargs: Filters to identify the record(s) to delete, including advanced comparison operators for detailed querying.
 
         Returns:
             None
 
         Raises:
-            MultipleResultsFound: If `allow_multiple` is False and more than one record matches the filters.
+            MultipleResultsFound: If `allow_multiple` is `False` and more than one record matches the filters.
 
         Examples:
             Delete a user based on their ID:
             ```python
-            db_delete(db, id=1)
+            await user_crud.db_delete(db, id=1)
             ```
 
             Delete users older than 30 years and allow deletion of multiple records:
             ```python
-            db_delete(db, allow_multiple=True, age__gt=30)
+            await user_crud.db_delete(
+                db,
+                allow_multiple=True,
+                age__gt=30,
+            )
             ```
 
             Delete a user with a specific username, ensuring only one record is deleted:
             ```python
-            db_delete(db, username='unique_username', allow_multiple=False)
+            await user_crud.db_delete(
+                db,
+                allow_multiple=False,
+                username='unique_username',
+            )
             ```
         """
         if not allow_multiple and (total_count := await self.count(db, **kwargs)) > 1:
@@ -1804,19 +1915,19 @@ class FastCRUD(
         **kwargs: Any,
     ) -> None:
         """
-        Soft deletes a record or optionally multiple records if it has an "is_deleted" attribute, otherwise performs a hard delete, based on specified filters.
-        For filtering details see:
-        https://igorbenav.github.io/fastcrud/advanced/crud/#advanced-filters
+        Soft deletes a record or optionally multiple records if it has an `"is_deleted"` attribute, otherwise performs a hard delete, based on specified filters.
+
+        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.
             db_row: Optional existing database row to delete. If provided, the method will attempt to delete this specific row, ignoring other filters.
-            allow_multiple: If True, allows deleting multiple records that match the filters. If False, raises an error if more than one record matches the filters.
-            commit: If True, commits the transaction immediately. Default is True.
+            allow_multiple: If `True`, allows deleting multiple records that match the filters. If `False`, raises an error if more than one record matches the filters.
+            commit: If `True`, commits the transaction immediately. Default is `True`.
             **kwargs: Filters to identify the record(s) to delete, supporting advanced comparison operators for refined querying.
 
         Raises:
-            MultipleResultsFound: If `allow_multiple` is False and more than one record matches the filters.
+            MultipleResultsFound: If `allow_multiple` is `False` and more than one record matches the filters.
             NoResultFound: If no record matches the filters.
 
         Returns:
@@ -1825,17 +1936,25 @@ class FastCRUD(
         Examples:
             Soft delete a specific user by ID:
             ```python
-            delete(db, id=1)
+            await user_crud.delete(db, id=1)
             ```
 
             Hard delete users with account creation dates before 2020, allowing deletion of multiple records:
             ```python
-            delete(db, allow_multiple=True, creation_date__lt=datetime(2020, 1, 1))
+            await user_crud.delete(
+                db,
+                allow_multiple=True,
+                creation_date__lt=datetime(2020, 1, 1),
+            )
             ```
 
             Soft delete a user with a specific email, ensuring only one record is deleted:
             ```python
-            delete(db, email='unique@example.com', allow_multiple=False)
+            await user_crud.delete(
+                db,
+                allow_multiple=False,
+                email='unique@example.com',
+            )
             ```
         """
         filters = self._parse_filters(**kwargs)

--- a/fastcrud/crud/helper.py
+++ b/fastcrud/crud/helper.py
@@ -53,11 +53,11 @@ def _extract_matching_columns_from_schema(
 
     Args:
         model: The SQLAlchemy ORM model containing columns to be matched with the schema fields.
-        schema: Optional; a Pydantic schema containing field names to be matched with the model's columns. If None, all columns from the model are used.
-        prefix: Optional; a prefix to be added to all column names. If None, no prefix is added.
-        alias: Optional; an alias for the model, used for referencing the columns through this alias in the query. If None, the original model is used.
-        use_temporary_prefix: Whether to use or not an aditional prefix for joins. Default False.
-        temp_prefix: The temporary prefix to be used. Default "joined__".
+        schema: Optional; a Pydantic schema containing field names to be matched with the model's columns. If `None`, all columns from the model are used.
+        prefix: Optional; a prefix to be added to all column names. If `None`, no prefix is added.
+        alias: Optional; an alias for the model, used for referencing the columns through this alias in the query. If `None`, the original model is used.
+        use_temporary_prefix: Whether to use or not an aditional prefix for joins. Default `False`.
+        temp_prefix: The temporary prefix to be used. Default `"joined__"`.
 
     Returns:
         A list of ORM column objects (potentially labeled with a prefix) that correspond to the field names defined
@@ -111,11 +111,11 @@ def _auto_detect_join_condition(
         join_model: The SQLAlchemy model to join with the base model.
 
     Returns:
-        A SQLAlchemy ColumnElement representing the join condition, if successfully detected.
+        A SQLAlchemy `ColumnElement` representing the join condition, if successfully detected.
 
     Raises:
         ValueError: If the join condition cannot be automatically determined.
-        AttributeError: If either base_model or join_model does not have a '__table__' attribute.
+        AttributeError: If either base_model or join_model does not have a `__table__` attribute.
     """
     if not hasattr(base_model, "__table__"):
         raise AttributeError(
@@ -278,9 +278,9 @@ def _nest_join_data(
 
     Args:
         data: The flat dictionary containing data with potentially prefixed keys from joined tables.
-        join_definitions: A list of JoinConfig instances defining the join configurations, including prefixes.
-        temp_prefix: The temporary prefix applied to joined columns to differentiate them. Defaults to "joined__".
-        nested_data: The nested dictionary to which the data will be added. If None, a new dictionary is created. Defaults to None.
+        join_definitions: A list of `JoinConfig` instances defining the join configurations, including prefixes.
+        temp_prefix: The temporary prefix applied to joined columns to differentiate them. Defaults to `"joined__"`.
+        nested_data: The nested dictionary to which the data will be added. If None, a new dictionary is created. Defaults to `None`.
 
     Returns:
         dict[str, Any]: A dictionary with nested structures for joined table data.
@@ -299,8 +299,8 @@ def _nest_join_data(
             JoinConfig(
                 model=Article,
                 join_prefix='articles_',
-                relationship_type='one-to-many'
-            )
+                relationship_type='one-to-many',
+            ),
         ]
 
         Output:
@@ -328,8 +328,8 @@ def _nest_join_data(
             JoinConfig(
                 model=Author,
                 join_prefix='author_',
-                relationship_type='one-to-one'
-            )
+                relationship_type='one-to-one',
+            ),
         ]
 
         Output:
@@ -418,7 +418,7 @@ def _nest_multi_join_data(
 ) -> Sequence[Union[dict, BaseModel]]:
     """
     Nests joined data based on join definitions provided for multiple records. This function processes the input list of
-    dictionaries, identifying keys that correspond to joined tables using the provided joins_config, and nests them
+    dictionaries, identifying keys that correspond to joined tables using the provided `joins_config`, and nests them
     under their respective table keys.
 
     Args:
@@ -427,7 +427,7 @@ def _nest_multi_join_data(
         joins_config: The list of join configurations containing the joined model classes and related settings.
         schema_to_select: Pydantic schema for selecting specific columns from the primary model. Used for converting
                           dictionaries back to Pydantic models.
-        return_as_model: If True, converts the fetched data to Pydantic models based on schema_to_select. Defaults to False.
+        return_as_model: If `True`, converts the fetched data to Pydantic models based on `schema_to_select`. Defaults to `False`.
         nested_schema_to_select: A dictionary mapping join prefixes to their corresponding Pydantic schemas.
 
     Returns:

--- a/fastcrud/endpoint/crud_router.py
+++ b/fastcrud/endpoint/crud_router.py
@@ -50,9 +50,9 @@ def crud_router(
     Args:
         session: The SQLAlchemy async session.
         model: The SQLAlchemy model.
-        crud: An optional FastCRUD instance. If not provided, uses FastCRUD(model).
         create_schema: Pydantic schema for creating an item.
         update_schema: Pydantic schema for updating an item.
+        crud: An optional `FastCRUD` instance. If not provided, uses `FastCRUD(model)`.
         delete_schema: Optional Pydantic schema for deleting an item.
         path: Base path for the CRUD endpoints.
         tags: Optional list of tags for grouping endpoints in the documentation.
@@ -60,25 +60,26 @@ def crud_router(
         create_deps: Optional list of functions to be injected as dependencies for the create endpoint.
         read_deps: Optional list of functions to be injected as dependencies for the read endpoint.
         read_multi_deps: Optional list of functions to be injected as dependencies for the read multiple items endpoint.
+        read_paginated_deps: Optional list of functions to be injected as dependencies for the read paginated endpoint.
         update_deps: Optional list of functions to be injected as dependencies for the update endpoint.
         delete_deps: Optional list of functions to be injected as dependencies for the delete endpoint.
         db_delete_deps: Optional list of functions to be injected as dependencies for the hard delete endpoint.
-        included_methods: Optional list of CRUD methods to include. If None, all methods are included.
+        included_methods: Optional list of CRUD methods to include. If `None`, all methods are included.
         deleted_methods: Optional list of CRUD methods to exclude.
-        endpoint_creator: Optional custom class derived from EndpointCreator for advanced customization.
-        is_deleted_column: Optional column name to use for indicating a soft delete. Defaults to "is_deleted".
-        deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to "deleted_at".
-        updated_at_column: Optional column name to use for storing the timestamp of an update. Defaults to "updated_at".
+        endpoint_creator: Optional custom class derived from `EndpointCreator` for advanced customization.
+        is_deleted_column: Optional column name to use for indicating a soft delete. Defaults to `"is_deleted"`.
+        deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to `"deleted_at"`.
+        updated_at_column: Optional column name to use for storing the timestamp of an update. Defaults to `"updated_at"`.
         endpoint_names: Optional dictionary to customize endpoint names for CRUD operations. Keys are operation types
-                        ("create", "read", "update", "delete", "db_delete", "read_multi", "read_paginated"), and
+                        (`"create"`, `"read"`, `"update"`, `"delete"`, `"db_delete"`, `"read_multi"`, `"read_paginated"`), and
                         values are the custom names to use. Unspecified operations will use default names.
-        filter_config: Optional FilterConfig instance or dictionary to configure filters for the `read_multi` and `read_paginated` endpoints.
+        filter_config: Optional `FilterConfig` instance or dictionary to configure filters for the `read_multi` and `read_paginated` endpoints.
 
     Returns:
-        Configured APIRouter instance with the CRUD endpoints.
+        Configured `APIRouter` instance with the CRUD endpoints.
 
     Raises:
-        ValueError: If both 'included_methods' and 'deleted_methods' are provided.
+        ValueError: If both `included_methods` and `deleted_methods` are provided.
 
     Examples:
         Basic Setup:
@@ -89,7 +90,7 @@ def crud_router(
             create_schema=CreateMyModelSchema,
             update_schema=UpdateMyModelSchema,
             path="/mymodel",
-            tags=["MyModel"]
+            tags=["MyModel"],
         )
         ```
 
@@ -107,7 +108,7 @@ def crud_router(
             read_deps=[get_current_user],
             update_deps=[get_current_user],
             path="/users",
-            tags=["Users"]
+            tags=["Users"],
         )
         ```
 
@@ -120,7 +121,7 @@ def crud_router(
             update_schema=UpdateProductSchema,
             delete_schema=DeleteProductSchema,
             path="/products",
-            tags=["Products"]
+            tags=["Products"],
         )
         ```
 
@@ -129,11 +130,11 @@ def crud_router(
         router = crud_router(
             session=async_session,
             model=OrderModel,
-            crud=CRUDOrderModel(OrderModel),
             create_schema=CreateOrderSchema,
             update_schema=UpdateOrderSchema,
+            crud=CRUDOrderModel(OrderModel),
             path="/orders",
-            tags=["Orders", "Sales"]
+            tags=["Orders", "Sales"],
         )
         ```
 
@@ -142,21 +143,21 @@ def crud_router(
         product_router = crud_router(
             session=async_session,
             model=ProductModel,
-            crud=CRUDProductModel(ProductModel),
             create_schema=CreateProductSchema,
             update_schema=UpdateProductSchema,
+            crud=CRUDProductModel(ProductModel),
             path="/products",
-            tags=["Inventory"]
+            tags=["Inventory"],
         )
 
         customer_router = crud_router(
             session=async_session,
             model=CustomerModel,
-            crud=CRUDCustomerModel(CustomerModel),
             create_schema=CreateCustomerSchema,
             update_schema=UpdateCustomerSchema,
+            crud=CRUDCustomerModel(CustomerModel),
             path="/customers",
-            tags=["CRM"]
+            tags=["CRM"],
         )
         ```
 
@@ -166,16 +167,16 @@ def crud_router(
         router = crud_router(
             session=async_session,
             model=MyModel,
-            crud=CRUDMyModel(MyModel),
             create_schema=CreateMyModel,
             update_schema=UpdateMyModel,
+            crud=CRUDMyModel(MyModel),
             included_methods=["create", "read"],
             path="/mymodel",
-            tags=["MyModel"]
+            tags=["MyModel"],
         )
         ```
 
-        Using a Custom EndpointCreator:
+        Using a Custom `EndpointCreator`:
         ```python
         class CustomEndpointCreator(EndpointCreator):
             def _custom_route(self):
@@ -201,12 +202,12 @@ def crud_router(
         router = crud_router(
             session=async_session,
             model=MyModel,
-            crud=CRUDMyModel(MyModel),
             create_schema=CreateMyModel,
             update_schema=UpdateMyModel,
-            endpoint_creator=CustomEndpointCreator,
+            crud=CRUDMyModel(MyModel),
             path="/mymodel",
-            tags=["MyModel"]
+            tags=["MyModel"],
+            endpoint_creator=CustomEndpointCreator,
         )
 
         app.include_router(my_router)
@@ -228,12 +229,12 @@ def crud_router(
                 "delete": "remove_task",
                 "db_delete": "permanently_remove_task",
                 "read_multi": "list_tasks",
-                "read_paginated": "paginate_tasks"
-            }
+                "read_paginated": "paginate_tasks",
+            },
         )
         ```
 
-        Using FilterConfig with dict:
+        Using `FilterConfig` with `dict`:
         ```python
         from fastapi import FastAPI
         from fastcrud import crud_router
@@ -248,7 +249,7 @@ def crud_router(
             model=MyModel,
             create_schema=CreateMyModel,
             update_schema=UpdateMyModel,
-            filter_config=FilterConfig(filters={"id": None, "name": "default"})
+            filter_config=FilterConfig(filters={"id": None, "name": "default"}),
         )
         # Adds CRUD routes with filtering capabilities
         app.include_router(router, prefix="/mymodel")
@@ -260,7 +261,7 @@ def crud_router(
         # Example GET request: /mymodel/get_multi?id=1&name=example
         ```
 
-        Using FilterConfig with keyword arguments:
+        Using `FilterConfig` with keyword arguments:
         ```python
         from fastapi import FastAPI
         from fastcrud import crud_router
@@ -275,7 +276,7 @@ def crud_router(
             model=MyModel,
             create_schema=CreateMyModel,
             update_schema=UpdateMyModel,
-            filter_config=FilterConfig(id=None, name="default")
+            filter_config=FilterConfig(id=None, name="default"),
         )
         # Adds CRUD routes with filtering capabilities
         app.include_router(router, prefix="/mymodel")

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -36,25 +36,25 @@ class EndpointCreator:
     This class simplifies the process of adding create, read, update, and delete (CRUD) endpoints
     to a FastAPI router. It is initialized with a SQLAlchemy session, model, CRUD operations,
     and Pydantic schemas, and allows for custom dependency injection for each endpoint.
-    The method assumes 'id' is the primary key for path parameters.
+    The method assumes `id` is the primary key for path parameters.
 
     Attributes:
         session: The SQLAlchemy async session.
         model: The SQLAlchemy model.
-        crud: An optional FastCRUD instance. If not provided, uses FastCRUD(model).
         create_schema: Pydantic schema for creating an item.
         update_schema: Pydantic schema for updating an item.
-        delete_schema: Optional Pydantic schema for deleting an item.
+        crud: An optional FastCRUD instance. If not provided, uses `FastCRUD(model)`.
         include_in_schema: Whether to include the created endpoints in the OpenAPI schema.
+        delete_schema: Optional Pydantic schema for deleting an item.
         path: Base path for the CRUD endpoints.
         tags: List of tags for grouping endpoints in the documentation.
-        is_deleted_column: Optional column name to use for indicating a soft delete. Defaults to "is_deleted".
-        deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to "deleted_at".
-        updated_at_column: Optional column name to use for storing the timestamp of an update. Defaults to "updated_at".
+        is_deleted_column: Optional column name to use for indicating a soft delete. Defaults to `"is_deleted"`.
+        deleted_at_column: Optional column name to use for storing the timestamp of a soft delete. Defaults to `"deleted_at"`.
+        updated_at_column: Optional column name to use for storing the timestamp of an update. Defaults to `"updated_at"`.
         endpoint_names: Optional dictionary to customize endpoint names for CRUD operations. Keys are operation types
-                        ("create", "read", "update", "delete", "db_delete", "read_multi", "read_paginated"), and
+                        (`"create"`, `"read"`, `"update"`, `"delete"`, `"db_delete"`, `"read_multi"`, `"read_paginated"`), and
                         values are the custom names to use. Unspecified operations will use default names.
-        filter_config: Optional FilterConfig instance or dictionary to configure filters for the `read_multi` and `read_paginated` endpoints.
+        filter_config: Optional `FilterConfig` instance or dictionary to configure filters for the `read_multi` and `read_paginated` endpoints.
 
     Raises:
         ValueError: If both `included_methods` and `deleted_methods` are provided.
@@ -74,7 +74,7 @@ class EndpointCreator:
             session=async_session,
             model=MyModel,
             create_schema=CreateMyModel,
-            update_schema=UpdateMyModel
+            update_schema=UpdateMyModel,
         )
         endpoint_creator.add_routes_to_router()
         app.include_router(endpoint_creator.router, prefix="/mymodel")
@@ -91,7 +91,7 @@ class EndpointCreator:
 
         endpoint_creator.add_routes_to_router(
             read_deps=[get_current_user],
-            update_deps=[get_current_user]
+            update_deps=[get_current_user],
         )
         ```
 
@@ -99,7 +99,7 @@ class EndpointCreator:
         ```python
         # Only create 'create' and 'read' endpoints
         endpoint_creator.add_routes_to_router(
-            included_methods=["create", "read"]
+            included_methods=["create", "read"],
         )
         ```
 
@@ -107,7 +107,7 @@ class EndpointCreator:
         ```python
         # Create all but 'update' and 'delete' endpoints
         endpoint_creator.add_routes_to_router(
-            deleted_methods=["update", "delete"]
+            deleted_methods=["update", "delete"],
         )
         ```
 
@@ -119,9 +119,9 @@ class EndpointCreator:
         other_endpoint_creator = EndpointCreator(
             session=async_session,
             model=OtherModel,
-            crud=other_model_crud,
             create_schema=CreateOtherModel,
-            update_schema=UpdateOtherModel
+            update_schema=UpdateOtherModel,
+            crud=other_model_crud,
         )
         other_endpoint_creator.add_routes_to_router()
         app.include_router(other_endpoint_creator.router, prefix="/othermodel")
@@ -141,12 +141,12 @@ class EndpointCreator:
                 "read": "fetch",  # Custom endpoint name for reading a single item
                 "update": "change",  # Custom endpoint name for updating items
                 # The delete operation will use the default name "delete"
-            }
+            },
         )
         endpoint_creator.add_routes_to_router()
         ```
 
-        Using filter_config with dict:
+        Using `filter_config` with `dict`:
         ```python
         from fastapi import FastAPI
         from fastcrud import EndpointCreator, FilterConfig
@@ -161,7 +161,7 @@ class EndpointCreator:
             model=MyModel,
             create_schema=CreateMyModel,
             update_schema=UpdateMyModel,
-            filter_config=FilterConfig(filters={"id": None, "name": "default"})
+            filter_config=FilterConfig(filters={"id": None, "name": "default"}),
         )
         # Adds CRUD routes with filtering capabilities
         endpoint_creator.add_routes_to_router()
@@ -175,7 +175,7 @@ class EndpointCreator:
         # Example GET request: /mymodel/get_multi?id=1&name=example
         ```
 
-        Using filter_config with keyword arguments:
+        Using `filter_config` with keyword arguments:
         ```python
         from fastapi import FastAPI
         from fastcrud import EndpointCreator, FilterConfig
@@ -190,7 +190,7 @@ class EndpointCreator:
             model=MyModel,
             create_schema=CreateMyModel,
             update_schema=UpdateMyModel,
-            filter_config=FilterConfig(id=None, name="default")
+            filter_config=FilterConfig(id=None, name="default"),
         )
         # Adds CRUD routes with filtering capabilities
         endpoint_creator.add_routes_to_router()
@@ -403,7 +403,7 @@ class EndpointCreator:
         """
         Creates an endpoint for hard deleting an item from the database.
 
-        This endpoint is only added if the delete_schema is provided during initialization.
+        This endpoint is only added if the `delete_schema` is provided during initialization.
         The endpoint expects an item ID as a path parameter and uses the provided SQLAlchemy
         async session to permanently delete the item from the database.
         """
@@ -453,11 +453,12 @@ class EndpointCreator:
             create_deps: List of functions to be injected as dependencies for the create endpoint.
             read_deps: List of functions to be injected as dependencies for the read endpoint.
             read_multi_deps: List of functions to be injected as dependencies for the read multiple items endpoint.
+            read_paginated_deps: List of functions to be injected as dependencies for the read paginated endpoint.
             update_deps: List of functions to be injected as dependencies for the update endpoint.
             delete_deps: List of functions to be injected as dependencies for the delete endpoint.
             db_delete_deps: List of functions to be injected as dependencies for the hard delete endpoint.
             included_methods: Optional list of methods to include. Defaults to all CRUD methods.
-            deleted_methods: Optional list of methods to exclude. Defaults to None.
+            deleted_methods: Optional list of methods to exclude. Defaults to `None`.
 
         Raises:
             ValueError: If both `included_methods` and `deleted_methods` are provided.
@@ -467,7 +468,7 @@ class EndpointCreator:
             ```python
             # Only create 'create' and 'read' endpoints
             endpoint_creator.add_routes_to_router(
-                included_methods=["create", "read"]
+                included_methods=["create", "read"],
             )
             ```
 
@@ -475,7 +476,7 @@ class EndpointCreator:
             ```python
             # Create all endpoints except 'delete' and 'db_delete'
             endpoint_creator.add_routes_to_router(
-                deleted_methods=["delete", "db_delete"]
+                deleted_methods=["delete", "db_delete"],
             )
             ```
 
@@ -488,14 +489,14 @@ class EndpointCreator:
             endpoint_creator.add_routes_to_router(
                 read_deps=[get_current_user],
                 update_deps=[get_current_user],
-                included_methods=["read", "update"]
+                included_methods=["read", "update"],
             )
             ```
 
         Note:
             This method should be called to register the endpoints with the FastAPI application.
-            If 'delete_schema' is provided, a hard delete endpoint is also registered.
-            This method assumes 'id' is the primary key for path parameters.
+            If `delete_schema` is provided on class instantiation, a hard delete endpoint is also registered.
+            This method assumes `id` is the primary key for path parameters.
         """
         if (included_methods is not None) and (deleted_methods is not None):
             raise ValueError(
@@ -634,9 +635,9 @@ class EndpointCreator:
         Adds a custom route to the FastAPI router.
 
         Args:
-            path: URL path for the custom route.
             endpoint: The endpoint function to execute when the route is called.
-            methods: A list of HTTP methods for the route (e.g., ['GET', 'POST']).
+            methods: A list of HTTP methods for the route (e.g., `['GET', 'POST']`).
+            path: URL path for the custom route.
             dependencies: A list of functions to be injected as dependencies for the route.
             include_in_schema: Whether to include this route in the OpenAPI schema.
             tags: Tags for grouping and categorizing the route in documentation.
@@ -652,11 +653,11 @@ class EndpointCreator:
 
             endpoint_creator.add_custom_route(
                 endpoint=custom_endpoint,
-                path="/custom",
                 methods=["GET"],
+                path="/custom",
                 tags=["custom"],
                 summary="Custom Endpoint",
-                description="This is a custom endpoint."
+                description="This is a custom endpoint.",
             )
             ```
         """

--- a/fastcrud/paginated/helper.py
+++ b/fastcrud/paginated/helper.py
@@ -5,23 +5,17 @@ def compute_offset(page: int, items_per_page: int) -> int:
     For example, if each page displays 10 items and you want to display page 3, the offset will be 20,
     meaning the display should start with the 21st item.
 
-    Parameters
-    ----------
-    page : int
-        The current page number. Page numbers should start from 1.
-    items_per_page : int
-        The number of items to be displayed on each page.
+    Args:
+        page: The current page number. Page numbers should start from 1.
+        items_per_page: The number of items to be displayed on each page.
 
-    Returns
-    -------
-    int
+    Returns:
         The calculated offset.
 
-    Examples
-    --------
-    >>> offset(1, 10)
-    0
-    >>> offset(3, 10)
-    20
+    Examples:
+        >>> offset(1, 10)
+        0
+        >>> offset(3, 10)
+        20
     """
     return (page - 1) * items_per_page

--- a/fastcrud/paginated/response.py
+++ b/fastcrud/paginated/response.py
@@ -6,23 +6,16 @@ def paginated_response(
 ) -> dict[str, Any]:
     """Create a paginated response based on the provided data and pagination parameters.
 
-    Parameters
-    ----------
-    crud_data : ListResponse[SchemaType]
-        Data to be paginated, including the list of items and total count.
-    page : int
-        Current page number.
-    items_per_page : int
-        Number of items per page.
+    Args:
+        crud_data: Data to be paginated, including the list of items and total count.
+        page: Current page number.
+        items_per_page: Number of items per page.
 
-    Returns
-    -------
-    dict[str, Any]
+    Returns:
         A structured paginated response dict containing the list of items, total count, pagination flags, and numbers.
 
-    Note
-    ----
-    The function does not actually paginate the data but formats the response to indicate pagination metadata.
+    Note:
+        The function does not actually paginate the data but formats the response to indicate pagination metadata.
     """
     return {
         "data": crud_data["data"],


### PR DESCRIPTION
## Description
Preliminary to work I've been doing for #72, this PR is to some cleanup of the docs and docstrings, mostly in terms of consistency in formatting. See the Changes section for more details.

## Changes

* Add inline code markup in places where it's missing.
* Add trailing commas in example multi-line parameter lists.
* Adjust spacing and tab indent levels.
* Migrate soft delete column final paragraphs up: Put them before talking about an updated-at column instead of after, so we're not randomly going back to a previous topic.
* Quote strings in code markup to make it clear that they are strings.
* Replace some HTML in docs with Markdown. (Couldn't quite figure out how to do it for the HTML at the start of `index.md`, but still an improvement.)
* Apply correct/standard formatting to `paginated/` docstrings.
* Other misc docstring formatting fixes.

## Tests
There are no code changes, and therefore no changes to tests.

## Checklist
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have added necessary documentation (if appropriate).
