### PR TITLE
fix: default page or items_per_page for when paginating using the get on list

### DIFF
--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -352,7 +352,7 @@ class EndpointCreator:
             ),
             filters: dict = Depends(dynamic_filters),
         ):
-            is_paginated = (page is not None) and (items_per_page is not None)
+            is_paginated = (page is not None) or (items_per_page is not None)
             has_offset_limit = (offset is not None) and (limit is not None)
 
             if is_paginated and has_offset_limit:
@@ -361,6 +361,10 @@ class EndpointCreator:
                 )
 
             if is_paginated:
+                if not page:
+                    page = 1
+                if not items_per_page:
+                    items_per_page = 10
                 offset = compute_offset(page=page, items_per_page=items_per_page)  # type: ignore
                 limit = items_per_page
                 crud_data = await self.crud.get_multi(

--- a/tests/sqlmodel/endpoint/test_get_paginated.py
+++ b/tests/sqlmodel/endpoint/test_get_paginated.py
@@ -87,3 +87,69 @@ async def test_read_items_with_pagination_and_filters(
 
     for item in data["data"]:
         assert item["name"] == name
+
+
+@pytest.mark.asyncio
+async def test_read_items_with_only_items_per_page_on_pagination(
+    client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    items_per_page = 1
+
+    response = client.get(f"/test/get_multi?&itemsPerPage={items_per_page}")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= items_per_page
+
+    test_item = test_data[0]
+    assert any(item["name"] == test_item["name"] for item in data["data"])
+
+    assert data["page"] == 1
+    assert data["items_per_page"] == items_per_page
+
+
+@pytest.mark.asyncio
+async def test_read_items_with_only_page_on_pagination(
+    client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    page = 1
+
+    response = client.get(f"/test/get_multi?&page={page}")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= 10
+
+    test_item = test_data[0]
+    assert any(item["name"] == test_item["name"] for item in data["data"])
+
+    assert data["page"] == page
+    assert data["items_per_page"] == 10


### PR DESCRIPTION
# Pull Request Template for FastCRUD

## Description
fixes: https://github.com/igorbenav/fastcrud/issues/175

## Changes
Added default values for pagination (for when filling just page_number or just items_per_page)

## Tests
Added tests to validate default page or default items_per_page on get list usage.

## Checklist
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have added necessary documentation (if appropriate).
- [X] I have added tests that cover my changes (if applicable).
- [X] All new and existing tests passed.

## Additional Notes
.
