### PR TITLE
Make `is_deleted` Field Optional and Configurable in Soft Delete Logic

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -2343,7 +2343,7 @@ class FastCRUD(
                 f"Expected exactly one record to delete, found {total_count}."
             )
 
-        update_values = {}
+        update_values: dict[str, Union[bool, datetime]] = {}
         if self.deleted_at_column in self.model_col_names:
             update_values[self.deleted_at_column] = datetime.now(timezone.utc)
         if self.is_deleted_column in self.model_col_names:


### PR DESCRIPTION
# Pull Request Template for FastCRUD

## Description
This pull request introduces changes to make the is_deleted field optional and configurable in the soft delete logic of the FastCRUD class. This issues https://github.com/igorbenav/fastcrud/issues/88

## Changes
Added logic to conditionally update the is_deleted column based on its presence in the configuration.
Updated the soft delete process to only set the is_deleted field if it is explicitly configured.

## Tests
No new tests have been added yet

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] All new and existing tests passed.

