### PR TITLE
Add collapsed space for models/schemas in `fast_crud.py`

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -104,6 +104,8 @@ class FastCRUD(
             Soft deletes a record if it has an `"is_deleted"` attribute (or other attribute as defined by `is_deleted_column`); otherwise, performs a hard delete.
 
     Examples:
+        ??? example "Models and Schemas Used Below"
+
             ??? example "`customer/model.py`"
 
                 ```python

--- a/fastcrud/endpoint/crud_router.py
+++ b/fastcrud/endpoint/crud_router.py
@@ -82,8 +82,6 @@ def crud_router(
         ValueError: If both `included_methods` and `deleted_methods` are provided.
 
     Examples:
-        Basic Setup:
-
         ??? example "Models and Schemas Used Below"
 
             ??? example "`mymodel/model.py`"
@@ -170,6 +168,8 @@ def crud_router(
                 fastcrud/examples/order/schemas.py:deleteschema
                 --8<--
                 ```
+
+        Basic Setup:
 
         ```python
         mymodel_router = crud_router(


### PR DESCRIPTION
## Description

Breaking this out from #130 in an admittedly possibly unnecessary attempt to keep each of the PRs I'm doing smaller and more specifically focused on a single thing.

## Changes

Adding a collapsed example space in `fast_crud.py`'s docstring, akin to what's already in `crud_router.py` from #127, for includes of models/schemas to be added into in other PRs.

## Checklist
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have added necessary documentation (if appropriate).
