### PR TITLE
Correct links to advanced filters in docstrings?

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -431,7 +431,7 @@ class FastCRUD(
 
         This method allows for advanced filtering through comparison operators, enabling queries to be refined beyond simple equality checks.
 
-        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
+        For filtering details see [the Advanced Filters documentation](../advanced/crud.md/#advanced-filters)
 
         Args:
             schema_to_select: Pydantic schema to determine which columns to include in the selection. If not provided, selects all columns of the model.
@@ -493,7 +493,7 @@ class FastCRUD(
 
         This method allows for advanced filtering through comparison operators, enabling queries to be refined beyond simple equality checks.
 
-        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
+        For filtering details see [the Advanced Filters documentation](../advanced/crud.md/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.
@@ -718,7 +718,7 @@ class FastCRUD(
         """
         Checks if any records exist that match the given filter conditions.
 
-        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
+        For filtering details see [the Advanced Filters documentation](../advanced/crud.md/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.
@@ -763,7 +763,7 @@ class FastCRUD(
         """
         Counts records that match specified filters.
 
-        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
+        For filtering details see [the Advanced Filters documentation](../advanced/crud.md/#advanced-filters)
 
         Can also count records based on a configuration of joins, useful for complex queries involving relationships.
 
@@ -886,7 +886,7 @@ class FastCRUD(
         """
         Fetches multiple records based on filters, supporting sorting, pagination.
 
-        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
+        For filtering details see [the Advanced Filters documentation](../advanced/crud.md/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.
@@ -1032,7 +1032,7 @@ class FastCRUD(
         to automatically detect the join condition using foreign key relationships. For multiple joins, use `joins_config` to
         specify each join configuration.
 
-        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
+        For filtering details see [the Advanced Filters documentation](../advanced/crud.md/#advanced-filters)
 
         Args:
             db: The SQLAlchemy async session.
@@ -1339,7 +1339,7 @@ class FastCRUD(
         """
         Fetch multiple records with a join on another model, allowing for pagination, optional sorting, and model conversion.
 
-        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
+        For filtering details see [the Advanced Filters documentation](../advanced/crud.md/#advanced-filters)
 
         Args:
             db: The SQLAlchemy async session.
@@ -1720,7 +1720,7 @@ class FastCRUD(
         """
         Implements cursor-based pagination for fetching records. This method is designed for efficient data retrieval in large datasets and is ideal for features like infinite scrolling.
 
-        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
+        For filtering details see [the Advanced Filters documentation](../advanced/crud.md/#advanced-filters)
 
         Args:
             db: The SQLAlchemy async session.
@@ -1830,7 +1830,7 @@ class FastCRUD(
         """
         Updates an existing record or multiple records in the database based on specified filters. This method allows for precise targeting of records to update.
 
-        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
+        For filtering details see [the Advanced Filters documentation](../advanced/crud.md/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.
@@ -2000,7 +2000,7 @@ class FastCRUD(
         """
         Deletes a record or multiple records from the database based on specified filters.
 
-        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
+        For filtering details see [the Advanced Filters documentation](../advanced/crud.md/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.
@@ -2060,7 +2060,7 @@ class FastCRUD(
         """
         Soft deletes a record or optionally multiple records if it has an `"is_deleted"` attribute, otherwise performs a hard delete, based on specified filters.
 
-        For filtering details see [the Advanced Filters documentation](../../advanced/crud/#advanced-filters)
+        For filtering details see [the Advanced Filters documentation](../advanced/crud.md/#advanced-filters)
 
         Args:
             db: The database session to use for the operation.


### PR DESCRIPTION
## Description

(Possibly?) corrected relative links from `fast_crud.py`'s docstrings to the section of the docs covering advanced filters.

## Changes

This is a possible correction to #124: `mkdocs` complains about not recognizing the relative links' destination. The recommendation it provides didn't quite make sense to me relative to the URL structure as rendered, but it apparently automatically substituted it in and it appeared to work, so I just left them as I'd written them.

Now, I realize now that it may be more about the actual structure of the filesystem getting from `api/fastcrud.md` (which contains the includes from the code's docstrings) to `advanced/crud.md`, and `mkdocs` handles translating the file paths to URLs. So I put this PR together to fix the links and you can figure out whether or not it needs to go in. :D

## Tests

No changes.

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have added necessary documentation (if appropriate).

## Additional Notes

As noted above, I'm not 100% certain just how correct/needed this is; I'm pretty sure, since `mkdocs` has stopped complaining, but the links in the rendered pages worked either way and I can't tell if that's because it doesn't matter or just that `mkdocs` is cleverer than I am and was covering for my mistakes.