### PR TITLE
Fix return type for async session fixture in tests.

### DIFF
--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncGenerator
 from typing import Optional
 from datetime import datetime
 
@@ -278,7 +279,7 @@ async_engine = create_async_engine(
 
 
 @pytest_asyncio.fixture(scope="function")
-async def async_session() -> AsyncSession:
+async def async_session() -> AsyncGenerator[AsyncSession]:
     session = sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
     async with session() as s:

--- a/tests/sqlmodel/conftest.py
+++ b/tests/sqlmodel/conftest.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncGenerator
 from typing import Optional
 
 import pytest
@@ -272,7 +273,7 @@ async_engine = create_async_engine(
 
 
 @pytest_asyncio.fixture(scope="function")
-async def async_session() -> AsyncSession:
+async def async_session() -> AsyncGenerator[AsyncSession]:
     session = sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
 
     async with session() as s:


### PR DESCRIPTION
## Description
Another PR based on stuff discovered while working on #72, this one changes the return type for the async session fixture, because `yield` makes the fixture function a generator.

## Changes
Make the return type for the async session fixtures `AsyncGenerator[AsyncSession]` instead of just `AsyncSession`.

## Tests
No tests added or changed; just fixture typing.

## Checklist
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] All new and existing tests passed.
