### PR TITLE
Add update override arg to upsert_multi

### DIFF
--- a/tests/sqlalchemy/crud/test_upsert.py
+++ b/tests/sqlalchemy/crud/test_upsert.py
@@ -73,6 +73,35 @@ async def test_upsert_successful(async_session, test_model, read_schema):
             {
                 "kwargs": {
                     "return_columns": ["id", "name"],
+                    "update_override": {"name": "New"},
+                },
+                "expected_result": {
+                    "data": [
+                        {
+                            "id": 1,
+                            "name": "New",
+                        }
+                    ]
+                },
+            },
+            marks=pytest.mark.dialect("postgresql"),
+            id="postgresql-dict-update-override",
+        ),
+        pytest.param(
+            {
+                "kwargs": {"return_columns": ["id", "name"]},
+                "expected_result": {
+                    "data": [
+                        {
+                            "id": 1,
+                            "name": "New Record",
+                        }
+                    ]
+                },
+            },
+            {
+                "kwargs": {
+                    "return_columns": ["id", "name"],
                     "name__match": "NewRecord",
                 },
                 "expected_result": {"data": []},
@@ -161,6 +190,35 @@ async def test_upsert_successful(async_session, test_model, read_schema):
             {
                 "kwargs": {
                     "return_columns": ["id", "name"],
+                    "update_override": {"name": "New"},
+                },
+                "expected_result": {
+                    "data": [
+                        {
+                            "id": 1,
+                            "name": "New",
+                        }
+                    ]
+                },
+            },
+            marks=pytest.mark.dialect("sqlite"),
+            id="sqlite-dict-update-override",
+        ),
+        pytest.param(
+            {
+                "kwargs": {"return_columns": ["id", "name"]},
+                "expected_result": {
+                    "data": [
+                        {
+                            "id": 1,
+                            "name": "New Record",
+                        }
+                    ]
+                },
+            },
+            {
+                "kwargs": {
+                    "return_columns": ["id", "name"],
                     "name__like": "NewRecord",
                 },
                 "expected_result": {"data": []},
@@ -207,6 +265,18 @@ async def test_upsert_successful(async_session, test_model, read_schema):
             },
             marks=pytest.mark.dialect("mysql"),
             id="mysql-none",
+        ),
+        pytest.param(
+            {
+                "kwargs": {},
+                "expected_result": None,
+            },
+            {
+                "kwargs": {"update_override": {"name": "New"}},
+                "expected_result": None,
+            },
+            marks=pytest.mark.dialect("mysql"),
+            id="mysql-dict-update-override",
         ),
     ],
 )


### PR DESCRIPTION
## Description

This is about allowing overrides to the update logic of the SQL query of the `upsert_multi` operation. This is useful if you have more custom logic to update on, such as when using `case` statements.

```python
# If the model we are inserting has a manually set name, we default to the
# existing value, otherwise, we insert the new value.
update_override={"name": case(
    (fast_crud.model.name.is_(None), stmt.excluded.name),
    else_=fast_crud.model.name,
)}
```

## Changes

Add `update_override` arg to `upsert_multi` and implement it for all three currently supported dialects i.e. postgresql, sqlite, and mysql.

## Tests

I have added one test per dialect that validates that `update_override` is being respected and updates the value regardless of the default logic.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.
