### PR TITLE
Add missing commit to update

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -2222,6 +2222,8 @@ class FastCRUD(
         if return_columns:
             stmt = stmt.returning(*[column(name) for name in return_columns])
             db_row = await db.execute(stmt)
+            if commit:
+                await db.commit()
             if allow_multiple:
                 return self._as_multi_response(
                     db_row,

--- a/tests/sqlalchemy/crud/test_update.py
+++ b/tests/sqlalchemy/crud/test_update.py
@@ -276,3 +276,7 @@ async def test_update_with_returning(
     )
 
     assert updated_record == expected_result
+
+    # Rollback the current transaction to see if the record was actually committed
+    await async_session.rollback()
+    assert await crud.count(async_session, name="Updated Name") == 1


### PR DESCRIPTION
## Description

fixes: https://github.com/igorbenav/fastcrud/issues/168

## Changes

Add the option to commit the update when `return_columns` or `return_as_model` is used.

## Tests

I have added a test that manually rolls back the current transaction to see if the record was updated and committed.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.