### PR TITLE
Models and Schemas, Batch 5: Projects and Participants

### DIFF
--- a/docs/advanced/crud.md
+++ b/docs/advanced/crud.md
@@ -609,6 +609,16 @@ This order ensures that the SQL joins are structured correctly to reflect the ma
 
     Note that the first one can be the model defined in `FastCRUD(Model)`.
 
+??? example "Models"
+
+    ```python
+    --8<--
+    tests/sqlalchemy/conftest.py:model_project
+    tests/sqlalchemy/conftest.py:model_participant
+    tests/sqlalchemy/conftest.py:model_proj_parts_assoc
+    --8<--
+    ```
+
 ```python
 # Fetch projects with their participants via a many-to-many relationship
 joins_config = [
@@ -626,11 +636,16 @@ joins_config = [
     ),
 ]
 
-crud_project = FastCRUD(Project)
+project_crud = FastCRUD(Project)
+
+class ReadProjectSchema(BaseModel):
+    id: int
+    name: str
+    description: Optional[str] = None
 
 projects_with_participants = await project_crud.get_multi_joined(
     db=db,
-    schema_to_select=ProjectSchema,
+    schema_to_select=ReadProjectSchema,
     joins_config=joins_config,
 )
 ```

--- a/docs/usage/crud.md
+++ b/docs/usage/crud.md
@@ -445,8 +445,18 @@ count(
 **Purpose**: To count records that match specified filters, especially useful in scenarios involving joins between models. This method supports counting unique entities across relationships, a common requirement in many-to-many or complex relationships.  
 **Usage Example**: Count the number of unique projects a participant is involved in, considering a many-to-many relationship between `Project` and `Participant` models.
 
+??? example "Models"
+
+    ```python
+    --8<--
+    tests/sqlalchemy/conftest.py:model_project
+    tests/sqlalchemy/conftest.py:model_participant
+    tests/sqlalchemy/conftest.py:model_proj_parts_assoc
+    --8<--
+    ```
+
 ```python
-# Assuming a Project model related to a Participant model through a many-to-many relationship
+project_crud = FastCRUD(Project)
 projects_count = await project_crud.count(
     db=session,
     joins_config=[

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -312,6 +312,28 @@ class FastCRUD(
                 --8<--
                 ```
 
+            ---
+
+            ??? example "`Project`, `Participant`, `ProjectsParticipantsAssociation`"
+
+                ```python
+                # These models taken from tests/sqlalchemy/conftest.py
+                --8<--
+                tests/sqlalchemy/conftest.py:model_project
+                tests/sqlalchemy/conftest.py:model_participant
+                tests/sqlalchemy/conftest.py:model_proj_parts_assoc
+                --8<--
+                ```
+
+            ??? example "`ReadProjectSchema`"
+
+                ```python
+                class ReadProjectSchema(BaseModel):
+                    id: int
+                    name: str
+                    description: Optional[str] = None
+                ```
+
         Example 1: Basic Usage
         ----------------------
 
@@ -1060,6 +1082,7 @@ class FastCRUD(
             ```
 
             Count projects with at least one participant (many-to-many relationship):
+
             ```python
             joins_config = [
                 JoinConfig(
@@ -1073,10 +1096,12 @@ class FastCRUD(
                     join_type="inner",
                 ),
             ]
-            count = await crud.count(db, joins_config=joins_config)
+            project_crud = FastCRUD(Project)
+            count = await project_crud.count(db, joins_config=joins_config)
             ```
 
             Count projects by a specific participant name (filter applied on a joined model):
+
             ```python
             joins_config = [
                 JoinConfig(
@@ -1091,7 +1116,7 @@ class FastCRUD(
                     filters={'name': 'Jane Doe'},
                 ),
             ]
-            count = await crud.count(db, joins_config=joins_config)
+            count = await project_crud.count(db, joins_config=joins_config)
             ```
         """
         primary_filters = self._parse_filters(**kwargs)
@@ -1456,6 +1481,7 @@ class FastCRUD(
             ```
 
             Fetching a single project and its associated participants where a participant has a specific role:
+
             ```python
             joins_config = [
                 JoinConfig(
@@ -1470,9 +1496,12 @@ class FastCRUD(
                     filters={'role': 'Designer'},
                 ),
             ]
-            project = await crud.get_joined(
+
+            project_crud = FastCRUD(Project)
+
+            project = await project_crud.get_joined(
                 db=session,
-                schema_to_select=ProjectSchema,
+                schema_to_select=ReadProjectSchema,
                 joins_config=joins_config,
             )
             ```
@@ -1803,6 +1832,7 @@ class FastCRUD(
             ```
 
             Fetching multiple project records and their associated participants where participants have a specific role:
+
             ```python
             joins_config = [
                 JoinConfig(
@@ -1817,11 +1847,14 @@ class FastCRUD(
                     filters={'role': 'Developer'},
                 ),
             ]
-            projects = await crud.get_multi_joined(
+
+            project_crud = FastCRUD(Project)
+
+            projects = await project_crud.get_multi_joined(
                 db=session,
-                schema_to_select=ProjectSchema,
-                joins_config=joins_config,
+                schema_to_select=ReadProjectSchema,
                 limit=10,
+                joins_config=joins_config,
             )
             ```
 

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -96,6 +96,7 @@ class BookingModel(Base):
     user = relationship("ModelTest", foreign_keys=[user_id], backref="user_bookings")
 
 
+# --8<-- [start:model_project]
 class Project(Base):
     __tablename__ = "projects"
     id = Column(Integer, primary_key=True)
@@ -108,6 +109,8 @@ class Project(Base):
     )
 
 
+# --8<-- [end:model_project]
+# --8<-- [start:model_participant]
 class Participant(Base):
     __tablename__ = "participants"
     id = Column(Integer, primary_key=True)
@@ -120,12 +123,15 @@ class Participant(Base):
     )
 
 
+# --8<-- [end:model_participant]
+# --8<-- [start:model_proj_parts_assoc]
 class ProjectsParticipantsAssociation(Base):
     __tablename__ = "projects_participants_association"
     project_id = Column(Integer, ForeignKey("projects.id"), primary_key=True)
     participant_id = Column(Integer, ForeignKey("participants.id"), primary_key=True)
 
 
+# --8<-- [end:model_proj_parts_assoc]
 class Card(Base):
     __tablename__ = "cards"
     id = Column(Integer, primary_key=True)


### PR DESCRIPTION
## Description

Models and schemas for #72, using the models from the unit tests for projects, project participants, and the associations between the two.

## Changes

Doc snippet inclusion markers in unit test config for models:

* `Project`
* `Participant`
* `ProjectsParticipantsAssociation`

Also, addition of a `ReadProjectSchema` and doc/docstring updates overall for all of these.

## Tests

As noted above, `tests/sqlalchemy/conftest.py` has snippet markers added for the above models, but are otherwise functionally unchanged.

## Checklist
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have added necessary documentation (if appropriate).

## Additional Notes

Coming back to this after a while away. I made sure to rebase and otherwise tried to ensure that changes that have happened in the meantime aren't affected, but please let me know if I've missed something.