### PR TITLE
bump cryptography to fix vulnerability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastcrud"
-version = "0.15.5"
+version = "0.15.6"
 description = "FastCRUD is a Python package for FastAPI, offering robust async CRUD operations and flexible endpoint creation utilities."
 authors = ["Igor Benav <igor.magalhaes.r@gmail.com>"]
 license = "MIT"
@@ -49,7 +49,7 @@ asyncpg = "^0.30.0"
 psycopg2-binary = "^2.9.10"
 psycopg = "^3.2.1"
 aiomysql = "^0.2.0"
-cryptography = "^43.0.1"
+cryptography = "^44.0.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 keywords = ["fastapi", "crud", "async", "sqlalchemy", "pydantic"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.9.2"
 SQLAlchemy = "^2.0.0"
 pydantic = "^2.0.0"
 SQLAlchemy-Utils = "^0.41.1"


### PR DESCRIPTION
"pyca/cryptography's wheels include a statically linked copy of OpenSSL. The versions of OpenSSL included in cryptography 42.0.0-44.0.0 are vulnerable to a security issue. More details about the vulnerability itself can be found in https://openssl-library.org/news/secadv/20250211.txt."