### PR TITLE
add handling for sqlalchemy_utils types in _get_python_type function

### DIFF
--- a/fastcrud/endpoint/helper.py
+++ b/fastcrud/endpoint/helper.py
@@ -117,6 +117,10 @@ def _get_python_type(column: Column) -> Optional[type]:
         direct_type: Optional[type] = column.type.python_type
         return direct_type
     except NotImplementedError:
+        if column.type.__module__.startswith("sqlalchemy_utils"):
+            # if the type is from sqlalchemy_utils and doesn't have a direct mapping to Python types, will be ignored
+            return None
+
         if hasattr(column.type, "impl") and hasattr(column.type.impl, "python_type"):
             if _is_uuid_type(column.type.impl):  # pragma: no cover
                 return UUID

--- a/tests/sqlalchemy/conftest.py
+++ b/tests/sqlalchemy/conftest.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from typing import Optional
 from datetime import datetime
 
@@ -689,3 +690,27 @@ def endpoint_creator(test_model, async_session) -> EndpointCreator:
             "read_multi": "get_multi",
         },
     )
+
+
+@pytest.fixture
+def fake_sqlalchemy_utils_column_no_python_type() -> SimpleNamespace:
+    fake_column = SimpleNamespace(
+        __module__="sqlalchemy_utils.anything",
+        type=SimpleNamespace(
+            __module__="sqlalchemy_utils.types.anything",
+            python_type=None,
+        ),
+    )
+    return fake_column
+
+
+@pytest.fixture
+def fake_sqlalchemy_utils_column_with_python_type() -> SimpleNamespace:
+    fake_column = SimpleNamespace(
+        __module__="sqlalchemy_utils.anything",
+        type=SimpleNamespace(
+            __module__="sqlalchemy_utils.types.anything",
+            python_type=str,
+        ),
+    )
+    return fake_column

--- a/tests/sqlalchemy/core/test_helper.py
+++ b/tests/sqlalchemy/core/test_helper.py
@@ -1,0 +1,16 @@
+from fastcrud.endpoint import helper
+
+
+def test_get_python_type_returns_none_when_not_implemented(
+    fake_sqlalchemy_utils_column_no_python_type,
+) -> None:
+    result = helper._get_python_type(fake_sqlalchemy_utils_column_no_python_type)
+    assert result is None
+
+
+def test_get_python_type_returns_correct_type_when_implemented(
+    fake_sqlalchemy_utils_column_with_python_type,
+) -> None:
+    result = helper._get_python_type(fake_sqlalchemy_utils_column_with_python_type)
+    assert result is not None
+    assert result == fake_sqlalchemy_utils_column_with_python_type.type.python_type


### PR DESCRIPTION
# Add Handling for Sqlalchemy-Utils Types

## Description
I add a check for sqlalchemy_utils types in `_get_python_type` function.
If column type is from sqlalchemy_utils and has no direct Python type, it will return None and ignore it.

## Changes
Add check:
If `column.type.python_type` raised `NotImplementedError` and `column.type.__module__` starts with "sqlalchemy_utils", return None in `_get_python_type`

## Tests
Added test to cover the change, one in case a sqlalchemy-utils type doesn't implement python_type and another one in case it implemented it

## Checklist
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] I have added necessary documentation (if appropriate).
- [X] I have added tests that cover my changes (if applicable).
- [X] All new and existing tests passed.

## Additional Notes
this PR solve https://github.com/benavlabs/crudadmin/issues/21 issue
