### PR TITLE
kwargs missing type

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -424,7 +424,7 @@ class FastCRUD(
         schema_to_select: Optional[type[BaseModel]] = None,
         sort_columns: Optional[Union[str, list[str]]] = None,
         sort_orders: Optional[Union[str, list[str]]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> Select:
         """
         Constructs a SQL Alchemy `Select` statement with optional column selection, filtering, and sorting.


### PR DESCRIPTION
## Description

Noticed `griffe` complaining about not having a type annotation for `**kwargs` in `fast_crud.py`'s `select()` while compiling docs, so putting this tiny PR together to backfill that.

## Changes

Added type annotation to a `kwargs` parameter.

## Checklist
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] All new and existing tests passed. (Within the bounds of my comment to #110 about the new surprise stealth Docker dev-dep.)
