### PR TITLE
Improve update method when item is not found

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -2145,6 +2145,7 @@ class FastCRUD(
 
         Raises:
             MultipleResultsFound: If `allow_multiple` is `False` and more than one record matches the filters.
+            NoResultFound: If no record matches the filters.
             ValueError: If extra fields not present in the model are provided in the update data.
             ValueError: If `return_as_model` is `True` but `schema_to_select` is not provided.
 
@@ -2199,7 +2200,10 @@ class FastCRUD(
             )
             ```
         """
-        if not allow_multiple and (total_count := await self.count(db, **kwargs)) > 1:
+        total_count = await self.count(db, **kwargs)
+        if total_count == 0:
+            raise NoResultFound("No record found to update.")
+        if not allow_multiple and total_count > 1:
             raise MultipleResultsFound(
                 f"Expected exactly one record to update, found {total_count}."
             )

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Generic, Union, Optional, Callable
 from datetime import datetime, timezone
+import warnings
 
 from pydantic import BaseModel, ValidationError
 from sqlalchemy import (
@@ -2202,7 +2203,12 @@ class FastCRUD(
         """
         total_count = await self.count(db, **kwargs)
         if total_count == 0:
-            raise NoResultFound("No record found to update.")
+            warnings.warn(
+                "Passing non-existing records to `update` will raise NoResultFound on version 0.15.3.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            # raise NoResultFound("No record found to update.")
         if not allow_multiple and total_count > 1:
             raise MultipleResultsFound(
                 f"Expected exactly one record to update, found {total_count}."

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -2146,7 +2146,7 @@ class FastCRUD(
 
         Raises:
             MultipleResultsFound: If `allow_multiple` is `False` and more than one record matches the filters.
-            NoResultFound: If no record matches the filters.
+            NoResultFound: If no record matches the filters. (on version 0.15.3)
             ValueError: If extra fields not present in the model are provided in the update data.
             ValueError: If `return_as_model` is `True` but `schema_to_select` is not provided.
 

--- a/tests/sqlalchemy/crud/test_get_multi_by_cursor.py
+++ b/tests/sqlalchemy/crud/test_get_multi_by_cursor.py
@@ -124,7 +124,7 @@ async def test_get_multi_by_cursor_pagination_integrity(async_session, test_data
         db=async_session,
         object={"name": "Updated Name"},
         allow_multiple=True,
-        name="SpecificName",
+        name=test_data[0]["name"],
     )
 
     second_batch = await crud.get_multi_by_cursor(

--- a/tests/sqlalchemy/crud/test_update.py
+++ b/tests/sqlalchemy/crud/test_update.py
@@ -2,7 +2,8 @@ from datetime import datetime, timezone
 import pytest
 
 from sqlalchemy import select
-from sqlalchemy.exc import MultipleResultsFound
+from sqlalchemy.exc import MultipleResultsFound, NoResultFound
+
 
 from fastcrud.crud.fast_crud import FastCRUD
 from ...sqlalchemy.conftest import ModelTest, UpdateSchemaTest, ModelTestWithTimestamp
@@ -51,12 +52,11 @@ async def test_update_non_existent_record(async_session, test_data):
     crud = FastCRUD(ModelTest)
     non_existent_id = 99999
     updated_data = {"name": "New Name"}
-    await crud.update(db=async_session, object=updated_data, id=non_existent_id)
 
-    record = await async_session.execute(
-        select(ModelTest).where(ModelTest.id == non_existent_id)
-    )
-    assert record.scalar_one_or_none() is None
+    with pytest.raises(NoResultFound) as exc_info:
+        await crud.update(db=async_session, object=updated_data, id=non_existent_id)
+
+    assert "No record found to update" in str(exc_info.value)
 
 
 @pytest.mark.asyncio
@@ -69,14 +69,10 @@ async def test_update_invalid_filters(async_session, test_data):
     updated_data = {"name": "New Name"}
 
     non_matching_filter = {"name": "NonExistingName"}
-    await crud.update(db=async_session, object=updated_data, **non_matching_filter)
+    with pytest.raises(NoResultFound) as exc_info:
+        await crud.update(db=async_session, object=updated_data, **non_matching_filter)
 
-    for item in test_data:
-        record = await async_session.execute(
-            select(ModelTest).where(ModelTest.id == item["id"])
-        )
-        fetched_record = record.scalar_one()
-        assert fetched_record.name != "New Name"
+    assert "No record found to update" in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/sqlalchemy/crud/test_update.py
+++ b/tests/sqlalchemy/crud/test_update.py
@@ -2,8 +2,7 @@ from datetime import datetime, timezone
 import pytest
 
 from sqlalchemy import select
-from sqlalchemy.exc import MultipleResultsFound, NoResultFound
-
+from sqlalchemy.exc import MultipleResultsFound
 
 from fastcrud.crud.fast_crud import FastCRUD
 from ...sqlalchemy.conftest import ModelTest, UpdateSchemaTest, ModelTestWithTimestamp
@@ -52,11 +51,24 @@ async def test_update_non_existent_record(async_session, test_data):
     crud = FastCRUD(ModelTest)
     non_existent_id = 99999
     updated_data = {"name": "New Name"}
+    """
+    In version 0.15.3, the `update` method will raise a `NoResultFound` exception:
 
+    ```
     with pytest.raises(NoResultFound) as exc_info:
         await crud.update(db=async_session, object=updated_data, id=non_existent_id)
 
     assert "No record found to update" in str(exc_info.value)
+    ```
+
+    For 0.15.2, the test will check if the record is not updated.
+    """
+    await crud.update(db=async_session, object=updated_data, id=non_existent_id)
+
+    record = await async_session.execute(
+        select(ModelTest).where(ModelTest.id == non_existent_id)
+    )
+    assert record.scalar_one_or_none() is None
 
 
 @pytest.mark.asyncio
@@ -69,10 +81,26 @@ async def test_update_invalid_filters(async_session, test_data):
     updated_data = {"name": "New Name"}
 
     non_matching_filter = {"name": "NonExistingName"}
+    """
+    In version 0.15.3, the `update` method will raise a `NoResultFound` exception:
+
+    ```
     with pytest.raises(NoResultFound) as exc_info:
         await crud.update(db=async_session, object=updated_data, **non_matching_filter)
 
     assert "No record found to update" in str(exc_info.value)
+    ```
+
+    For 0.15.2, the test will check if the record is not updated.
+    """
+    await crud.update(db=async_session, object=updated_data, **non_matching_filter)
+
+    for item in test_data:
+        record = await async_session.execute(
+            select(ModelTest).where(ModelTest.id == item["id"])
+        )
+        fetched_record = record.scalar_one()
+        assert fetched_record.name != "New Name"
 
 
 @pytest.mark.asyncio

--- a/tests/sqlmodel/crud/test_get_multi_by_cursor.py
+++ b/tests/sqlmodel/crud/test_get_multi_by_cursor.py
@@ -124,7 +124,7 @@ async def test_get_multi_by_cursor_pagination_integrity(async_session, test_data
         db=async_session,
         object={"name": "Updated Name"},
         allow_multiple=True,
-        name="SpecificName",
+        name=test_data[0]["name"],
     )
 
     second_batch = await crud.get_multi_by_cursor(

--- a/tests/sqlmodel/crud/test_update.py
+++ b/tests/sqlmodel/crud/test_update.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 import pytest
 
 from sqlalchemy import select
-from sqlalchemy.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.exc import MultipleResultsFound
 
 from fastcrud.crud.fast_crud import FastCRUD
 from ...sqlmodel.conftest import ModelTest, UpdateSchemaTest, ModelTestWithTimestamp
@@ -51,11 +51,24 @@ async def test_update_non_existent_record(async_session, test_data):
     crud = FastCRUD(ModelTest)
     non_existent_id = 99999
     updated_data = {"name": "New Name"}
+    """
+    In version 0.15.3, the `update` method will raise a `NoResultFound` exception:
 
+    ```
     with pytest.raises(NoResultFound) as exc_info:
         await crud.update(db=async_session, object=updated_data, id=non_existent_id)
 
     assert "No record found to update" in str(exc_info.value)
+    ```
+
+    For 0.15.2, the test will check if the record is not updated.
+    """
+    await crud.update(db=async_session, object=updated_data, id=non_existent_id)
+
+    record = await async_session.execute(
+        select(ModelTest).where(ModelTest.id == non_existent_id)
+    )
+    assert record.scalar_one_or_none() is None
 
 
 @pytest.mark.asyncio
@@ -68,11 +81,26 @@ async def test_update_invalid_filters(async_session, test_data):
     updated_data = {"name": "New Name"}
 
     non_matching_filter = {"name": "NonExistingName"}
+    """
+    In version 0.15.3, the `update` method will raise a `NoResultFound` exception:
 
+    ```
     with pytest.raises(NoResultFound) as exc_info:
         await crud.update(db=async_session, object=updated_data, **non_matching_filter)
 
     assert "No record found to update" in str(exc_info.value)
+    ```
+
+    For 0.15.2, the test will check if the record is not updated.
+    """
+    await crud.update(db=async_session, object=updated_data, **non_matching_filter)
+
+    for item in test_data:
+        record = await async_session.execute(
+            select(ModelTest).where(ModelTest.id == item["id"])
+        )
+        fetched_record = record.scalar_one()
+        assert fetched_record.name != "New Name"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Pull Request Template for FastCRUD

## Description
Improve the behaviour of CRUD `update` method when the filtered item for update is not found.

It was requested (and closes #137) to keep consistency with the CRUD `delete` method.

## Changes
Raise exception `NoResultFound` when the filters for the object to update don't match any items.

## Tests
Updated:
`sqlalchemy/crud/test_update.py`: `test_update_non_existent_record`, `test_update_invalid_filters`
`sqlalchemy/crud/test_get_multi_by_cursor.py`:  `test_test_get_multi_by_cursor_pagination_integrity`

`sqlmodel/crud/test_update.py`: `test_update_non_existent_record`, `test_update_invalid_filters`
`sqlmodel/crud/test_get_multi_by_cursor.py`:  `test_test_get_multi_by_cursor_pagination_integrity`

## Checklist
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have added tests that cover my changes (if applicable).
- [X] All new and existing tests passed.

## Additional Notes
Include any additional information that you think is important for reviewers to know.
