### PR TITLE
Some fixes

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Generic, Union, Optional, Callable
 from datetime import datetime, timezone
-import warnings
 
 from pydantic import ValidationError
 from sqlalchemy import (
@@ -2206,12 +2205,7 @@ class FastCRUD(
         """
         total_count = await self.count(db, **kwargs)
         if total_count == 0:
-            warnings.warn(
-                "Passing non-existing records to `update` will raise NoResultFound on version 0.15.3.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            # raise NoResultFound("No record found to update.")
+            raise NoResultFound("No record found to update.")
         if not allow_multiple and total_count > 1:
             raise MultipleResultsFound(
                 f"Expected exactly one record to update, found {total_count}."

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -32,6 +32,8 @@ from fastcrud.types import (
     SelectSchemaType,
     UpdateSchemaInternalType,
     UpdateSchemaType,
+    GetMultiResponseModel,
+    GetMultiResponseDict,
 )
 
 from .helper import (
@@ -1148,7 +1150,7 @@ class FastCRUD(
         return_as_model: bool = False,
         return_total_count: bool = True,
         **kwargs: Any,
-    ) -> dict[str, Any]:
+    ) -> Union[GetMultiResponseModel[SelectSchemaType], GetMultiResponseDict]:
         """
         Fetches multiple records based on filters, supporting sorting, pagination.
 
@@ -1166,7 +1168,10 @@ class FastCRUD(
             **kwargs: Filters to apply to the query, including advanced comparison operators for more detailed querying.
 
         Returns:
-            A dictionary containing `"data"` with fetched records and `"total_count"` indicating the total number of records matching the filters.
+            A dictionary containing the data list and optionally the total count:
+            - With return_as_model=True: Dict with "data": List[SelectSchemaType]
+            - With return_as_model=False: Dict with "data": List[Dict[str, Any]]
+            - If return_total_count=True, includes "total_count": int
 
         Raises:
             ValueError: If `limit` or `offset` is negative, or if `schema_to_select` is required but not provided or invalid.

--- a/fastcrud/types.py
+++ b/fastcrud/types.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Any
+from typing import TypeVar, Any, Dict, Union, List
 
 from pydantic import BaseModel
 
@@ -9,3 +9,6 @@ CreateSchemaType = TypeVar("CreateSchemaType", bound=BaseModel)
 UpdateSchemaType = TypeVar("UpdateSchemaType", bound=BaseModel)
 UpdateSchemaInternalType = TypeVar("UpdateSchemaInternalType", bound=BaseModel)
 DeleteSchemaType = TypeVar("DeleteSchemaType", bound=BaseModel)
+
+GetMultiResponseDict = Dict[str, Union[List[Dict[str, Any]], int]]
+GetMultiResponseModel = Dict[str, Union[List[SelectSchemaType], int]]

--- a/tests/sqlalchemy/core/test_uuid.py
+++ b/tests/sqlalchemy/core/test_uuid.py
@@ -8,6 +8,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from fastcrud import crud_router, FastCRUD
+from fastcrud import FilterConfig
+from fastcrud.endpoint.helper import _create_dynamic_filters
 from pydantic import BaseModel
 
 from ..conftest import Base
@@ -202,3 +204,43 @@ async def test_uuid_list_endpoint(uuid_client):
             UUID(item["id"])
         except ValueError:  # pragma: no cover
             pytest.fail("Invalid UUID format in list response")
+
+
+def test_create_dynamic_filters_type_conversion():
+    filter_config = FilterConfig(uuid_field=None, int_field=None, str_field=None)
+    column_types = {
+        "uuid_field": UUID,
+        "int_field": int,
+        "str_field": str,
+    }
+
+    filters_func = _create_dynamic_filters(filter_config, column_types)
+
+    test_uuid = "123e4567-e89b-12d3-a456-426614174000"
+    result = filters_func(uuid_field=test_uuid, int_field="123", str_field=456)
+
+    assert isinstance(result["uuid_field"], UUID)
+    assert result["uuid_field"] == UUID(test_uuid)
+    assert isinstance(result["int_field"], int)
+    assert result["int_field"] == 123
+    assert isinstance(result["str_field"], str)
+    assert result["str_field"] == "456"
+
+    result = filters_func(
+        uuid_field="not-a-uuid", int_field="not-an-int", str_field=456
+    )
+
+    assert result["uuid_field"] == "not-a-uuid"
+    assert result["int_field"] == "not-an-int"
+    assert isinstance(result["str_field"], str)
+
+    result = filters_func(uuid_field=None, int_field="123", str_field=None)
+    assert "uuid_field" not in result
+    assert result["int_field"] == 123
+    assert "str_field" not in result
+
+    result = filters_func(unknown_field="test")
+    assert result["unknown_field"] == "test"
+
+    empty_filters_func = _create_dynamic_filters(None, {})
+    assert empty_filters_func() == {}

--- a/tests/sqlalchemy/crud/test_update.py
+++ b/tests/sqlalchemy/crud/test_update.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 import pytest
 
 from sqlalchemy import select
-from sqlalchemy.exc import MultipleResultsFound
+from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 
 from fastcrud.crud.fast_crud import FastCRUD
 from ...sqlalchemy.conftest import ModelTest, UpdateSchemaTest, ModelTestWithTimestamp
@@ -51,24 +51,11 @@ async def test_update_non_existent_record(async_session, test_data):
     crud = FastCRUD(ModelTest)
     non_existent_id = 99999
     updated_data = {"name": "New Name"}
-    """
-    In version 0.15.3, the `update` method will raise a `NoResultFound` exception:
 
-    ```
     with pytest.raises(NoResultFound) as exc_info:
         await crud.update(db=async_session, object=updated_data, id=non_existent_id)
 
     assert "No record found to update" in str(exc_info.value)
-    ```
-
-    For 0.15.2, the test will check if the record is not updated.
-    """
-    await crud.update(db=async_session, object=updated_data, id=non_existent_id)
-
-    record = await async_session.execute(
-        select(ModelTest).where(ModelTest.id == non_existent_id)
-    )
-    assert record.scalar_one_or_none() is None
 
 
 @pytest.mark.asyncio
@@ -81,26 +68,10 @@ async def test_update_invalid_filters(async_session, test_data):
     updated_data = {"name": "New Name"}
 
     non_matching_filter = {"name": "NonExistingName"}
-    """
-    In version 0.15.3, the `update` method will raise a `NoResultFound` exception:
-
-    ```
     with pytest.raises(NoResultFound) as exc_info:
         await crud.update(db=async_session, object=updated_data, **non_matching_filter)
 
     assert "No record found to update" in str(exc_info.value)
-    ```
-
-    For 0.15.2, the test will check if the record is not updated.
-    """
-    await crud.update(db=async_session, object=updated_data, **non_matching_filter)
-
-    for item in test_data:
-        record = await async_session.execute(
-            select(ModelTest).where(ModelTest.id == item["id"])
-        )
-        fetched_record = record.scalar_one()
-        assert fetched_record.name != "New Name"
 
 
 @pytest.mark.asyncio

--- a/tests/sqlmodel/crud/test_update.py
+++ b/tests/sqlmodel/crud/test_update.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 import pytest
 
 from sqlalchemy import select
-from sqlalchemy.exc import MultipleResultsFound
+from sqlalchemy.exc import MultipleResultsFound, NoResultFound
 
 from fastcrud.crud.fast_crud import FastCRUD
 from ...sqlmodel.conftest import ModelTest, UpdateSchemaTest, ModelTestWithTimestamp
@@ -51,24 +51,11 @@ async def test_update_non_existent_record(async_session, test_data):
     crud = FastCRUD(ModelTest)
     non_existent_id = 99999
     updated_data = {"name": "New Name"}
-    """
-    In version 0.15.3, the `update` method will raise a `NoResultFound` exception:
 
-    ```
     with pytest.raises(NoResultFound) as exc_info:
         await crud.update(db=async_session, object=updated_data, id=non_existent_id)
 
     assert "No record found to update" in str(exc_info.value)
-    ```
-
-    For 0.15.2, the test will check if the record is not updated.
-    """
-    await crud.update(db=async_session, object=updated_data, id=non_existent_id)
-
-    record = await async_session.execute(
-        select(ModelTest).where(ModelTest.id == non_existent_id)
-    )
-    assert record.scalar_one_or_none() is None
 
 
 @pytest.mark.asyncio
@@ -81,26 +68,11 @@ async def test_update_invalid_filters(async_session, test_data):
     updated_data = {"name": "New Name"}
 
     non_matching_filter = {"name": "NonExistingName"}
-    """
-    In version 0.15.3, the `update` method will raise a `NoResultFound` exception:
 
-    ```
     with pytest.raises(NoResultFound) as exc_info:
         await crud.update(db=async_session, object=updated_data, **non_matching_filter)
 
     assert "No record found to update" in str(exc_info.value)
-    ```
-
-    For 0.15.2, the test will check if the record is not updated.
-    """
-    await crud.update(db=async_session, object=updated_data, **non_matching_filter)
-
-    for item in test_data:
-        record = await async_session.execute(
-            select(ModelTest).where(ModelTest.id == item["id"])
-        )
-        fetched_record = record.scalar_one()
-        assert fetched_record.name != "New Name"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #126, #123

- Get multi with return_as_model is now properly typed
- Filter with a UUID that is not a primary key now working
- Update with not found record now raise error as previously defined by warning