### PR TITLE
Fix get_multi_joined total_count with join_model parameter.

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -2125,7 +2125,7 @@ class FastCRUD(
 
         if return_total_count:
             total_count: int = await self.count(
-                db=db, joins_config=joins_config, **kwargs
+                db=db, joins_config=join_definitions, **kwargs
             )
             response["total_count"] = total_count
 

--- a/tests/sqlalchemy/crud/test_get_multi_joined_total_count.py
+++ b/tests/sqlalchemy/crud/test_get_multi_joined_total_count.py
@@ -1,0 +1,108 @@
+import pytest
+from fastcrud import FastCRUD, JoinConfig
+from tests.sqlalchemy.conftest import ModelTest, TierModel, CreateSchemaTest, TierSchemaTest
+
+
+@pytest.mark.asyncio
+async def test_get_multi_joined_total_count_with_join_model(async_session, test_data, test_data_tier):
+    """Test that total_count is correct when using join_model parameter."""
+    # Setup test data
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    await async_session.commit()
+
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    
+    # Use join_model parameter
+    result_with_join_model = await crud.get_multi_joined(
+        db=async_session,
+        join_model=TierModel,
+        join_prefix="tier_",
+        schema_to_select=CreateSchemaTest,
+        join_schema_to_select=TierSchemaTest,
+        offset=0,
+        limit=5,  # Use a smaller limit to ensure we're not just getting all records
+    )
+    
+    # Use joins_config parameter
+    result_with_joins_config = await crud.get_multi_joined(
+        db=async_session,
+        schema_to_select=CreateSchemaTest,
+        joins_config=[
+            JoinConfig(
+                model=TierModel,
+                join_on=ModelTest.tier_id == TierModel.id,
+                join_prefix="tier_",
+                schema_to_select=TierSchemaTest,
+                join_type="left",
+            )
+        ],
+        offset=0,
+        limit=5,  # Same limit as above
+    )
+    
+    # Both approaches should return the same total_count
+    assert result_with_join_model["total_count"] == len(test_data)
+    assert result_with_joins_config["total_count"] == len(test_data)
+    assert result_with_join_model["total_count"] == result_with_joins_config["total_count"]
+    
+    # Data length should be limited by the limit parameter
+    assert len(result_with_join_model["data"]) == 5
+    assert len(result_with_joins_config["data"]) == 5
+
+
+@pytest.mark.asyncio
+async def test_get_multi_joined_total_count_with_filters(async_session, test_data, test_data_tier):
+    """Test that total_count is correct when using filters with join_model parameter."""
+    # Setup test data
+    for tier_item in test_data_tier:
+        async_session.add(TierModel(**tier_item))
+    await async_session.commit()
+
+    for user_item in test_data:
+        async_session.add(ModelTest(**user_item))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    
+    # Count how many records have tier_id=1
+    expected_count = sum(1 for item in test_data if item["tier_id"] == 1)
+    
+    # Use join_model parameter with filter
+    result_with_join_model = await crud.get_multi_joined(
+        db=async_session,
+        join_model=TierModel,
+        join_prefix="tier_",
+        schema_to_select=CreateSchemaTest,
+        join_schema_to_select=TierSchemaTest,
+        offset=0,
+        limit=10,
+        tier_id=1,  # Filter by tier_id
+    )
+    
+    # Use joins_config parameter with same filter
+    result_with_joins_config = await crud.get_multi_joined(
+        db=async_session,
+        schema_to_select=CreateSchemaTest,
+        joins_config=[
+            JoinConfig(
+                model=TierModel,
+                join_on=ModelTest.tier_id == TierModel.id,
+                join_prefix="tier_",
+                schema_to_select=TierSchemaTest,
+                join_type="left",
+            )
+        ],
+        offset=0,
+        limit=10,
+        tier_id=1,  # Same filter
+    )
+    
+    # Both approaches should return the same filtered total_count
+    assert result_with_join_model["total_count"] == expected_count
+    assert result_with_joins_config["total_count"] == expected_count
+    assert result_with_join_model["total_count"] == result_with_joins_config["total_count"]


### PR DESCRIPTION
Issue Summary
The issue was in the get_multi_joined method of the FastCRUD class. When using the join_model parameter without providing joins_config, the method was incorrectly passing only joins_config to the count method instead of the combined join_definitions list. This resulted in incorrect total_count values when using join_model.
Solution
I fixed the issue by changing line 2128 in fastcrud/crud/fast_crud.py to pass join_definitions instead of joins_config to the count method:

Solving: https://github.com/igorbenav/fastcrud/issues/219
## Tests
I created a new test file tests/sqlalchemy/crud/test_get_multi_joined_total_count.py with two test cases:
test_get_multi_joined_total_count_with_join_model - Tests that total_count is correct when using join_model
test_get_multi_joined_total_count_with_filters - Tests that total_count is correct when using filters with join_model
Both tests verify that the total_count is the same whether using join_model or joins_config.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.

## Additional Notes
Include any additional information that you think is important for reviewers to know.
