### PR TITLE
Pagination fix

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -1,5 +1,6 @@
 from typing import Any, Generic, Union, Optional, Callable
 from datetime import datetime, timezone
+import warnings
 
 from pydantic import ValidationError
 from sqlalchemy import (
@@ -15,6 +16,7 @@ from sqlalchemy import (
     desc,
     or_,
     column,
+    tuple_
 )
 from sqlalchemy.exc import ArgumentError, MultipleResultsFound, NoResultFound
 from sqlalchemy.sql import Join
@@ -2048,11 +2050,13 @@ class FastCRUD(
     async def get_multi_by_cursor(
         self,
         db: AsyncSession,
-        cursor: Any = None,
+        cursor: Any | tuple[Any] = None,
         limit: int = 100,
         schema_to_select: Optional[type[SelectSchemaType]] = None,
         sort_column: str = "id",
         sort_order: str = "asc",
+        sort_columns: list[str] = [],
+        return_total_count: bool = True,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """
@@ -2126,19 +2130,28 @@ class FastCRUD(
         if limit == 0:
             return {"data": [], "next_cursor": None}
 
+        if len(sort_columns) == 0:
+            sort_columns = [sort_column]
+
+        assert not cursor or (isinstance(cursor, tuple) and len(sort_columns) == len(cursor)) or (len(sort_columns) == 1), f"cursor {cursor} not valid for sort_columns {sort_columns}"
+
         stmt = await self.select(schema_to_select=schema_to_select, **kwargs)
 
-        if cursor:
-            if sort_order == "asc":
-                stmt = stmt.filter(getattr(self.model, sort_column) > cursor)
+        if not isinstance(cursor, bool) and cursor and (not isinstance(cursor, tuple) or len(cursor) > 0):
+            if len(sort_columns) == 1 and sort_order == "asc":
+                stmt = stmt.filter(getattr(self.model, sort_columns[0]) > cursor)
+            elif len(sort_columns) == 1 and sort_order == "desc":
+                stmt = stmt.filter(getattr(self.model, sort_columns[0]) < cursor)
+            elif sort_order == "asc":
+                attributes = (getattr(self.model, sc) for sc in sort_columns)
+                stmt = stmt.filter(tuple_(*attributes) > tuple_(*cursor))
             else:
-                stmt = stmt.filter(getattr(self.model, sort_column) < cursor)
+                attributes = (getattr(self.model, sc) for sc in sort_columns)
+                stmt = stmt.filter(tuple_(*attributes) < tuple_(*cursor))
 
-        stmt = stmt.order_by(
-            asc(getattr(self.model, sort_column))
-            if sort_order == "asc"
-            else desc(getattr(self.model, sort_column))
-        )
+        stmt = self._apply_sorting(stmt, sort_columns, [sort_order] * len(sort_columns))
+        filters = self._parse_filters(**kwargs)
+        stmt = stmt.filter(*filters)
         stmt = stmt.limit(limit)
 
         result = await db.execute(stmt)
@@ -2146,12 +2159,19 @@ class FastCRUD(
 
         next_cursor = None
         if len(data) == limit:
-            if sort_order == "asc":
-                next_cursor = data[-1][sort_column]
+            if len(sort_columns) == 1:
+                next_cursor = data[-1][sort_columns[0]]
             else:
-                data[0][sort_column]
+                next_cursor = tuple([data[-1][sc] for sc in sort_columns])
+        
+        response = {"data": data, "next_cursor": next_cursor}
 
-        return {"data": data, "next_cursor": next_cursor}
+        if return_total_count:
+            total_count = await self.count(db=db, **kwargs)
+            response["total_count"] = total_count
+
+        return response
+
 
     async def update(
         self,

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -19,7 +19,7 @@ from ..exceptions.http_exceptions import (
     NotFoundException,
     BadRequestException,
 )
-from ..paginated.helper import compute_offset
+from ..paginated.helper import compute_offset, parse_cursor
 from ..paginated.response import paginated_response
 from .helper import (
     CRUDMethods,
@@ -30,7 +30,7 @@ from .helper import (
     _inject_dependencies,
     _apply_model_pk,
     _create_dynamic_filters,
-    _get_column_types,
+    _get_column_types
 )
 
 
@@ -388,34 +388,70 @@ class EndpointCreator:
             items_per_page: Optional[int] = Query(
                 None, alias="itemsPerPage", description="Number of items per page"
             ),
+            cursor: Optional[bool | Any] = Query(False, description="Pagination cursor -- set to True for first cursor page; can be used in conjuction with limit"),
             filters: dict = Depends(dynamic_filters),
         ) -> Union[dict[str, Any], PaginatedListResponse, ListResponse]:
-            is_paginated = (page is not None) or (items_per_page is not None)
+            paginated = (page is not None) or (items_per_page is not None)
             has_offset_limit = (offset is not None) and (limit is not None)
 
-            if is_paginated and has_offset_limit:
+            if paginated and has_offset_limit or paginated and cursor or has_offset_limit and cursor:
                 raise BadRequestException(
-                    detail="Conflicting parameters: Use either 'page' and 'itemsPerPage' for paginated results or 'offset' and 'limit' for specific range queries."
+                    detail=("Conflicting parameters: Use either 'page' and 'itemsPerPage' for paginated results,"
+                        +" 'cursor' and 'limit' for more efficient pagination or 'offset' and 'limit' for general range queries.")
                 )
 
-            if is_paginated:
+            if paginated:
                 if not page:
                     page = 1
                 if not items_per_page:
                     items_per_page = 10
                 offset = compute_offset(page=page, items_per_page=items_per_page)  # type: ignore
                 limit = items_per_page
+            elif cursor:
+                if not limit:
+                    limit = 100
+                page = -1
+                items_per_page = limit
             elif not has_offset_limit:
                 offset = 0
                 limit = 100
 
-            if self.select_schema is not None:
+            sort_columns = None
+            sort_orders = None
+            sort_column_types = ()
+
+            if paginated or cursor:
+                sort_columns = [k.name for k in _get_primary_keys(self.model)]
+                sort_orders = ["asc"] * len(sort_columns)
+                sort_column_types = []
+                for k in _get_primary_keys(self.model):
+                    try:
+                        sort_column_types.append(k.type.python_type)
+                    except NotImplementedError:
+                        # if the python_type does not exist for the column
+                        # we assume str
+                        sort_column_types.append(str)
+                sort_column_types = tuple(sort_column_types)
+
+            if cursor:
+                crud_data = await self.crud.get_multi_by_cursor(
+                    db,
+                    limit=limit, # type: ignore 
+                    schema_to_select=self.select_schema,
+                    sort_columns=sort_columns, # type: ignore
+                    sort_order=sort_orders[0], # type: ignore
+                    cursor=parse_cursor(cursor, sort_column_types),
+                    **filters,
+                )
+            elif self.select_schema is not None:
                 crud_data = await self.crud.get_multi(
                     db,
                     offset=offset,  # type: ignore
                     limit=limit,  # type: ignore
                     schema_to_select=self.select_schema,
                     return_as_model=True,
+                    sort_columns=sort_columns,
+                    sort_orders=sort_orders,
                     **filters,
                 )
             else:
@@ -423,27 +459,19 @@ class EndpointCreator:
                     db,
                     offset=offset,  # type: ignore
                     limit=limit,  # type: ignore
+                    sort_columns=sort_columns,
+                    sort_orders=sort_orders,
                     **filters,
                 )
 
-            if is_paginated:
+            if paginated or cursor:
                 return paginated_response(
                     crud_data=crud_data,
                     page=page,  # type: ignore
                     items_per_page=items_per_page,  # type: ignore
                 )
-
-            if not has_offset_limit:
-                offset = 0
-                limit = 100
-
-            crud_data = await self.crud.get_multi(
-                db,
-                offset=offset,  # type: ignore
-                limit=limit,  # type: ignore
-                **filters,
-            )
-            return crud_data  # pragma: no cover
+            else:
+                return crud_data  # pragma: no cover
 
         return endpoint
 

--- a/fastcrud/paginated/helper.py
+++ b/fastcrud/paginated/helper.py
@@ -1,3 +1,7 @@
+from typing import Any, Type
+from fastapi.exceptions import RequestValidationError
+
+
 def compute_offset(page: int, items_per_page: int) -> int:
     """Calculate the offset for pagination based on the given page number and items per page.
 
@@ -19,3 +23,51 @@ def compute_offset(page: int, items_per_page: int) -> int:
         20
     """
     return (page - 1) * items_per_page
+
+def parse_cursor(cursor: Any, type_tuple: tuple[Type[Any], ...] | tuple[()]):
+    """Parses a cursor the the expected format.
+
+    The cursor supplied by the query param is always a string. 
+    In reality, it can be either a truth-value (True) or a comma 
+    seperated sequence of any types or a singular any type.
+    The correct types are given by the type_tuple.
+    If it is a True-value, then None is returned as representative of the "first-page" cursor
+    Acceptable True-values: True, "True", "true", "T", "t", "Yes", "yes", "Y", "y"
+
+    Args:
+        cursor: the user-provided cursor
+        type_tuple: the types that should make up the cursor
+
+    Returns:
+        Correctly formatted cursor (boolean (True), string, tuple of strings)
+
+    Examples:
+        >>> parse_cursor(True)
+        None
+        >>> parse_cursor("True")
+        None
+        >>> parse_cursor("1")
+        "1"
+    """
+    if isinstance(cursor, bool) and cursor:
+        return None
+    elif isinstance(cursor, str) and cursor in {"True", "true", "t", "Yes", "yes", "Y", "y"}:
+        return None
+    elif isinstance(cursor, str) and "," in cursor:
+        cursor_tuple = tuple(cursor.split(","))
+        assert len(cursor_tuple) == len(type_tuple), f"cursor should be a tuple of len {len(type_tuple)} with types {type_tuple}"
+        parsed_cursor = []
+        for idx in range(len(cursor_tuple)):
+            try:
+                parsed_cursor.append(type_tuple[idx](cursor_tuple[idx]))
+            except:
+                raise RequestValidationError(f"cannot cast cursor value {cursor_tuple[idx]} to type {type_tuple[idx]}")
+        return tuple(parsed_cursor)
+    elif isinstance(cursor, str):
+        assert len(type_tuple) == 1, f"cursor should be a tuple of len {len(type_tuple)} with types {type_tuple}"
+        try:
+            return type_tuple[0](cursor)
+        except:
+            raise RequestValidationError(f"cannot cast cursor value {cursor} to type {type_tuple[0]}")
+    else:
+        raise ValueError(f"invalid cursor {cursor}")

--- a/fastcrud/paginated/response.py
+++ b/fastcrud/paginated/response.py
@@ -20,7 +20,8 @@ def paginated_response(
     return {
         "data": crud_data["data"],
         "total_count": crud_data["total_count"],
-        "has_more": (page * items_per_page) < crud_data["total_count"],
+        "has_more": crud_data["next_cursor"] is not None if "next_cursor" in crud_data else (page * items_per_page) < crud_data["total_count"],
         "page": page,
         "items_per_page": items_per_page,
+        "cursor": crud_data.get("next_cursor", False)
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ SQLAlchemy = "^2.0.0"
 pydantic = "^2.0.0"
 SQLAlchemy-Utils = "^0.41.1"
 fastapi = ">=0.100.0"
+testcontainers = {extras = ["postgres"], version = "^4.9.1"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.4"
@@ -44,7 +45,7 @@ sqlmodel = "^0.0.14"
 mypy = "^1.9.0"
 ruff = "^0.3.4"
 coverage = "^7.4.4"
-testcontainers = "^4.7.1"
+testcontainers = {extras = ["postgres"], version = "^4.9.1"}
 asyncpg = "^0.30.0"
 psycopg2-binary = "^2.9.10"
 psycopg = "^3.2.1"

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -386,10 +386,31 @@ def test_data_category() -> list[dict]:
     params=[
         {"id": 1, "uuid": "a", "name": "Tech"},
         {"id": 1, "uuid": "b", "name": "Health"},
+        {"id": 1, "uuid": "c", "name": "Travel"},
+        {"id": 2, "uuid": "a", "name": "Adventure"},
+        {"id": 2, "uuid": "b", "name": "Dining"},
+        {"id": 3, "uuid": "a", "name": "Business"},
+        {"id": 4, "uuid": "c", "name": "Craftmanship"},
+        {"id": 4, "uuid": "x", "name": "Natural Ressources"},
     ],
 )
 def test_data_multipk(request) -> list[dict]:
     return request.param
+
+@pytest.fixture(
+    scope="function"
+)
+def test_data_multipk_list() -> list[dict]:
+    return [
+        {"id": 1, "uuid": "a", "name": "Tech"},
+        {"id": 1, "uuid": "b", "name": "Health"},
+        {"id": 1, "uuid": "c", "name": "Travel"},
+        {"id": 2, "uuid": "a", "name": "Adventure"},
+        {"id": 2, "uuid": "b", "name": "Dining"},
+        {"id": 3, "uuid": "a", "name": "Business"},
+        {"id": 4, "uuid": "c", "name": "Craftmanship"},
+        {"id": 4, "uuid": "x", "name": "Natural Ressources"},
+    ]
 
 
 @pytest.fixture(scope="function")

--- a/tests/sqlalchemy/crud/test_get_multi.py
+++ b/tests/sqlalchemy/crud/test_get_multi.py
@@ -72,7 +72,6 @@ async def test_get_multi_pagination(async_session, test_model, test_data):
     ids2 = [item["id"] for item in result_page_2["data"]]
     assert max(ids1) < min(ids2) 
 
-
 @pytest.mark.asyncio
 async def test_get_multi_limitless(async_session, test_model, test_data):
     for item in test_data:
@@ -89,7 +88,6 @@ async def test_get_multi_limitless(async_session, test_model, test_data):
     results = await crud.get_multi(async_session, offset=0, limit=None)
 
     assert len(results["data"]) == total_count
-
 
 @pytest.mark.asyncio
 async def test_get_multi_sorting(async_session, test_model, test_data):

--- a/tests/sqlalchemy/crud/test_get_multi.py
+++ b/tests/sqlalchemy/crud/test_get_multi.py
@@ -29,7 +29,7 @@ async def test_get_multi_basic(async_session, test_model, test_data):
 
 
 @pytest.mark.asyncio
-async def test_get_multi_pagination(async_session, test_model, test_data):
+async def test_get_multi_offset_limit(async_session, test_model, test_data):
     for item in test_data:
         record = test_model(**item)
         async_session.add(record)
@@ -50,9 +50,31 @@ async def test_get_multi_pagination(async_session, test_model, test_data):
     ids2 = [item["id"] for item in result_page_2["data"]]
     assert max(ids1) < min(ids2) 
 
+@pytest.mark.asyncio
+async def test_get_multi_pagination(async_session, test_model, test_data):
+    for item in test_data:
+        record = test_model(**item)
+        async_session.add(record)
+    await async_session.commit()
+
+    total_count_query = await async_session.execute(
+        select(func.count()).select_from(test_model)
+    )
+    total_count = total_count_query.scalar()
+
+    crud = FastCRUD(test_model)
+    result_page_1 = await crud.get_multi(async_session, offset=0, limit=5, sort_columns=["id"], sort_orders=["asc"])
+    result_page_2 = await crud.get_multi(async_session, offset=5, limit=5, sort_columns=["id"], sort_orders=["asc"])
+
+    assert len(result_page_1["data"]) == min(5, total_count)
+    assert len(result_page_2["data"]) == min(5, max(0, total_count - 5))
+    ids1 = [item["id"] for item in result_page_1["data"]]
+    ids2 = [item["id"] for item in result_page_2["data"]]
+    assert max(ids1) < min(ids2) 
+
 
 @pytest.mark.asyncio
-async def test_get_multi_unpaginated(async_session, test_model, test_data):
+async def test_get_multi_limitless(async_session, test_model, test_data):
     for item in test_data:
         record = test_model(**item)
         async_session.add(record)

--- a/tests/sqlalchemy/crud/test_get_multi.py
+++ b/tests/sqlalchemy/crud/test_get_multi.py
@@ -46,6 +46,9 @@ async def test_get_multi_pagination(async_session, test_model, test_data):
 
     assert len(result_page_1["data"]) == min(5, total_count)
     assert len(result_page_2["data"]) == min(5, max(0, total_count - 5))
+    ids1 = [item["id"] for item in result_page_1["data"]]
+    ids2 = [item["id"] for item in result_page_2["data"]]
+    assert max(ids1) < min(ids2) 
 
 
 @pytest.mark.asyncio

--- a/tests/sqlalchemy/endpoint/test_get_paginated.py
+++ b/tests/sqlalchemy/endpoint/test_get_paginated.py
@@ -25,6 +25,7 @@ async def test_read_items_with_pagination(
     assert "page" in data
     assert "items_per_page" in data
     assert "has_more" in data
+    assert "cursor" in data
 
     assert len(data["data"]) > 0
     assert len(data["data"]) <= items_per_page
@@ -61,6 +62,7 @@ async def test_read_items_with_pagination_and_filters(
     assert "page" in data
     assert "items_per_page" in data
     assert "has_more" in data
+    assert "cursor" in data
 
     assert len(data["data"]) > 0
     assert len(data["data"]) <= items_per_page
@@ -81,6 +83,7 @@ async def test_read_items_with_pagination_and_filters(
     assert "page" in data
     assert "items_per_page" in data
     assert "has_more" in data
+    assert "cursor" in data
 
     assert len(data["data"]) > 0
     assert len(data["data"]) <= items_per_page
@@ -109,3 +112,350 @@ async def test_read_items_with_partial_pagination_params(
     data = response.json()
     assert data["page"] == 1
     assert data["items_per_page"] == 5
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_correctly_ordered(
+    client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    page = 1
+    items_per_page = 5
+
+    response = client.get(f"/test/get_multi?page={page}&itemsPerPage={items_per_page}")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= items_per_page
+
+    test_item = test_data[0]
+    assert any(item["name"] == test_item["name"] for item in data["data"])
+
+    assert data["page"] == page
+    assert data["items_per_page"] == items_per_page
+
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    page = 2
+    response2 = client.get(f"/test/get_multi?page={page}&itemsPerPage={items_per_page}")
+    data2 = response2.json()
+    ids1 = [td["id"] for td in data["data"]]
+    ids2 = [td["id"] for td in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_and_filters_correctly_ordered(
+    filtered_client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    page = 1
+    items_per_page = 5
+
+    tier_id = 1
+    response = filtered_client.get(
+        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&tier_id={tier_id}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= items_per_page
+
+    for item in data["data"]:
+        assert item["tier_id"] == tier_id
+
+    name = "Alice"
+    response = filtered_client.get(
+        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&name={name}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= items_per_page
+
+    for item in data["data"]:
+        assert item["name"] == name
+
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    # e.g. for itemsPerPage=5, the first page should deliver items 1-5 and the second page items 6-10
+    page = 2
+    response2 = filtered_client.get(
+        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&tier_id={tier_id}"
+    )
+    data2 = response2.json()
+    ids1 = [td["id"] for td in data["data"]]
+    ids2 = [td["id"] for td in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
+
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_cursor(
+    client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    # how to encode None values in url query params:
+    # https://github.com/python/cpython/issues/63057
+    cursor = None
+    limit = 5
+    response = client.get(f"/test/get_multi?cursor={cursor}&limit={limit}")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    test_item = test_data[0]
+    assert any(item["name"] == test_item["name"] for item in data["data"])
+
+    ids = [item["id"] for item in data["data"]]
+    assert data["cursor"] == max(ids)
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_cursor_and_filters(
+    filtered_client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    # how to encode None values in url query params:
+    # https://github.com/python/cpython/issues/63057
+    cursor = None
+    limit = 5
+
+    tier_id = 1
+    response = filtered_client.get(
+        f"/test/get_multi?cursor={cursor}&limit={limit}&tier_id={tier_id}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    for item in data["data"]:
+        assert item["tier_id"] == tier_id
+
+    ids = [item["id"] for item in data["data"]]
+    assert data["cursor"] == max(ids)
+
+    name = "Alice"
+    response = filtered_client.get(
+        f"/test/get_multi?cursor={cursor}&limit={limit}&name={name}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    for item in data["data"]:
+        assert item["name"] == name
+
+    ids = [item["id"] for item in data["data"]]
+    assert data["cursor"] == max(ids)
+
+
+@pytest.mark.asyncio
+async def test_read_items_with_partial_pagination_cursor_params(
+    client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+    # how to encode None values in url query params:
+    # https://github.com/python/cpython/issues/63057
+    cursor = None
+
+    response = client.get(f"/test/get_multi?cursor={cursor}")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data"]) > 0
+
+    response = client.get(f"/test/get_multi?limit=5")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= 5
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_cursor_correctly_ordered(
+    client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    # how to encode None values in url query params:
+    # https://github.com/python/cpython/issues/63057
+    cursor = None
+    limit = 5
+
+    response = client.get(f"/test/get_multi?cursor={cursor}&limit={limit}")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    test_item = test_data[0]
+    assert any(item["name"] == test_item["name"] for item in data["data"])
+
+    ids1 = [item["id"] for item in data["data"]]
+    assert data["cursor"] == max(ids1)
+
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    cursor = data["cursor"]
+    response2 = client.get(f"/test/get_multi?cursor={cursor}&limit={limit}")
+    data2 = response2.json()
+    ids1 = [td["id"] for td in data["data"]]
+    ids2 = [td["id"] for td in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_cursor_and_filters_correctly_ordered(
+    filtered_client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    # how to encode None values in url query params:
+    # https://github.com/python/cpython/issues/63057
+    cursor = None
+    limit = 5
+
+    tier_id = 1
+    response = filtered_client.get(
+        f"/test/get_multi?cursor={cursor}&limit={limit}&tier_id={tier_id}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    for item in data["data"]:
+        assert item["tier_id"] == tier_id
+
+    ids1 = [td["id"] for td in data["data"]]
+    assert data["cursor"] == max(ids1)
+
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    # e.g. for itemsPerPage=5, the first page should deliver items 1-5 and the second page items 6-10
+    cursor = data["cursor"]
+    response2 = filtered_client.get(
+        f"/test/get_multi?cursor={cursor}&limit={limit}&tier_id={tier_id}"
+    )
+    data2 = response2.json()
+    ids2 = [td["id"] for td in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
+
+    name = "Alice"
+    response = filtered_client.get(
+        f"/test/get_multi?cursor={cursor}&limit={limit}&name={name}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    for item in data["data"]:
+        assert item["name"] == name
+

--- a/tests/sqlalchemy/endpoint/test_get_paginated.py
+++ b/tests/sqlalchemy/endpoint/test_get_paginated.py
@@ -156,7 +156,7 @@ async def test_read_items_with_pagination_correctly_ordered(
     ids2 = [td["id"] for td in data2["data"]]
     # this checks for disjoint sets of ids
     # and for correct sequential ordering
-    assert max(ids1) < min(ids2) 
+    assert max(ids1) < min(ids2), f"ids are not sequential response 1:{ids1} -- response 2:{ids2}"
 
 @pytest.mark.asyncio
 async def test_read_items_with_pagination_and_filters_correctly_ordered(
@@ -191,6 +191,21 @@ async def test_read_items_with_pagination_and_filters_correctly_ordered(
     for item in data["data"]:
         assert item["tier_id"] == tier_id
 
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    # e.g. for itemsPerPage=5, the first page should deliver items 1-5 and the second page items 6-10
+    page = 2
+    response2 = filtered_client.get(
+        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&tier_id={tier_id}"
+    )
+    data2 = response2.json()
+    ids1 = [td["id"] for td in data["data"]]
+    ids2 = [td["id"] for td in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
+
+    page = 1
     name = "Alice"
     response = filtered_client.get(
         f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&name={name}"
@@ -212,21 +227,6 @@ async def test_read_items_with_pagination_and_filters_correctly_ordered(
     for item in data["data"]:
         assert item["name"] == name
 
-    # pagination should automatically order results by 
-    # primary key to ensure consistent responses 
-    # e.g. for itemsPerPage=5, the first page should deliver items 1-5 and the second page items 6-10
-    page = 2
-    response2 = filtered_client.get(
-        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&tier_id={tier_id}"
-    )
-    data2 = response2.json()
-    ids1 = [td["id"] for td in data["data"]]
-    ids2 = [td["id"] for td in data2["data"]]
-    # this checks for disjoint sets of ids
-    # and for correct sequential ordering
-    assert max(ids1) < min(ids2) 
-
-
 @pytest.mark.asyncio
 async def test_read_items_with_pagination_cursor(
     client: TestClient, async_session, test_model, test_data
@@ -236,9 +236,7 @@ async def test_read_items_with_pagination_cursor(
         async_session.add(new_item)
     await async_session.commit()
 
-    # how to encode None values in url query params:
-    # https://github.com/python/cpython/issues/63057
-    cursor = None
+    cursor = True
     limit = 5
     response = client.get(f"/test/get_multi?cursor={cursor}&limit={limit}")
 
@@ -260,7 +258,52 @@ async def test_read_items_with_pagination_cursor(
     assert any(item["name"] == test_item["name"] for item in data["data"])
 
     ids = [item["id"] for item in data["data"]]
-    assert data["cursor"] == max(ids)
+    assert (data["cursor"] is None and not data["has_more"] and data["total_count"] == len(data["data"])) or data["cursor"] == max(ids)
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_multicursor(
+    client: TestClient, async_session, multi_pk_model, test_data_multipk_list
+):
+    for data in test_data_multipk_list:
+        new_item = multi_pk_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    cursor = True
+    limit = 5
+    response = client.get(f"/multi_pk/get_multi?cursor={cursor}&limit={limit}")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    test_item = test_data_multipk_list[0]
+    assert any(item["name"] == test_item["name"] for item in data["data"])
+
+    ids1 = [(item["id"],item["uuid"]) for item in data["data"]]
+    ids1_max = max(ids1)
+    assert (data["cursor"] is None and not data["has_more"] and data["total_count"] == len(data["data"])) \
+        or (len(data["cursor"]) == len(ids1_max) and not any(data["cursor"][i] != ids1_max[i] for i in range(len(ids1_max))))
+
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    cursor = data["cursor"]
+    response2 = client.get(f"/multi_pk/get_multi?cursor={','.join([str(c) for c in cursor])}&limit={limit}")
+    data2 = response2.json()
+    ids2 = [(item["id"],item["uuid"]) for item in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
 
 @pytest.mark.asyncio
 async def test_read_items_with_pagination_cursor_and_filters(
@@ -271,9 +314,7 @@ async def test_read_items_with_pagination_cursor_and_filters(
         async_session.add(new_item)
     await async_session.commit()
 
-    # how to encode None values in url query params:
-    # https://github.com/python/cpython/issues/63057
-    cursor = None
+    cursor = True
     limit = 5
 
     tier_id = 1
@@ -298,7 +339,7 @@ async def test_read_items_with_pagination_cursor_and_filters(
         assert item["tier_id"] == tier_id
 
     ids = [item["id"] for item in data["data"]]
-    assert data["cursor"] == max(ids)
+    assert (data["cursor"] is None and not data["has_more"] and data["total_count"] == len(data["data"])) or data["cursor"] == max(ids)
 
     name = "Alice"
     response = filtered_client.get(
@@ -320,7 +361,7 @@ async def test_read_items_with_pagination_cursor_and_filters(
         assert item["name"] == name
 
     ids = [item["id"] for item in data["data"]]
-    assert data["cursor"] == max(ids)
+    assert (data["cursor"] is None and not data["has_more"] and data["total_count"] == len(data["data"])) or data["cursor"] == max(ids)
 
 
 @pytest.mark.asyncio
@@ -331,20 +372,12 @@ async def test_read_items_with_partial_pagination_cursor_params(
         new_item = test_model(**data)
         async_session.add(new_item)
     await async_session.commit()
-    # how to encode None values in url query params:
-    # https://github.com/python/cpython/issues/63057
-    cursor = None
+    cursor = True
 
     response = client.get(f"/test/get_multi?cursor={cursor}")
     assert response.status_code == 200
     data = response.json()
     assert len(data["data"]) > 0
-
-    response = client.get(f"/test/get_multi?limit=5")
-    assert response.status_code == 200
-    data = response.json()
-    assert len(data["data"]) > 0
-    assert len(data["data"]) <= 5
 
 @pytest.mark.asyncio
 async def test_read_items_with_pagination_cursor_correctly_ordered(
@@ -355,9 +388,7 @@ async def test_read_items_with_pagination_cursor_correctly_ordered(
         async_session.add(new_item)
     await async_session.commit()
 
-    # how to encode None values in url query params:
-    # https://github.com/python/cpython/issues/63057
-    cursor = None
+    cursor = True
     limit = 5
 
     response = client.get(f"/test/get_multi?cursor={cursor}&limit={limit}")
@@ -400,9 +431,7 @@ async def test_read_items_with_pagination_cursor_and_filters_correctly_ordered(
         async_session.add(new_item)
     await async_session.commit()
 
-    # how to encode None values in url query params:
-    # https://github.com/python/cpython/issues/63057
-    cursor = None
+    cursor = True
     limit = 5
 
     tier_id = 1

--- a/tests/sqlmodel/conftest.py
+++ b/tests/sqlmodel/conftest.py
@@ -373,6 +373,21 @@ def test_data_category() -> list[dict]:
 def test_data_multipk(request) -> list[dict]:
     return request.param
 
+@pytest.fixture(
+    scope="function"
+)
+def test_data_multipk_list() -> list[dict]:
+    return [
+        {"id": 1, "uuid": "a", "name": "Tech"},
+        {"id": 1, "uuid": "b", "name": "Health"},
+        {"id": 1, "uuid": "c", "name": "Travel"},
+        {"id": 2, "uuid": "a", "name": "Adventure"},
+        {"id": 2, "uuid": "b", "name": "Dining"},
+        {"id": 3, "uuid": "a", "name": "Business"},
+        {"id": 4, "uuid": "c", "name": "Craftmanship"},
+        {"id": 4, "uuid": "x", "name": "Natural Ressources"},
+    ]
+
 
 @pytest.fixture(scope="function")
 def test_data_booking() -> list[dict]:

--- a/tests/sqlmodel/crud/test_get_multi.py
+++ b/tests/sqlmodel/crud/test_get_multi.py
@@ -46,7 +46,9 @@ async def test_get_multi_pagination(async_session, test_model, test_data):
 
     assert len(result_page_1["data"]) == min(5, total_count)
     assert len(result_page_2["data"]) == min(5, max(0, total_count - 5))
-
+    ids1 = [item["id"] for item in result_page_1["data"]]
+    ids2 = [item["id"] for item in result_page_2["data"]]
+    assert max(ids1) < min(ids2) 
 
 @pytest.mark.asyncio
 async def test_get_multi_unpaginated(async_session, test_model, test_data):

--- a/tests/sqlmodel/endpoint/test_get_paginated.py
+++ b/tests/sqlmodel/endpoint/test_get_paginated.py
@@ -1,7 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
 
-
 @pytest.mark.asyncio
 async def test_read_items_with_pagination(
     client: TestClient, async_session, test_model, test_data
@@ -156,7 +155,7 @@ async def test_read_items_with_pagination_correctly_ordered(
     ids2 = [td["id"] for td in data2["data"]]
     # this checks for disjoint sets of ids
     # and for correct sequential ordering
-    assert max(ids1) < min(ids2) 
+    assert max(ids1) < min(ids2), f"ids are not sequential response 1:{ids1} -- response 2:{ids2}"
 
 @pytest.mark.asyncio
 async def test_read_items_with_pagination_and_filters_correctly_ordered(
@@ -191,6 +190,21 @@ async def test_read_items_with_pagination_and_filters_correctly_ordered(
     for item in data["data"]:
         assert item["tier_id"] == tier_id
 
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    # e.g. for itemsPerPage=5, the first page should deliver items 1-5 and the second page items 6-10
+    page = 2
+    response2 = filtered_client.get(
+        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&tier_id={tier_id}"
+    )
+    data2 = response2.json()
+    ids1 = [td["id"] for td in data["data"]]
+    ids2 = [td["id"] for td in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
+
+    page = 1
     name = "Alice"
     response = filtered_client.get(
         f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&name={name}"
@@ -212,21 +226,6 @@ async def test_read_items_with_pagination_and_filters_correctly_ordered(
     for item in data["data"]:
         assert item["name"] == name
 
-    # pagination should automatically order results by 
-    # primary key to ensure consistent responses 
-    # e.g. for itemsPerPage=5, the first page should deliver items 1-5 and the second page items 6-10
-    page = 2
-    response2 = filtered_client.get(
-        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&tier_id={tier_id}"
-    )
-    data2 = response2.json()
-    ids1 = [td["id"] for td in data["data"]]
-    ids2 = [td["id"] for td in data2["data"]]
-    # this checks for disjoint sets of ids
-    # and for correct sequential ordering
-    assert max(ids1) < min(ids2) 
-
-
 @pytest.mark.asyncio
 async def test_read_items_with_pagination_cursor(
     client: TestClient, async_session, test_model, test_data
@@ -236,9 +235,7 @@ async def test_read_items_with_pagination_cursor(
         async_session.add(new_item)
     await async_session.commit()
 
-    # how to encode None values in url query params:
-    # https://github.com/python/cpython/issues/63057
-    cursor = None
+    cursor = True
     limit = 5
     response = client.get(f"/test/get_multi?cursor={cursor}&limit={limit}")
 
@@ -260,7 +257,52 @@ async def test_read_items_with_pagination_cursor(
     assert any(item["name"] == test_item["name"] for item in data["data"])
 
     ids = [item["id"] for item in data["data"]]
-    assert data["cursor"] == max(ids)
+    assert (data["cursor"] is None and not data["has_more"] and data["total_count"] == len(data["data"])) or data["cursor"] == max(ids)
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_multicursor(
+    client: TestClient, async_session, multi_pk_model, test_data_multipk_list
+):
+    for data in test_data_multipk_list:
+        new_item = multi_pk_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    cursor = True
+    limit = 5
+    response = client.get(f"/multi_pk/get_multi?cursor={cursor}&limit={limit}")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    test_item = test_data_multipk_list[0]
+    assert any(item["name"] == test_item["name"] for item in data["data"])
+
+    ids1 = [(item["id"],item["uuid"]) for item in data["data"]]
+    ids1_max = max(ids1)
+    assert (data["cursor"] is None and not data["has_more"] and data["total_count"] == len(data["data"])) \
+        or (len(data["cursor"]) == len(ids1_max) and not any(data["cursor"][i] != ids1_max[i] for i in range(len(ids1_max))))
+
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    cursor = data["cursor"]
+    response2 = client.get(f"/multi_pk/get_multi?cursor={','.join([str(c) for c in cursor])}&limit={limit}")
+    data2 = response2.json()
+    ids2 = [(item["id"],item["uuid"]) for item in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
 
 @pytest.mark.asyncio
 async def test_read_items_with_pagination_cursor_and_filters(
@@ -271,9 +313,7 @@ async def test_read_items_with_pagination_cursor_and_filters(
         async_session.add(new_item)
     await async_session.commit()
 
-    # how to encode None values in url query params:
-    # https://github.com/python/cpython/issues/63057
-    cursor = None
+    cursor = True
     limit = 5
 
     tier_id = 1
@@ -298,7 +338,7 @@ async def test_read_items_with_pagination_cursor_and_filters(
         assert item["tier_id"] == tier_id
 
     ids = [item["id"] for item in data["data"]]
-    assert data["cursor"] == max(ids)
+    assert (data["cursor"] is None and not data["has_more"] and data["total_count"] == len(data["data"])) or data["cursor"] == max(ids)
 
     name = "Alice"
     response = filtered_client.get(
@@ -320,7 +360,7 @@ async def test_read_items_with_pagination_cursor_and_filters(
         assert item["name"] == name
 
     ids = [item["id"] for item in data["data"]]
-    assert data["cursor"] == max(ids)
+    assert (data["cursor"] is None and not data["has_more"] and data["total_count"] == len(data["data"])) or data["cursor"] == max(ids)
 
 
 @pytest.mark.asyncio
@@ -331,20 +371,12 @@ async def test_read_items_with_partial_pagination_cursor_params(
         new_item = test_model(**data)
         async_session.add(new_item)
     await async_session.commit()
-    # how to encode None values in url query params:
-    # https://github.com/python/cpython/issues/63057
-    cursor = None
+    cursor = True
 
     response = client.get(f"/test/get_multi?cursor={cursor}")
     assert response.status_code == 200
     data = response.json()
     assert len(data["data"]) > 0
-
-    response = client.get(f"/test/get_multi?limit=5")
-    assert response.status_code == 200
-    data = response.json()
-    assert len(data["data"]) > 0
-    assert len(data["data"]) <= 5
 
 @pytest.mark.asyncio
 async def test_read_items_with_pagination_cursor_correctly_ordered(
@@ -355,9 +387,7 @@ async def test_read_items_with_pagination_cursor_correctly_ordered(
         async_session.add(new_item)
     await async_session.commit()
 
-    # how to encode None values in url query params:
-    # https://github.com/python/cpython/issues/63057
-    cursor = None
+    cursor = True
     limit = 5
 
     response = client.get(f"/test/get_multi?cursor={cursor}&limit={limit}")
@@ -400,9 +430,7 @@ async def test_read_items_with_pagination_cursor_and_filters_correctly_ordered(
         async_session.add(new_item)
     await async_session.commit()
 
-    # how to encode None values in url query params:
-    # https://github.com/python/cpython/issues/63057
-    cursor = None
+    cursor = True
     limit = 5
 
     tier_id = 1

--- a/tests/sqlmodel/endpoint/test_get_paginated.py
+++ b/tests/sqlmodel/endpoint/test_get_paginated.py
@@ -25,6 +25,7 @@ async def test_read_items_with_pagination(
     assert "page" in data
     assert "items_per_page" in data
     assert "has_more" in data
+    assert "cursor" in data
 
     assert len(data["data"]) > 0
     assert len(data["data"]) <= items_per_page
@@ -61,6 +62,7 @@ async def test_read_items_with_pagination_and_filters(
     assert "page" in data
     assert "items_per_page" in data
     assert "has_more" in data
+    assert "cursor" in data
 
     assert len(data["data"]) > 0
     assert len(data["data"]) <= items_per_page
@@ -81,78 +83,13 @@ async def test_read_items_with_pagination_and_filters(
     assert "page" in data
     assert "items_per_page" in data
     assert "has_more" in data
+    assert "cursor" in data
 
     assert len(data["data"]) > 0
     assert len(data["data"]) <= items_per_page
 
     for item in data["data"]:
         assert item["name"] == name
-
-
-@pytest.mark.asyncio
-async def test_read_items_with_only_items_per_page_on_pagination(
-    client: TestClient, async_session, test_model, test_data
-):
-    for data in test_data:
-        new_item = test_model(**data)
-        async_session.add(new_item)
-    await async_session.commit()
-
-    items_per_page = 1
-
-    response = client.get(f"/test/get_multi?&itemsPerPage={items_per_page}")
-
-    assert response.status_code == 200
-
-    data = response.json()
-
-    assert "data" in data
-    assert "total_count" in data
-    assert "page" in data
-    assert "items_per_page" in data
-    assert "has_more" in data
-
-    assert len(data["data"]) > 0
-    assert len(data["data"]) <= items_per_page
-
-    test_item = test_data[0]
-    assert any(item["name"] == test_item["name"] for item in data["data"])
-
-    assert data["page"] == 1
-    assert data["items_per_page"] == items_per_page
-
-
-@pytest.mark.asyncio
-async def test_read_items_with_only_page_on_pagination(
-    client: TestClient, async_session, test_model, test_data
-):
-    for data in test_data:
-        new_item = test_model(**data)
-        async_session.add(new_item)
-    await async_session.commit()
-
-    page = 1
-
-    response = client.get(f"/test/get_multi?&page={page}")
-
-    assert response.status_code == 200
-
-    data = response.json()
-
-    assert "data" in data
-    assert "total_count" in data
-    assert "page" in data
-    assert "items_per_page" in data
-    assert "has_more" in data
-
-    assert len(data["data"]) > 0
-    assert len(data["data"]) <= 10
-
-    test_item = test_data[0]
-    assert any(item["name"] == test_item["name"] for item in data["data"])
-
-    assert data["page"] == page
-    assert data["items_per_page"] == 10
 
 
 @pytest.mark.asyncio
@@ -175,3 +112,350 @@ async def test_read_items_with_partial_pagination_params(
     data = response.json()
     assert data["page"] == 1
     assert data["items_per_page"] == 5
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_correctly_ordered(
+    client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    page = 1
+    items_per_page = 5
+
+    response = client.get(f"/test/get_multi?page={page}&itemsPerPage={items_per_page}")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= items_per_page
+
+    test_item = test_data[0]
+    assert any(item["name"] == test_item["name"] for item in data["data"])
+
+    assert data["page"] == page
+    assert data["items_per_page"] == items_per_page
+
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    page = 2
+    response2 = client.get(f"/test/get_multi?page={page}&itemsPerPage={items_per_page}")
+    data2 = response2.json()
+    ids1 = [td["id"] for td in data["data"]]
+    ids2 = [td["id"] for td in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_and_filters_correctly_ordered(
+    filtered_client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    page = 1
+    items_per_page = 5
+
+    tier_id = 1
+    response = filtered_client.get(
+        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&tier_id={tier_id}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= items_per_page
+
+    for item in data["data"]:
+        assert item["tier_id"] == tier_id
+
+    name = "Alice"
+    response = filtered_client.get(
+        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&name={name}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= items_per_page
+
+    for item in data["data"]:
+        assert item["name"] == name
+
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    # e.g. for itemsPerPage=5, the first page should deliver items 1-5 and the second page items 6-10
+    page = 2
+    response2 = filtered_client.get(
+        f"/test/get_multi?page={page}&itemsPerPage={items_per_page}&tier_id={tier_id}"
+    )
+    data2 = response2.json()
+    ids1 = [td["id"] for td in data["data"]]
+    ids2 = [td["id"] for td in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
+
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_cursor(
+    client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    # how to encode None values in url query params:
+    # https://github.com/python/cpython/issues/63057
+    cursor = None
+    limit = 5
+    response = client.get(f"/test/get_multi?cursor={cursor}&limit={limit}")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    test_item = test_data[0]
+    assert any(item["name"] == test_item["name"] for item in data["data"])
+
+    ids = [item["id"] for item in data["data"]]
+    assert data["cursor"] == max(ids)
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_cursor_and_filters(
+    filtered_client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    # how to encode None values in url query params:
+    # https://github.com/python/cpython/issues/63057
+    cursor = None
+    limit = 5
+
+    tier_id = 1
+    response = filtered_client.get(
+        f"/test/get_multi?cursor={cursor}&limit={limit}&tier_id={tier_id}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "page" in data
+    assert "items_per_page" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    for item in data["data"]:
+        assert item["tier_id"] == tier_id
+
+    ids = [item["id"] for item in data["data"]]
+    assert data["cursor"] == max(ids)
+
+    name = "Alice"
+    response = filtered_client.get(
+        f"/test/get_multi?cursor={cursor}&limit={limit}&name={name}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    for item in data["data"]:
+        assert item["name"] == name
+
+    ids = [item["id"] for item in data["data"]]
+    assert data["cursor"] == max(ids)
+
+
+@pytest.mark.asyncio
+async def test_read_items_with_partial_pagination_cursor_params(
+    client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+    # how to encode None values in url query params:
+    # https://github.com/python/cpython/issues/63057
+    cursor = None
+
+    response = client.get(f"/test/get_multi?cursor={cursor}")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data"]) > 0
+
+    response = client.get(f"/test/get_multi?limit=5")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= 5
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_cursor_correctly_ordered(
+    client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    # how to encode None values in url query params:
+    # https://github.com/python/cpython/issues/63057
+    cursor = None
+    limit = 5
+
+    response = client.get(f"/test/get_multi?cursor={cursor}&limit={limit}")
+
+    assert response.status_code == 200
+
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    test_item = test_data[0]
+    assert any(item["name"] == test_item["name"] for item in data["data"])
+
+    ids1 = [item["id"] for item in data["data"]]
+    assert data["cursor"] == max(ids1)
+
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    cursor = data["cursor"]
+    response2 = client.get(f"/test/get_multi?cursor={cursor}&limit={limit}")
+    data2 = response2.json()
+    ids1 = [td["id"] for td in data["data"]]
+    ids2 = [td["id"] for td in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
+
+@pytest.mark.asyncio
+async def test_read_items_with_pagination_cursor_and_filters_correctly_ordered(
+    filtered_client: TestClient, async_session, test_model, test_data
+):
+    for data in test_data:
+        new_item = test_model(**data)
+        async_session.add(new_item)
+    await async_session.commit()
+
+    # how to encode None values in url query params:
+    # https://github.com/python/cpython/issues/63057
+    cursor = None
+    limit = 5
+
+    tier_id = 1
+    response = filtered_client.get(
+        f"/test/get_multi?cursor={cursor}&limit={limit}&tier_id={tier_id}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    for item in data["data"]:
+        assert item["tier_id"] == tier_id
+
+    ids1 = [td["id"] for td in data["data"]]
+    assert data["cursor"] == max(ids1)
+
+    # pagination should automatically order results by 
+    # primary key to ensure consistent responses 
+    # e.g. for itemsPerPage=5, the first page should deliver items 1-5 and the second page items 6-10
+    cursor = data["cursor"]
+    response2 = filtered_client.get(
+        f"/test/get_multi?cursor={cursor}&limit={limit}&tier_id={tier_id}"
+    )
+    data2 = response2.json()
+    ids2 = [td["id"] for td in data2["data"]]
+    # this checks for disjoint sets of ids
+    # and for correct sequential ordering
+    assert max(ids1) < min(ids2) 
+
+    name = "Alice"
+    response = filtered_client.get(
+        f"/test/get_multi?cursor={cursor}&limit={limit}&name={name}"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "data" in data
+    assert "total_count" in data
+    assert "has_more" in data
+    assert "cursor" in data
+
+    assert len(data["data"]) > 0
+    assert len(data["data"]) <= limit
+
+    for item in data["data"]:
+        assert item["name"] == name
+


### PR DESCRIPTION
# Pull Request Template for FastCRUD

## Description
This pull request is about fixing issue #197 including some pagination related changes listed below.

## Changes
- [x] Support for cursor based pagination on _read_items function in EndpointCreator (single PK and composite)
- [x] Added ASC column sorting by model primary key for pagination in _read_items
- [x] Added cursor field in pagination response and changed has_more to work with cursor based pagination
- [x] Added cursor parsing function based on SqlAlchemy column.type.python_type (see considerations below)
- [x] Allow for multiple sort columns and tuple cursor in FastCRUD.get_multi_by_cursor for composite PKs
- [x] Added missing _parse_filters in FastCRUD.get_multi_by_cursor
- [x] Added missing total_count in return value of FastCRUD.get_multi_by_cursor if corresponding argument is set to True
- [x] Changed dev-dependency of testcontainers in pyproject.toml, as this was a source of errors for me when running pytest

### Considerations
1. Using SQLAlchemy column.type.python_type to parse the cursor might be error prone, as I assume a str-type if python_type is not implemented (e.g. AutoStr for SqlModel) -- maybe there is a better way?
2. The first "page" with cursor pagination can be retrieved by setting cursor=True in the query params. This is considered when parsing the cursor.
3. Composite cursors are assumed to be comma-separated in the url query param
4. FastCRUD.get_multi_by_cursor has now the arguments sort_columns as well as the previously existing sort_column for backward compatibility. Do we want to include a deprecation warning for sort_column, as this is a bit redundant, or do we want to keep both for convenience? Multiple sort orders for different parts of the (possibly) composite PK is not an option, as I use tuple-comparison for the cursor in the case of composite PKs (stolen from here: https://stackoverflow.com/questions/68953290/sqlalchemy-query-with-where-with-comparison-on-tuple-of-multiple-columns).

## Tests
All test stuff was equivalently added to sqlalchemy and sqlmodel.
- Added test_data_multipk_list function to conftest.py as I did not wanna touch test_data_multipk
- Added several more tests in crud/test_get_multi as well as endpoint/test_get_paginated to test the fixed Bug as well as the new cursor based pagination endpoint.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.

## Additional Notes
Not done yet (have to check the code style stuff and add to the documentation). But wanted to get early feedback as well as open the discussion to the points of considerations.
