### PR TITLE
Models and Schemas, Batch 1: Simple/One-Off Models

### DIFF
--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -525,8 +525,11 @@ This method constructs a SQL Alchemy `Select` statement, offering optional colum
 #### Usage Example:
 
 ```python
+--8<--
+fastcrud/examples/mymodel/schemas.py:readschema
+--8<--
 stmt = await my_model_crud.select(
-    schema_to_select=MySchema,
+    schema_to_select=ReadMyModelSchema,
     sort_columns='name',
     name__like='%example%',
 )

--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -149,6 +149,7 @@ items = await item_crud.get_multi(
 ```
 
 ### AND clauses
+
 AND clauses can be achieved by chaining multiple filters together.
 
 ```python
@@ -160,13 +161,13 @@ items = await item_crud.get_multi(
 )
 ```
 
-#### Counting Records
+### Counting Records
 
 ```python
-# Count items added in the last month
+# Count items created in the last month
 item_count = await item_crud.count(
     db=db,
-    added_at__gte=datetime.datetime.now() - datetime.timedelta(days=30),
+    created_at__gte=datetime.datetime.now() - datetime.timedelta(days=30),
 )
 ```
 
@@ -177,12 +178,12 @@ For `create`, `update`, `db_delete` and `delete` methods of `FastCRUD`, you have
 ```python
 from fastcrud import FastCRUD
 
-from .models.item import Item
 from .database import session as db
+from .item.model import Item
 
-crud_items = FastCRUD(Item)
+item_crud = FastCRUD(Item)
 
-await crud_items.delete(
+await item_crud.delete(
     db=db, 
     commit=False, 
     id=1,
@@ -197,15 +198,16 @@ In `update` method, you can pass `return_columns` parameter containing a list of
 ```python
 from fastcrud import FastCRUD
 
-from .models.item import Item
 from .database import session as db
+from .item.model import Item
 
-crud_items = FastCRUD(Item)
-item = await crud_items.update(
+item_crud = FastCRUD(Item)
+
+item = await item_crud.update(
     db=db,
     object={"price": 9.99},
-    price__lt=10
     return_columns=["price"],
+    price__lt=10,
 )
 # this will return the updated price
 ```
@@ -215,17 +217,18 @@ You can also pass `schema_to_select` parameter and `return_as_model` to return t
 ```python
 from fastcrud import FastCRUD
 
-from .models.item import Item
-from .schemas.item import ItemSchema
 from .database import session as db
+from .item.model import Base, Item
+from .item.schemas import ItemSchema
 
-crud_items = FastCRUD(Item)
-item = await crud_items.update(
+item_crud = FastCRUD(Item)
+
+item = await item_crud.update(
     db=db,
     object={"price": 9.99},
-    price__lt=10
     schema_to_select=ItemSchema,
     return_as_model=True,
+    price__lt=10,
 )
 # this will return the updated data in the form of ItemSchema
 ```
@@ -237,11 +240,12 @@ If you pass `None` to `limit` in `get_multi` and `get_multi_joined`, you get the
 ```python
 from fastcrud import FastCRUD
 
-from .models.item import Item
 from .database import session as db
+from .item.model import Item
 
-crud_items = FastCRUD(Item)
-items = await crud_items.get_multi(db=db, limit=None)
+item_crud = FastCRUD(Item)
+
+items = await item_crud.get_multi(db=db, limit=None)
 # this will return all items in the db
 ```
 
@@ -260,15 +264,15 @@ FastCRUD provides an `upsert_multi` method to efficiently upsert multiple record
 ```python
 from fastcrud import FastCRUD
 
-from .models.item import Item
-from .schemas.item import ItemCreateSchema
 from .database import session as db
+from .item.model import Item
+from .item.schemas import CreateItemSchema, ItemSchema
 
-crud_items = FastCRUD(Item)
-items = await crud_items.upsert_multi(
+item_crud = FastCRUD(Item)
+items = await item_crud.upsert_multi(
     db=db,
     instances=[
-        ItemCreateSchema(price=9.99),
+        CreateItemSchema(price=9.99),
     ],
     schema_to_select=ItemSchema,
     return_as_model=True,

--- a/docs/advanced/endpoint.md
+++ b/docs/advanced/endpoint.md
@@ -186,6 +186,25 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
 
 You can control which CRUD operations are exposed by using `included_methods` and `deleted_methods`. These parameters allow you to specify exactly which CRUD methods should be included or excluded when setting up the router. By default, all CRUD endpoints are included.
 
+??? example "`mymodel/model.py`"
+
+    ```python
+    --8<--
+    fastcrud/examples/mymodel/model.py:imports
+    fastcrud/examples/mymodel/model.py:model_simple
+    --8<--
+    ```
+
+??? example "`mymodel/schemas.py`"
+
+    ```python
+    --8<--
+    fastcrud/examples/mymodel/schemas.py:imports
+    fastcrud/examples/mymodel/schemas.py:createschema
+    fastcrud/examples/mymodel/schemas.py:updateschema
+    --8<--
+    ```
+
 ### Using `included_methods`
 
 Using `included_methods` you may define exactly the methods you want to be included.
@@ -195,8 +214,8 @@ Using `included_methods` you may define exactly the methods you want to be inclu
 my_router = crud_router(
     session=get_session,
     model=MyModel,
-    create_schema=CreateMyModel,
-    update_schema=UpdateMyModel,
+    create_schema=CreateMyModelSchema,
+    update_schema=UpdateMyModelSchema,
     crud=FastCRUD(MyModel),
     path="/mymodel",
     tags=["MyModel"],
@@ -215,8 +234,8 @@ Using `deleted_methods` you define the methods that will not be included.
 my_router = crud_router(
     session=get_session,
     model=MyModel,
-    create_schema=CreateMyModel,
-    update_schema=UpdateMyModel,
+    create_schema=CreateMyModelSchema,
+    update_schema=UpdateMyModelSchema,
     crud=FastCRUD(MyModel),
     path="/mymodel",
     tags=["MyModel"],
@@ -240,10 +259,11 @@ Here's how you can customize endpoint names using the `crud_router` function:
 
 ```python
 from fastapi import FastAPI
-from yourapp.crud import crud_router
-from yourapp.models import YourModel
-from yourapp.schemas import CreateYourModelSchema, UpdateYourModelSchema
-from yourapp.database import async_session
+from fastcrud import crud_router
+
+from .database import async_session
+from .mymodel.model import MyModel
+from .mymodel.schemas import CreateMyModelSchema, UpdateMyModelSchema
 
 app = FastAPI()
 
@@ -260,11 +280,11 @@ custom_endpoint_names = {
 # Setup CRUD router with custom endpoint names
 app.include_router(crud_router(
     session=async_session,
-    model=YourModel,
-    create_schema=CreateYourModelSchema,
-    update_schema=UpdateYourModelSchema,
-    path="/yourmodel",
-    tags=["YourModel"],
+    model=MyModel,
+    create_schema=CreateMyModelSchema,
+    update_schema=UpdateMyModelSchema,
+    path="/mymodel",
+    tags=["MyModel"],
     endpoint_names=custom_endpoint_names,
 ))
 ```
@@ -290,11 +310,11 @@ custom_endpoint_names = {
 # Initialize and use the custom EndpointCreator
 endpoint_creator = EndpointCreator(
     session=async_session,
-    model=YourModel,
-    create_schema=CreateYourModelSchema,
-    update_schema=UpdateYourModelSchema,
-    path="/yourmodel",
-    tags=["YourModel"],
+    model=MyModel,
+    create_schema=CreateMyModelSchema,
+    update_schema=UpdateMyModelSchema,
+    path="/mymodel",
+    tags=["MyModel"],
     endpoint_names=custom_endpoint_names,
 )
 
@@ -347,7 +367,7 @@ class MyCustomEndpointCreator(EndpointCreator):
 
 ### Adding custom routes
 
-```python hl_lines="5-9"
+```python hl_lines="5-11"
 from fastcrud import EndpointCreator
 
 # Define the custom EndpointCreator
@@ -416,8 +436,8 @@ class MyCustomEndpointCreator(EndpointCreator):
 my_router = crud_router(
     session=get_session,
     model=MyModel,
-    create_schema=CreateMyModel,
-    update_schema=UpdateMyModel,
+    create_schema=CreateMyModelSchema,
+    update_schema=UpdateMyModelSchema,
     crud=FastCRUD(MyModel),
     path="/mymodel",
     tags=["MyModel"],
@@ -439,18 +459,18 @@ Here's how to specify custom soft delete columns when utilizing `EndpointCreator
 First, ensure your SQLAlchemy model is equipped with the custom soft delete columns. Here's an example model with custom columns for soft deletion:
 
 ```python
-from sqlalchemy import Column, Integer, String, DateTime, Boolean
-from sqlalchemy.ext.declarative import declarative_base
-from datetime import datetime
+--8<--
+fastcrud/examples/mymodel/model.py:imports
+fastcrud/examples/mymodel/model.py:model_softdelete
+--8<--
+```
 
-Base = declarative_base()
+And a schema necessary to activate the soft delete endpoint:
 
-class MyModel(Base):
-    __tablename__ = 'my_model'
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
-    archived = Column(Boolean, default=False)  # Custom soft delete column
-    archived_at = Column(DateTime)  # Custom timestamp column for soft delete
+```python
+--8<--
+fastcrud/examples/mymodel/schemas.py:deleteschema
+--8<--
 ```
 
 ### Using `EndpointCreator` and `crud_router` with Custom Soft Delete or Update Columns
@@ -511,7 +531,10 @@ By specifying custom column names for soft deletion, you can adapt FastCRUD to f
 
 You can also customize your `updated_at` column:
 
-```python hl_lines="11"
+```python hl_lines="20"
+--8<--
+fastcrud/examples/mymodel/model.py:model
+--8<--
 app.include_router(endpoint_creator(
     session=async_session,
     model=MyModel,

--- a/docs/advanced/endpoint.md
+++ b/docs/advanced/endpoint.md
@@ -1,7 +1,7 @@
 # Advanced Use of EndpointCreator
 
 ## Available Automatic Endpoints
-FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints for your FastAPI application. Here's an overview of the available automatic endpoints and how they work:
+FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints for your FastAPI application. Here's an overview of the available automatic endpoints and how they work, based on [the automatic endpoints we've generated before](../usage/endpoint.md#step-3-use-crud_router-to-create-endpoints):
 
 ### Create
 
@@ -9,7 +9,7 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
 - **Method**: `POST`
 - **Description**: Creates a new item in the database.
 - **Request Body**: JSON object based on the `create_schema`.
-- **Example Request**: `POST /yourmodel/create` with JSON body.
+- **Example Request**: `POST /items/create` with JSON body.
 
 ### Read
 
@@ -17,13 +17,17 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
 - **Method**: `GET`
 - **Description**: Retrieves a single item by its ID.
 - **Path Parameters**: `id` - The ID of the item to retrieve.
-- **Example Request**: `GET /yourmodel/get/1`.
+- **Example Request**: `GET /items/get/1`.
 - **Example Return**:
 ```javascript
 {
     "id": 1,
     "name": "Item 1",
-    "description": "Description of item 1"
+    "description": "Description of item 1",
+    "category": "Movies",
+    "price": 5.99,
+    "last_sold": null,
+    "created_at": "2024-01-01 12:00:00"
 }
 ```
 
@@ -35,15 +39,47 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
 - **Query Parameters**:
     - `offset` (optional): The offset from where to start fetching items.
     - `limit` (optional): The maximum number of items to return.
-- **Example Request**: `GET /yourmodel/get_multi?offset=3&limit=4`.
+- **Example Request**: `GET /items/get_multi?offset=3&limit=4`.
 - **Example Return**:
 ```javascript
 {
   "data": [
-    {"id": 4, "name": "Item 4", "description": "Description of item 4"},
-    {"id": 5, "name": "Item 5", "description": "Description of item 5"},
-    {"id": 6, "name": "Item 6", "description": "Description of item 6"},
-    {"id": 7, "name": "Item 7", "description": "Description of item 7"}
+    {
+        "id": 4,
+        "name": "Item 4",
+        "description": "Description of item 4",
+        "category": "Books",
+        "price": 5.99,
+        "last_sold": null,
+        "created_at": "2024-01-01 12:01:00"
+    },
+    {
+        "id": 5,
+        "name": "Item 5",
+        "description": "Description of item 5",
+        "category": "Music",
+        "price": 5.99,
+        "last_sold": "2024-04-01 00:00:00",
+        "created_at": "2024-01-01 12:10:00"
+    },
+    {
+        "id": 6,
+        "name": "Item 6",
+        "description": "Description of item 6",
+        "category": "TV",
+        "price": 5.99,
+        "last_sold": null,
+        "created_at": "2024-01-01 12:15:00"
+    },
+    {
+        "id": 7,
+        "name": "Item 7",
+        "description": "Description of item 7",
+        "category": "Books",
+        "price": 5.99,
+        "last_sold": null,
+        "created_at": "2024-01-01 13:00:30"
+    }
   ],
   "total_count": 50
 }
@@ -58,14 +94,38 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
 - **Query Parameters**:
     - `page`: The page number, starting from 1.
     - `itemsPerPage`: The number of items per page.
-- **Example Request**: `GET /yourmodel/get_paginated?page=1&itemsPerPage=3`.
+- **Example Request**: `GET /items/get_paginated?page=1&itemsPerPage=3`.
 - **Example Return**:
 ```javascript
 {
   "data": [
-    {"id": 1, "name": "Item 1", "description": "Description of item 1"},
-    {"id": 2, "name": "Item 2", "description": "Description of item 2"},
-    {"id": 3, "name": "Item 3", "description": "Description of item 3"}
+    {
+        "id": 1,
+        "name": "Item 1",
+        "description": "Description of item 1",
+        "category": "Movies",
+        "price": 5.99,
+        "last_sold": null,
+        "created_at": "2024-01-01 12:00:01"
+    },
+    {
+        "id": 2,
+        "name": "Item 2",
+        "description": "Description of item 2",
+        "category": "TV",
+        "price": 19.99,
+        "last_sold": null,
+        "created_at": "2024-01-01 12:00:15"
+    },
+    {
+        "id": 3,
+        "name": "Item 3",
+        "description": "Description of item 3",
+        "category": "Books",
+        "price": 4.99,
+        "last_sold": null,
+        "created_at": "2024-01-01 12:00:16"
+    }
   ],
   "total_count": 50,
   "has_more": true,
@@ -101,7 +161,7 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
 - **Description**: Updates an existing item by its ID.
 - **Path Parameters**: `id` - The ID of the item to update.
 - **Request Body**: JSON object based on the `update_schema`.
-- **Example Request**: `PATCH /yourmodel/update/1` with JSON body.
+- **Example Request**: `PATCH /items/update/1` with JSON body.
 - **Example Return**: `None`
 
 ### Delete
@@ -110,7 +170,7 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
 - **Method**: `DELETE`
 - **Description**: Deletes (soft delete if configured) an item by its ID.
 - **Path Parameters**: `id` - The ID of the item to delete.
-- **Example Request**: `DELETE /yourmodel/delete/1`.
+- **Example Request**: `DELETE /items/delete/1`.
 - **Example Return**: `None`
 
 ### DB Delete (Hard Delete)
@@ -119,7 +179,7 @@ FastCRUD automates the creation of CRUD (Create, Read, Update, Delete) endpoints
 - **Method**: `DELETE`
 - **Description**: Permanently deletes an item by its ID, bypassing the soft delete mechanism.
 - **Path Parameters**: `id` - The ID of the item to hard delete.
-- **Example Request**: `DELETE /yourmodel/db_delete/1`.
+- **Example Request**: `DELETE /items/db_delete/1`.
 - **Example Return**: `None`
 
 ## Selective CRUD Operations
@@ -250,7 +310,6 @@ app.include_router(endpoint_creator.router)
 
     `default_endpoint_names` for `EndpointCreator` are going to be changed to empty strings in the next major release.
     See [this issue](https://github.com/igorbenav/fastcrud/issues/67) for more details.
-
 
 ## Extending `EndpointCreator`
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,23 +8,21 @@ Assuming you have your SQLAlchemy model, Pydantic schemas and database connectio
 
 Define your SQLAlchemy model
 
-```python title="setup.py" hl_lines="9-12"
+```python title="setup.py" hl_lines="11-19"
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel
 
+
 class Base(DeclarativeBase):
     pass
 
-class Item(Base):
-    __tablename__ = 'items'
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
 
-class ItemCreateSchema(BaseModel):
-    name: str
-
+--8<--
+fastcrud/examples/item/model.py:model
+fastcrud/examples/item/schemas.py:itemschema
+--8<--
 DATABASE_URL = "sqlite+aiosqlite:///./test.db"
 engine = create_async_engine(DATABASE_URL, echo=True)
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -32,23 +30,21 @@ async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False
 
 Then your Pydantic schemas
 
-```python title="setup.py" hl_lines="14 15"
+```python title="setup.py" hl_lines="22-27"
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel
 
+
 class Base(DeclarativeBase):
     pass
 
-class Item(Base):
-    __tablename__ = 'items'
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
 
-class ItemCreateSchema(BaseModel):
-    name: str
-
+--8<--
+fastcrud/examples/item/model.py:model
+fastcrud/examples/item/schemas.py:itemschema
+--8<--
 DATABASE_URL = "sqlite+aiosqlite:///./test.db"
 engine = create_async_engine(DATABASE_URL, echo=True)
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -56,23 +52,21 @@ async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False
 
 And, finally, your database connection
 
-```python title="setup.py" hl_lines="17-19"
+```python title="setup.py" hl_lines="30-32"
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel
 
+
 class Base(DeclarativeBase):
     pass
 
-class Item(Base):
-    __tablename__ = 'items'
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
 
-class ItemCreateSchema(BaseModel):
-    name: str
-
+--8<--
+fastcrud/examples/item/model.py:model
+fastcrud/examples/item/schemas.py:itemschema
+--8<--
 DATABASE_URL = "sqlite+aiosqlite:///./test.db"
 engine = create_async_engine(DATABASE_URL, echo=True)
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)

--- a/docs/sqlmodel.md
+++ b/docs/sqlmodel.md
@@ -6,19 +6,16 @@ Wherever in the docs you see a SQLAlchemy model or Pydantic schema being used, y
 
 Define your SQLModel model
 
-```python title="setup.py" hl_lines="5-8"
+```python title="setup.py" hl_lines="6-15"
 from sqlmodel import SQLModel, Field
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.asyncio import AsyncSession
 
-class Item(SQLModel):
-    __tablename__ = 'items'
-    id: int = Field(primary_key=True)
-    name: str
 
-class ItemCreateSchema(SQLModel):
-    name: str
-
+--8<--
+fastcrud/examples/item/sqlmodel.py:model
+fastcrud/examples/item/sqlmodel.py:itemschema
+--8<--
 DATABASE_URL = "sqlite+aiosqlite:///./test.db"
 engine = create_async_engine(DATABASE_URL, echo=True)
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -26,19 +23,16 @@ async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False
 
 Then your schemas
 
-```python title="setup.py" hl_lines="10 11"
+```python title="setup.py" hl_lines="18-23"
 from sqlmodel import SQLModel, Field
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.asyncio import AsyncSession
 
-class Item(SQLModel):
-    __tablename__ = 'items'
-    id: int = Field(primary_key=True)
-    name: str
 
-class ItemCreateSchema(SQLModel):
-    name: str
-
+--8<--
+fastcrud/examples/item/sqlmodel.py:model
+fastcrud/examples/item/sqlmodel.py:itemschema
+--8<--
 DATABASE_URL = "sqlite+aiosqlite:///./test.db"
 engine = create_async_engine(DATABASE_URL, echo=True)
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -46,19 +40,16 @@ async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False
 
 And, finally, your database connection
 
-```python title="setup.py" hl_lines="13-15"
+```python title="setup.py" hl_lines="26-28"
 from sqlmodel import SQLModel, Field
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.asyncio import AsyncSession
 
-class Item(SQLModel):
-    __tablename__ = 'items'
-    id: int = Field(primary_key=True)
-    name: str
 
-class ItemCreateSchema(SQLModel):
-    name: str
-
+--8<--
+fastcrud/examples/item/sqlmodel.py:model
+fastcrud/examples/item/sqlmodel.py:itemschema
+--8<--
 DATABASE_URL = "sqlite+aiosqlite:///./test.db"
 engine = create_async_engine(DATABASE_URL, echo=True)
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)

--- a/docs/usage/crud.md
+++ b/docs/usage/crud.md
@@ -14,9 +14,26 @@ FastCRUD is a versatile tool for handling CRUD (Create, Read, Update, Delete) op
 
 Define your SQLAlchemy models and Pydantic schemas for data representation.
 
-```python
-# SQLAlchemy models and Pydantic schema definitions
-```
+??? example "Models and Schemas Used Below"
+
+    ??? example "`item/model.py`"
+
+        ```python
+        --8<--
+        fastcrud/examples/item/model.py:imports
+        fastcrud/examples/item/model.py:model
+        --8<--
+        ```
+
+    ??? example "`item/schemas.py`"
+
+        ```python
+        --8<--
+        fastcrud/examples/item/schemas.py:imports
+        fastcrud/examples/item/schemas.py:createschema
+        fastcrud/examples/item/schemas.py:updateschema
+        --8<--
+        ```
 
 ### Step 2: Initialize FastCRUD
 
@@ -26,7 +43,7 @@ Create a `FastCRUD` instance for your model to handle CRUD operations.
 from fastcrud import FastCRUD
 
 # Creating a FastCRUD instance
-my_model_crud = FastCRUD(MyModel)
+item_crud = FastCRUD(Item)
 ```
 
 ### Step 3: Pick your Method
@@ -35,7 +52,7 @@ Then you just pick the method you need and use it like this:
 
 ```python
 # Creating a new record
-new_record = await my_model_crud.create(db_session, create_schema_instance)
+new_record = await item_crud.create(db_session, create_schema_instance)
 ```
 
 More on available methods below.
@@ -60,7 +77,7 @@ create(
 **Usage Example**: Creates an item with name `"New Item"`.
 
 ```python
-new_item = await item_crud.create(db, ItemCreateSchema(name="New Item"))
+new_item = await item_crud.create(db, CreateItemSchema(name="New Item"))
 ```
 
 !!! WARNING
@@ -164,7 +181,11 @@ update(
 **Usage Example**: Updates the description of the item with `item_id` as its `id`.
 
 ```python
-await item_crud.update(db, ItemUpdateSchema(description="Updated"), id=item_id)
+await item_crud.update(
+    db,
+    UpdateItemSchema(description="Updated"),
+    id=item_id,
+)
 ```
 
 ### 7. Delete

--- a/docs/usage/endpoint.md
+++ b/docs/usage/endpoint.md
@@ -18,28 +18,24 @@ Before proceeding, ensure you have FastAPI and FastCRUD installed in your enviro
 
 First, define your SQLAlchemy model and corresponding Pydantic schemas for creating and updating data.
 
-```python title="models/item.py"
-from sqlalchemy import Column, Integer, String
-from sqlalchemy.orm import DeclarativeBase
-from pydantic import BaseModel
+???+ example "`item/model.py`"
 
-class Base(DeclarativeBase):
-    pass
+    ```python
+    --8<--
+    fastcrud/examples/item/model.py:imports
+    fastcrud/examples/item/model.py:model
+    --8<--
+    ```
 
-class Item(Base):
-    __tablename__ = 'items'
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
-    description = Column(String)
+???+ example "`item/schemas.py`"
 
-class ItemCreateSchema(BaseModel):
-    name: str
-    description: str
-
-class ItemUpdateSchema(BaseModel):
-    name: str
-    description: str
-```
+    ```python
+    --8<--
+    fastcrud/examples/item/schemas.py:imports
+    fastcrud/examples/item/schemas.py:createschema
+    fastcrud/examples/item/schemas.py:updateschema
+    --8<--
+    ```
 
 ### Step 2: Set Up FastAPI and FastCRUD
 
@@ -80,8 +76,8 @@ app = FastAPI(lifespan=lifespan)
 item_router = crud_router(
     session=get_session,
     model=Item,
-    create_schema=ItemCreateSchema,
-    update_schema=ItemUpdateSchema,
+    create_schema=CreateItemSchema,
+    update_schema=UpdateItemSchema,
     path="/items",
     tags=["Items"],
 )
@@ -107,28 +103,25 @@ Using the `EndpointCreator` class in FastCRUD is a more flexible way to add CRUD
 
 Define your SQLAlchemy models and corresponding Pydantic schemas for data validation.
 
-```python title="models/item.py"
-from sqlalchemy import Column, Integer, String
-from sqlalchemy.orm import DeclarativeBase
-from pydantic import BaseModel
+???+ example "`item/model.py`"
 
-class Base(DeclarativeBase):
-    pass
+    ```python
+    --8<--
+    fastcrud/examples/item/model.py:imports
+    fastcrud/examples/item/model.py:model
+    --8<--
+    ```
 
-class Item(Base):
-    __tablename__ = 'items'
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
-    description = Column(String)
+???+ example "`item/schemas.py`"
 
-class ItemCreateSchema(BaseModel):
-    name: str
-    description: str
-
-class ItemUpdateSchema(BaseModel):
-    name: str
-    description: str
-```
+    ```python
+    --8<--
+    fastcrud/examples/item/schemas.py:imports
+    fastcrud/examples/item/schemas.py:createschema
+    fastcrud/examples/item/schemas.py:updateschema
+    fastcrud/examples/item/schemas.py:deleteschema
+    --8<--
+    ```
 
 ### Step 2: Set Up FastAPI and FastCRUD
 
@@ -162,7 +155,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan)
 
 # CRUD operations setup
-crud = FastCRUD(Item)
+item_crud = FastCRUD(Item)
 ```
 
 ### Step 3: Initialize `EndpointCreator`
@@ -175,13 +168,13 @@ from fastcrud import EndpointCreator
 # Initialize EndpointCreator
 endpoint_creator = EndpointCreator(
     session=get_session,
-    model=YourModel,
-    create_schema=YourCreateSchema,
-    update_schema=YourUpdateSchema,
-    crud=crud,
-    delete_schema=YourDeleteSchema,
-    path="/yourmodelpath",
-    tags=["YourModelTag"],
+    model=Item,
+    create_schema=CreateItemSchema,
+    update_schema=UpdateItemSchema,
+    crud=item_crud,
+    delete_schema=DeleteItemSchema,
+    path="/itempath",
+    tags=["ItemTag"]
 )
 ```
 

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -161,6 +161,12 @@ class FastCRUD(
         ----------------------------
         Implement cursor-based pagination for efficient data retrieval in large datasets.
         ```python
+        class Comment(Base):
+            id = Column(Integer, primary_key=True)
+            user_id = Column(Integer, ForeignKey("user.id"))
+            subject = Column(String)
+            body = Column(String)
+
         comment_crud = FastCRUD(Comment)
 
         first_page = await comment_crud.get_multi_by_cursor(db, limit=10)

--- a/fastcrud/endpoint/crud_router.py
+++ b/fastcrud/endpoint/crud_router.py
@@ -83,8 +83,31 @@ def crud_router(
 
     Examples:
         Basic Setup:
+
+        ??? example "Models and Schemas Used Below"
+
+            ??? example "`mymodel/model.py`"
+
+                ```python
+                --8<--
+                fastcrud/examples/mymodel/model.py:imports
+                fastcrud/examples/mymodel/model.py:model_simple
+                --8<--
+                ```
+
+            ??? example "`mymodel/schemas.py`"
+
+                ```python
+                --8<--
+                fastcrud/examples/mymodel/schemas.py:imports
+                fastcrud/examples/mymodel/schemas.py:createschema
+                fastcrud/examples/mymodel/schemas.py:updateschema
+                fastcrud/examples/mymodel/schemas.py:deleteschema
+                --8<--
+                ```
+
         ```python
-        router = crud_router(
+        mymodel_router = crud_router(
             session=async_session,
             model=MyModel,
             create_schema=CreateMyModelSchema,
@@ -163,16 +186,23 @@ def crud_router(
 
         With Selective CRUD Methods:
         ```python
+        CRUDMyModel = FastCRUD[
+            MyModel,
+            CreateMyModelSchema,
+            UpdateMyModelSchema,
+            UpdateMyModelSchema,
+            DeleteMyModelSchema,
+        ]
         # Only include 'create' and 'read' methods
-        router = crud_router(
+        mymodel_router = crud_router(
             session=async_session,
             model=MyModel,
-            create_schema=CreateMyModel,
-            update_schema=UpdateMyModel,
+            create_schema=CreateMyModelSchema,
+            update_schema=UpdateMyModelSchema,
             crud=CRUDMyModel(MyModel),
-            included_methods=["create", "read"],
             path="/mymodel",
             tags=["MyModel"],
+            included_methods=["create", "read"],
         )
         ```
 
@@ -199,18 +229,25 @@ def crud_router(
                         # Other parameters as needed
                     )
 
-        router = crud_router(
+        CRUDMyModel = FastCRUD[
+            MyModel,
+            CreateMyModelSchema,
+            UpdateMyModelSchema,
+            UpdateMyModelSchema,
+            DeleteMyModelSchema,
+        ]
+        mymodel_router = crud_router(
             session=async_session,
             model=MyModel,
-            create_schema=CreateMyModel,
-            update_schema=UpdateMyModel,
+            create_schema=CreateMyModelSchema,
+            update_schema=UpdateMyModelSchema,
             crud=CRUDMyModel(MyModel),
             path="/mymodel",
             tags=["MyModel"],
             endpoint_creator=CustomEndpointCreator,
         )
 
-        app.include_router(my_router)
+        app.include_router(mymodel_router)
         ```
 
         Customizing Endpoint Names:
@@ -238,21 +275,22 @@ def crud_router(
         ```python
         from fastapi import FastAPI
         from fastcrud import crud_router
-        from myapp.models import MyModel
-        from myapp.schemas import CreateMyModel, UpdateMyModel
-        from myapp.database import async_session
+
+        from .database import async_session
+        from .mymodel.model import MyModel
+        from .mymodel.schemas import CreateMyModelSchema, UpdateMyModelSchema
 
         app = FastAPI()
 
-        router = crud_router(
+        mymodel_router = crud_router(
             session=async_session,
             model=MyModel,
-            create_schema=CreateMyModel,
-            update_schema=UpdateMyModel,
+            create_schema=CreateMyModelSchema,
+            update_schema=UpdateMyModelSchema,
             filter_config=FilterConfig(filters={"id": None, "name": "default"}),
         )
         # Adds CRUD routes with filtering capabilities
-        app.include_router(router, prefix="/mymodel")
+        app.include_router(mymodel_router, prefix="/mymodel")
 
         # Explanation:
         # The FilterConfig specifies that 'id' should be a query parameter with no default value
@@ -265,21 +303,22 @@ def crud_router(
         ```python
         from fastapi import FastAPI
         from fastcrud import crud_router
-        from myapp.models import MyModel
-        from myapp.schemas import CreateMyModel, UpdateMyModel
-        from myapp.database import async_session
+
+        from .database import async_session
+        from .mymodel.model import MyModel
+        from .mymodel.schemas import CreateMyModelSchema, UpdateMyModelSchema
 
         app = FastAPI()
 
-        router = crud_router(
+        mymodel_router = crud_router(
             session=async_session,
             model=MyModel,
-            create_schema=CreateMyModel,
-            update_schema=UpdateMyModel,
+            create_schema=CreateMyModelSchema,
+            update_schema=UpdateMyModelSchema,
             filter_config=FilterConfig(id=None, name="default"),
         )
         # Adds CRUD routes with filtering capabilities
-        app.include_router(router, prefix="/mymodel")
+        app.include_router(mymodel_router, prefix="/mymodel")
 
         # Explanation:
         # The FilterConfig specifies that 'id' should be a query parameter with no default value

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -119,8 +119,8 @@ class EndpointCreator:
         other_endpoint_creator = EndpointCreator(
             session=async_session,
             model=OtherModel,
-            create_schema=CreateOtherModel,
-            update_schema=UpdateOtherModel,
+            create_schema=CreateOtherModelSchema,
+            update_schema=UpdateOtherModelSchema,
             crud=other_model_crud,
         )
         other_endpoint_creator.add_routes_to_router()

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -61,20 +61,40 @@ class EndpointCreator:
 
     Examples:
         Basic Setup:
+
+        ??? example "`mymodel/model.py`"
+
+            ```python
+            --8<--
+            fastcrud/examples/mymodel/model.py:imports
+            fastcrud/examples/mymodel/model.py:model_simple
+            --8<--
+            ```
+
+        ??? example "`mymodel/schemas.py`"
+
+            ```python
+            --8<--
+            fastcrud/examples/mymodel/schemas.py:imports
+            fastcrud/examples/mymodel/schemas.py:createschema
+            fastcrud/examples/mymodel/schemas.py:updateschema
+            --8<--
+            ```
+
         ```python
         from fastapi import FastAPI
         from fastcrud import EndpointCreator
 
-        from myapp.models import MyModel
-        from myapp.schemas import CreateMyModel, UpdateMyModel
-        from myapp.database import async_session
+        from .database import async_session
+        from .mymodel.model import MyModel
+        from .mymodel.schemas import CreateMyModelSchema, UpdateMyModelSchema
 
         app = FastAPI()
         endpoint_creator = EndpointCreator(
             session=async_session,
             model=MyModel,
-            create_schema=CreateMyModel,
-            update_schema=UpdateMyModel,
+            create_schema=CreateMyModelSchema,
+            update_schema=UpdateMyModelSchema,
         )
         endpoint_creator.add_routes_to_router()
         app.include_router(endpoint_creator.router, prefix="/mymodel")
@@ -132,8 +152,8 @@ class EndpointCreator:
         endpoint_creator = EndpointCreator(
             session=async_session,
             model=MyModel,
-            create_schema=CreateMyModel,
-            update_schema=UpdateMyModel,
+            create_schema=CreateMyModelSchema,
+            update_schema=UpdateMyModelSchema,
             path="/mymodel",
             tags=["MyModel"],
             endpoint_names={
@@ -151,16 +171,16 @@ class EndpointCreator:
         from fastapi import FastAPI
         from fastcrud import EndpointCreator, FilterConfig
 
-        from myapp.models import MyModel
-        from myapp.schemas import CreateMyModel, UpdateMyModel
-        from myapp.database import async_session
+        from .database import async_session
+        from .mymodel.model import MyModel
+        from .mymodel.schemas import CreateMyModelSchema, UpdateMyModelSchema
 
         app = FastAPI()
         endpoint_creator = EndpointCreator(
             session=async_session,
             model=MyModel,
-            create_schema=CreateMyModel,
-            update_schema=UpdateMyModel,
+            create_schema=CreateMyModelSchema,
+            update_schema=UpdateMyModelSchema,
             filter_config=FilterConfig(filters={"id": None, "name": "default"}),
         )
         # Adds CRUD routes with filtering capabilities
@@ -180,16 +200,16 @@ class EndpointCreator:
         from fastapi import FastAPI
         from fastcrud import EndpointCreator, FilterConfig
 
-        from myapp.models import MyModel
-        from myapp.schemas: CreateMyModel, UpdateMyModel
-        from myapp.database: async_session
+        from .database import async_session
+        from .mymodel.model import MyModel
+        from .mymodel.schemas import CreateMyModelSchema, UpdateMyModelSchema
 
         app = FastAPI()
         endpoint_creator = EndpointCreator(
             session=async_session,
             model=MyModel,
-            create_schema=CreateMyModel,
-            update_schema=UpdateMyModel,
+            create_schema=CreateMyModelSchema,
+            update_schema=UpdateMyModelSchema,
             filter_config=FilterConfig(id=None, name="default"),
         )
         # Adds CRUD routes with filtering capabilities

--- a/fastcrud/examples/item/model.py
+++ b/fastcrud/examples/item/model.py
@@ -1,0 +1,23 @@
+# --8<-- [start:imports]
+from sqlalchemy import Column, DateTime, Integer, Numeric, String, func
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+# --8<-- [end:imports]
+# --8<-- [start:model]
+class Item(Base):
+    __tablename__ = "items"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    description = Column(String)
+    category = Column(String)
+    price = Column(Numeric)
+    last_sold = Column(DateTime)
+    created_at = Column(DateTime, default=func.now())
+
+
+# --8<-- [end:model]

--- a/fastcrud/examples/item/schemas.py
+++ b/fastcrud/examples/item/schemas.py
@@ -1,0 +1,57 @@
+# --8<-- [start:imports]
+import datetime
+
+from pydantic import BaseModel
+
+
+# --8<-- [end:imports]
+# --8<-- [start:schemas]
+# --8<-- [start:itemschema]
+class ItemSchema(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    category: str | None = None
+    price: float | None = None
+    last_sold: datetime.datetime | None = None
+
+
+# --8<-- [end:itemschema]
+# --8<-- [start:createschema]
+class CreateItemSchema(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    category: str | None = None
+    price: float | None = None
+    last_sold: datetime.datetime | None = None
+
+
+# --8<-- [end:createschema]
+# --8<-- [start:readschema]
+class ReadItemSchema(BaseModel):
+    id: int
+    name: str | None = None
+    description: str | None = None
+    category: str | None = None
+    price: float | None = None
+    last_sold: datetime.datetime | None = None
+    created_at: datetime.datetime
+
+
+# --8<-- [end:readschema]
+# --8<-- [start:updateschema]
+class UpdateItemSchema(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    category: str | None = None
+    price: float | None = None
+    last_sold: datetime.datetime | None = None
+
+
+# --8<-- [end:updateschema]
+# --8<-- [start:deleteschema]
+class DeleteItemSchema(BaseModel):
+    pass
+
+
+# --8<-- [end:deleteschema]
+# --8<-- [end:schemas]

--- a/fastcrud/examples/item/sqlmodel.py
+++ b/fastcrud/examples/item/sqlmodel.py
@@ -1,0 +1,71 @@
+# --8<-- [start:imports]
+import datetime
+
+from sqlmodel import Field, SQLModel, func
+
+
+# --8<-- [end:imports]
+# --8<-- [start:model]
+class Item(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str | None = None
+    description: str | None = None
+    category: str | None = None
+    price: float | None = None
+    last_sold: datetime.datetime | None = None
+    created_at: datetime.datetime = Field(
+        nullable=False, sa_column_kwargs={"default": func.now()}
+    )
+
+
+# --8<-- [end:model]
+# --8<-- [start:schemas]
+# --8<-- [start:itemschema]
+class ItemSchema(SQLModel):
+    name: str | None = None
+    description: str | None = None
+    category: str | None = None
+    price: float | None = None
+    last_sold: datetime.datetime | None = None
+
+
+# --8<-- [end:itemschema]
+# --8<-- [start:createschema]
+class CreateItemSchema(SQLModel):
+    name: str | None = None
+    description: str | None = None
+    category: str | None = None
+    price: float | None = None
+    last_sold: datetime.datetime | None = None
+
+
+# --8<-- [end:createschema]
+# --8<-- [start:readschema]
+class ReadItemSchema(SQLModel):
+    id: int
+    name: str | None = None
+    description: str | None = None
+    category: str | None = None
+    price: float | None = None
+    last_sold: datetime.datetime | None = None
+    created_at: datetime.datetime
+
+
+# --8<-- [end:readschema]
+# --8<-- [start:updateschema]
+class UpdateItemSchema(SQLModel):
+    name: str | None = None
+    description: str | None = None
+    category: str | None = None
+    price: float | None = None
+    last_sold: datetime.datetime | None = None
+
+
+# --8<-- [end:updateschema]
+# --8<-- [start:deleteschema]
+class DeleteItemSchema(SQLModel):
+    pass
+
+
+# --8<-- [end:deleteschema]
+# --8<-- [end:schemas]

--- a/fastcrud/examples/mymodel/model.py
+++ b/fastcrud/examples/mymodel/model.py
@@ -1,0 +1,25 @@
+# --8<-- [start:imports]
+from sqlalchemy import Boolean, Column, DateTime, Integer, String
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+# --8<-- [end:imports]
+# --8<-- [start:model]
+# --8<-- [start:model_softdelete]
+# --8<-- [start:model_simple]
+class MyModel(Base):
+    __tablename__ = "my_model"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    # --8<-- [end:model_simple]
+    archived = Column(Boolean, default=False)  # Custom soft delete column
+    archived_at = Column(DateTime)  # Custom timestamp column for soft delete
+    # --8<-- [end:model_softdelete]
+    date_updated = Column(DateTime)  # Custom timestamp column for update
+
+
+# --8<-- [end:model]

--- a/fastcrud/examples/mymodel/schemas.py
+++ b/fastcrud/examples/mymodel/schemas.py
@@ -1,0 +1,37 @@
+# --8<-- [start:imports]
+import datetime
+
+from pydantic import BaseModel
+
+
+# --8<-- [end:imports]
+# --8<-- [start:schemas]
+# --8<-- [start:createschema]
+class CreateMyModelSchema(BaseModel):
+    name: str | None = None
+
+
+# --8<-- [end:createschema]
+# --8<-- [start:readschema]
+class ReadMyModelSchema(BaseModel):
+    id: int
+    name: str | None = None
+    archived: bool
+    archived_at: datetime.datetime
+    date_updated: datetime.datetime
+
+
+# --8<-- [end:readschema]
+# --8<-- [start:updateschema]
+class UpdateMyModelSchema(BaseModel):
+    name: str | None = None
+
+
+# --8<-- [end:updateschema]
+# --8<-- [start:deleteschema]
+class DeleteMyModelSchema(BaseModel):
+    pass
+
+
+# --8<-- [end:deleteschema]
+# --8<-- [end:schemas]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ markdown_extensions:
   - codehilite
   - toc:
       permalink: true
+  - pymdownx.details:
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
## Description
This is the first batch of models and schemas for #72, covering the simpler, one-off models that don't have relationships. Further PRs will be batched out according to groups of related models.

## Changes

* Add simple example model for `Comment`.
* Correct schema names for `OtherModel`.

  Skipping defining the model/schemas this time, as nothing else uses them and it's irrelevant to just showing an additional endpoint router. I considered changing it to another more commonly used model/schema set, but decided it wasn't worth the hassle of figuring out.
* Add `pymdownx.details` to `mkdocs` config.

  Used for collapsed/folded code blocks as needed for doing multiple file includes via snippets.
* Model, schemas, and doc fixes for `Item`.

  This makes use of the `pymdownx.details` extension to allow for collapsed/folded code example blocks. (Other commits/PRs to come will also use this, but this is the first set.) I also replaced some uses of `MyModel` and `YourModel` (and associated schemas) with `Item` (and etc.) for simplicity, although there will also be some `MyModel` usage in the following commit.
* `MyModel` model, schemas, docs/docstrings.

## Tests

No changes to tests; this is purely in documentation and examples.

## Checklist
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have added necessary documentation (if appropriate).
