### PR TITLE
Expose types of filter parameters

### DIFF
--- a/fastcrud/core/filtering/__init__.py
+++ b/fastcrud/core/filtering/__init__.py
@@ -6,14 +6,24 @@ Python filter arguments into SQLAlchemy WHERE clauses. It supports a wide range
 of operators and complex filtering scenarios including OR, NOT, and joined model filters.
 """
 
+from .filter_model import Filter
 from .processor import FilterProcessor
-from .operators import SUPPORTED_FILTERS, get_sqlalchemy_filter, FilterCallable
+from .operators import (
+    COLLECTION_OPERATORS,
+    SUPPORTED_FILTERS,
+    FilterCallable,
+    get_operator_wrap_type,
+    get_sqlalchemy_filter,
+)
 from .validators import validate_joined_filter_format, validate_filter_operator
 
 __all__ = [
+    "COLLECTION_OPERATORS",
+    "Filter",
     "FilterProcessor",
     "FilterCallable",
     "SUPPORTED_FILTERS",
+    "get_operator_wrap_type",
     "get_sqlalchemy_filter",
     "validate_joined_filter_format",
     "validate_filter_operator",

--- a/fastcrud/core/filtering/filter_model.py
+++ b/fastcrud/core/filtering/filter_model.py
@@ -1,0 +1,64 @@
+"""
+Internal representation of a single filter definition.
+
+This module provides the :class:`Filter` Pydantic model, which captures all
+metadata needed to (a) generate a correct FastAPI / OpenAPI query parameter
+and (b) build a SQLAlchemy WHERE clause from a runtime value.
+
+It sits between :class:`~fastcrud.core.config.crud_configs.FilterConfig`
+(surface-level dict of ``"key__op": default`` entries) and the SQLAlchemy
+clauses produced by :class:`~fastcrud.core.filtering.processor.FilterProcessor`.
+"""
+
+from typing import Any, cast
+
+from pydantic import BaseModel, ConfigDict, SkipValidation, computed_field
+from sqlalchemy import Column
+
+
+class Filter(BaseModel):
+    """
+    Resolved metadata for a single filter entry in a ``FilterConfig``.
+
+    Attributes:
+        definition: Original key from ``FilterConfig`` (e.g. ``"name"``,
+            ``"age__gte"``, ``"tier.name__eq"``).
+        param_name: FastAPI-safe parameter name (dots replaced with
+            underscores), used as the actual function parameter name in the
+            generated dependency.
+        default_value: Default value or ``Depends(...)`` callable from
+            ``FilterConfig``.
+        operator: The operator suffix after ``__``, e.g. ``"gte"``,
+            ``"ilike"``, ``"in"``; ``None`` for bare equality filters.
+        wrap_type: Wrapper type for collection operators (``list`` for
+            ``in``/``not_in``/``between``); ``None`` otherwise.
+        joined_model: The related model class when the filter targets a
+            joined relationship (e.g. ``"tier.name"``); ``None`` for filters
+            on the base model.
+        column: The SQLAlchemy ``Column`` the filter ultimately applies to.
+        value_type: The Python type of ``column``, derived via
+            ``column.type.python_type``.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    definition: str
+    param_name: str
+    default_value: Any
+    operator: str | None
+    wrap_type: type | None
+    joined_model: type | None
+    column: SkipValidation[Column[Any]]
+    value_type: type
+
+    @computed_field
+    def type(self) -> type:
+        """
+        Final Python type for OpenAPI / FastAPI signature generation.
+
+        Returns ``value_type`` for scalar filters, or ``wrap_type[value_type]``
+        (e.g. ``list[int]``) for collection operators.
+        """
+        if self.wrap_type:
+            return cast(type, self.wrap_type[self.value_type])  # type: ignore[index]
+        return self.value_type

--- a/fastcrud/core/filtering/operators.py
+++ b/fastcrud/core/filtering/operators.py
@@ -13,6 +13,8 @@ from ...types import FilterValueType
 
 FilterCallable = Callable[[Column[Any]], Callable[..., ColumnElement[bool]]]
 
+COLLECTION_OPERATORS: frozenset[str] = frozenset({"in", "not_in", "between"})
+
 SUPPORTED_FILTERS: dict[str, FilterCallable] = {
     "eq": lambda column: column.__eq__,
     "gt": lambda column: column.__gt__,
@@ -72,7 +74,7 @@ def get_sqlalchemy_filter(
         >>> custom = {"year": lambda col: lambda val: func.extract('year', col) == val}
         >>> filter_func = get_sqlalchemy_filter('year', 2024, custom_filters=custom)
     """
-    if operator in {"in", "not_in", "between"}:
+    if operator in COLLECTION_OPERATORS:
         if not isinstance(value, (tuple, list, set)):
             raise ValueError(f"<{operator}> filter must be tuple, list or set")
 
@@ -87,3 +89,23 @@ def get_sqlalchemy_filter(
         return custom_filters[operator]
 
     return SUPPORTED_FILTERS.get(operator)
+
+
+def get_operator_wrap_type(operator: str | None) -> type | None:
+    """
+    Return the wrapper type for a filter operator's value, if any.
+
+    Collection operators (``in``, ``not_in``, ``between``) take a sequence of
+    values rather than a single value. Use this to derive the right type
+    annotation: e.g. for ``age__in`` the annotation is ``list[int]``, not
+    ``int``.
+
+    Args:
+        operator: Filter operator string, or None for a bare equality filter.
+
+    Returns:
+        ``list`` for collection operators; ``None`` otherwise.
+    """
+    if operator in COLLECTION_OPERATORS:
+        return list
+    return None

--- a/fastcrud/core/filtering/processor.py
+++ b/fastcrud/core/filtering/processor.py
@@ -6,15 +6,19 @@ into SQLAlchemy WHERE clauses. It supports complex filtering scenarios including
 OR conditions, NOT conditions, and joined model filters.
 """
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from sqlalchemy import Column, or_, not_, and_
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.sql.elements import ColumnElement
 
-from ..introspection import get_model_column
+from ..introspection import get_column_types, get_model_column
 from ...types import ModelType, FilterValueType
-from .operators import get_sqlalchemy_filter, FilterCallable
+from .filter_model import Filter
+from .operators import get_operator_wrap_type, get_sqlalchemy_filter, FilterCallable
 from .validators import validate_joined_filter_format
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..config.crud_configs import FilterConfig
 
 
 class FilterProcessor:
@@ -371,6 +375,75 @@ class FilterProcessor:
             return [target_column == value]
         else:
             return self._handle_standard_filter(target_column, operator, value)
+
+    def interpret_filters(self, filter_config: "FilterConfig") -> list[Filter]:
+        """
+        Resolve every entry in ``filter_config`` into a :class:`Filter` object.
+
+        For each ``"definition": default`` pair in ``filter_config.filters``,
+        this method splits the operator suffix, walks any relationship path
+        (e.g. ``"tier.name"``), looks up the target SQLAlchemy column on the
+        appropriate model, and derives the Python value type.
+
+        Used by :func:`~fastcrud.fastapi_dependencies.create_dynamic_filters`
+        to build a typed FastAPI dependency, but the resulting metadata is
+        general-purpose.
+
+        Args:
+            filter_config: The ``FilterConfig`` to interpret.
+
+        Returns:
+            One ``Filter`` per entry in ``filter_config.filters``, in
+            definition order.
+
+        Raises:
+            ValueError: If a joined filter references a missing relationship
+                or column, or the format is invalid.
+        """
+        filters: list[Filter] = []
+
+        for definition, default_value in filter_config.filters.items():
+            field_and_operator = definition.rsplit("__", 1)
+            field_definition = field_and_operator[0]
+            operator = field_and_operator[1] if len(field_and_operator) > 1 else None
+
+            param_name = definition.replace(".", "_")
+            wrap_type = get_operator_wrap_type(operator)
+
+            if filter_config.is_joined_filter(definition):
+                validate_joined_filter_format(definition)
+
+                relationship_name, column_name = field_definition.split(".", 1)
+                relationship_column = get_model_column(self.model, relationship_name)
+
+                if not hasattr(relationship_column.property, "mapper"):
+                    raise ValueError(
+                        f"Invalid relationship '{relationship_name}' in model "
+                        f"'{self.model.__name__}'"
+                    )
+
+                joined_model = relationship_column.property.mapper.class_
+                column = get_model_column(joined_model, column_name)
+                value_type = dict(get_column_types(joined_model))[column_name]
+            else:
+                joined_model = None
+                column = get_model_column(self.model, field_definition)
+                value_type = dict(get_column_types(self.model))[field_definition]
+
+            filters.append(
+                Filter(
+                    definition=definition,
+                    param_name=param_name,
+                    default_value=default_value,
+                    operator=operator,
+                    wrap_type=wrap_type,
+                    joined_model=joined_model,
+                    column=column,
+                    value_type=value_type,
+                )
+            )
+
+        return filters
 
     def separate_joined_filters(
         self, **kwargs: Any

--- a/fastcrud/endpoint/endpoint_creator.py
+++ b/fastcrud/endpoint/endpoint_creator.py
@@ -737,7 +737,7 @@ class EndpointCreator:
         The query parameters are encapsulated in PaginatedRequestQuery schema,
         which can be reused in custom endpoints.
         """
-        dynamic_filters = create_dynamic_filters(self.filter_config, self.column_types)
+        dynamic_filters = create_dynamic_filters(self.filter_config, self.model)
 
         async def endpoint(
             db: AsyncSession = Depends(self.session),

--- a/fastcrud/fastapi_dependencies.py
+++ b/fastcrud/fastapi_dependencies.py
@@ -20,6 +20,9 @@ from uuid import UUID
 
 from fastapi import Depends, Query, Path, params
 
+from .core.filtering import FilterProcessor
+from .types import ModelType
+
 if TYPE_CHECKING:
     from .core.config import CreateConfig, UpdateConfig, DeleteConfig, FilterConfig
 
@@ -98,82 +101,91 @@ def _str_to_bool(value: bool | str) -> bool:
 
 
 def create_dynamic_filters(
-    filter_config: "FilterConfig | None", column_types: dict[str, type]
+    filter_config: "FilterConfig | None",
+    model: type[ModelType],
 ) -> Callable[..., dict[str, Any]]:
     """
     Create dynamic filter function for handling query parameters.
 
-    This function creates a dependency function that can parse and validate
-    query parameters based on the filter configuration and column types.
+    This function creates a FastAPI dependency that parses, validates, and
+    type-coerces query parameters based on a ``FilterConfig`` and the
+    SQLAlchemy model being filtered. Each filter entry is resolved into a
+    :class:`~fastcrud.core.filtering.Filter` whose ``type`` property is used
+    as the parameter annotation — so the generated OpenAPI schema reports
+    the correct type (``integer``, ``string``, ``boolean``, ``array``, …)
+    instead of falling back to ``any``.
 
     Args:
         filter_config: Configuration object defining available filters.
-        column_types: Dictionary mapping column names to their Python types.
+        model: The SQLAlchemy model the filters apply to. Used to introspect
+            column types and walk joined relationships.
 
     Returns:
         A dependency function that processes filter parameters.
 
     Example:
         >>> filter_config = FilterConfig(filters={"name": None, "age__gte": 18})
-        >>> column_types = {"name": str, "age": int}
-        >>> filter_func = create_dynamic_filters(filter_config, column_types)
+        >>> filter_func = create_dynamic_filters(filter_config, User)
         >>> # filter_func can be used with FastAPI's Depends()
     """
     if filter_config is None:
         return lambda: {}
 
-    param_to_filter_key = {}
-    for original_key in filter_config.filters.keys():
-        param_name = original_key.replace(".", "_")
-        param_to_filter_key[param_name] = original_key
+    interpreted = FilterProcessor(model).interpret_filters(filter_config)
+    filters_by_param: dict[str, Any] = {f.param_name: f for f in interpreted}
 
     def filters(
         **kwargs: Any,
     ) -> dict[str, Any]:
-        filtered_params = {}
+        filtered_params: dict[str, Any] = {}
         for param_name, value in kwargs.items():
-            if value is not None:
-                original_key = param_to_filter_key.get(param_name, param_name)
-                key_without_op = original_key.rsplit("__", 1)[0]
-                parse_func = column_types.get(key_without_op)
-                if parse_func:
-                    try:
-                        # Special handling for bool bool('false') = True
-                        filtered_params[original_key] = (
-                            _str_to_bool(value)
-                            if (parse_func is bool)
-                            else parse_func(value)
-                        )
-                    except (ValueError, TypeError):
-                        filtered_params[original_key] = value
+            if value is None:
+                continue
+
+            filter_ = filters_by_param.get(param_name)
+            if filter_ is None:
+                filtered_params[param_name] = value
+                continue
+
+            # Collection operators (in / not_in / between) pass through as-is —
+            # FastAPI handles list coercion via the parameter annotation.
+            if filter_.wrap_type is not None:
+                filtered_params[filter_.definition] = value
+                continue
+
+            try:
+                if filter_.value_type is bool:
+                    # Special-case: bool("false") is True. Use the helper to
+                    # honour query-string truthiness conventions.
+                    filtered_params[filter_.definition] = _str_to_bool(value)
                 else:
-                    filtered_params[original_key] = value
+                    filtered_params[filter_.definition] = filter_.value_type(value)
+            except (ValueError, TypeError):
+                filtered_params[filter_.definition] = value
+
         return filtered_params
 
-    params = []
-    for key, value in filter_config.filters.items():
-        param_name = key.replace(".", "_")
-
-        if callable(value):
-            params.append(
+    sig_params: list[inspect.Parameter] = []
+    for filter_ in interpreted:
+        if callable(filter_.default_value):
+            sig_params.append(
                 inspect.Parameter(
-                    param_name,
+                    filter_.param_name,
                     inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    default=Depends(value),
+                    default=Depends(filter_.default_value),
                 )
             )
         else:
-            params.append(
+            sig_params.append(
                 inspect.Parameter(
-                    param_name,
+                    filter_.param_name,
                     inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                    default=Query(value, alias=key),
+                    annotation=filter_.type,
+                    default=Query(filter_.default_value, alias=filter_.definition),
                 )
             )
 
-    sig = inspect.Signature(params)
-    setattr(filters, "__signature__", sig)
-
+    setattr(filters, "__signature__", inspect.Signature(sig_params))
     return filters
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import os
+
+# Disable testcontainers' Ryuk reaper before any subpackage imports it.
+#
+# Ryuk is a side-car container that watches the test process and cleans up
+# other containers when it exits. On macOS Docker Desktop, rapid sequential
+# test sessions can collide on the Ryuk container name and fail with a 409
+# Conflict, blocking the whole dialect test matrix. Disabling Ryuk skips the
+# coordinator entirely; spawned postgres/mysql containers stop on their own
+# when the test using them exits. The only downside is that if a test
+# process is killed (SIGKILL, OOM), its dialect containers leak — clean up
+# manually with `docker container prune`.
+os.environ.setdefault("TESTCONTAINERS_RYUK_DISABLED", "true")

--- a/tests/sqlalchemy/core/test_uuid.py
+++ b/tests/sqlalchemy/core/test_uuid.py
@@ -1,7 +1,7 @@
 import pytest
 from uuid import UUID, uuid4
 
-from sqlalchemy import Column, String
+from sqlalchemy import Column, Integer, String
 from sqlalchemy.dialects.postgresql import UUID as PostgresUUID
 from sqlalchemy.types import TypeDecorator
 from fastapi import FastAPI
@@ -219,15 +219,18 @@ async def test_uuid_list_endpoint(uuid_client):
             pytest.fail("Invalid UUID format in list response")
 
 
+class FilterTypesModel(Base):
+    __tablename__ = "filter_types_test"
+    id = Column(Integer, primary_key=True)
+    uuid_field = Column(CustomUUID())  # type: ignore[misc, var-annotated]
+    int_field = Column(Integer)
+    str_field = Column(String(255))
+
+
 def test_create_dynamic_filters_type_conversion():
     filter_config = FilterConfig(uuid_field=None, int_field=None, str_field=None)
-    column_types = {
-        "uuid_field": UUID,
-        "int_field": int,
-        "str_field": str,
-    }
 
-    filters_func = create_dynamic_filters(filter_config, column_types)
+    filters_func = create_dynamic_filters(filter_config, FilterTypesModel)
 
     test_uuid = "123e4567-e89b-12d3-a456-426614174000"
     result = filters_func(uuid_field=test_uuid, int_field="123", str_field=456)
@@ -255,5 +258,5 @@ def test_create_dynamic_filters_type_conversion():
     result = filters_func(unknown_field="test")
     assert result["unknown_field"] == "test"
 
-    empty_filters_func = create_dynamic_filters(None, {})
+    empty_filters_func = create_dynamic_filters(None, FilterTypesModel)
     assert empty_filters_func() == {}

--- a/tests/sqlalchemy/endpoint/test_filter_param_types.py
+++ b/tests/sqlalchemy/endpoint/test_filter_param_types.py
@@ -1,0 +1,128 @@
+"""
+Verify that ``crud_router`` exposes correct column types for filter query
+parameters in the generated OpenAPI schema.
+
+Before this was wired up, every filter parameter rendered as ``any``,
+regardless of the underlying column type. See issue #291.
+"""
+
+from typing import Any, cast
+
+import pytest
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sqlalchemy import Boolean, Column, Float, Integer, String
+
+from fastcrud import FastCRUD, FilterConfig, crud_router
+
+from ..conftest import Base, ModelTest
+
+
+class FilterParamTypesModel(Base):
+    __tablename__ = "filter_param_types_test"
+    id = Column(Integer, primary_key=True)
+    int_param = Column(Integer)
+    float_param = Column(Float)
+    str_param = Column(String(32))
+    bool_param = Column(Boolean)
+
+
+class NullSchema(BaseModel):
+    pass
+
+
+def _openapi_param_schema(app: FastAPI, path: str, name: str) -> dict[str, Any]:
+    """Return the ``schema`` block for a query parameter in the GET op of *path*."""
+    op = app.openapi()["paths"][path]["get"]
+    param = next(p for p in op["parameters"] if p["name"] == name)
+    return cast(dict[str, Any], param["schema"])
+
+
+def _router_for(model: Any, filter_config: FilterConfig, **kwargs: Any) -> FastAPI:
+    app = FastAPI()
+    app.include_router(
+        crud_router(
+            session=lambda: None,  # type: ignore[arg-type, return-value]
+            model=model,
+            create_schema=NullSchema,
+            update_schema=NullSchema,
+            filter_config=filter_config,
+            path="/items",
+            tags=["items"],
+            **kwargs,
+        )
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_simple_column_types_exposed_in_openapi():
+    """Each scalar column kind should surface its proper OpenAPI type."""
+    app = _router_for(
+        FilterParamTypesModel,
+        FilterConfig(int_param=None, float_param=None, str_param=None, bool_param=None),
+    )
+
+    assert _openapi_param_schema(app, "/items", "int_param")["type"] == "integer"
+    assert _openapi_param_schema(app, "/items", "float_param")["type"] == "number"
+    assert _openapi_param_schema(app, "/items", "str_param")["type"] == "string"
+    assert _openapi_param_schema(app, "/items", "bool_param")["type"] == "boolean"
+
+
+@pytest.mark.asyncio
+async def test_operator_filters_keep_column_type():
+    """``field__gte`` / ``field__ilike`` should inherit the column's type."""
+    app = _router_for(
+        FilterParamTypesModel,
+        FilterConfig(int_param__gte=None, str_param__ilike=None),
+    )
+
+    assert _openapi_param_schema(app, "/items", "int_param__gte")["type"] == "integer"
+    assert _openapi_param_schema(app, "/items", "str_param__ilike")["type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_collection_operators_render_as_array():
+    """``__in`` / ``__not_in`` / ``__between`` should be typed as arrays."""
+    app = _router_for(
+        FilterParamTypesModel,
+        FilterConfig(int_param__in=None, str_param__between=None),
+    )
+
+    in_schema = _openapi_param_schema(app, "/items", "int_param__in")
+    assert in_schema["type"] == "array"
+    assert in_schema["items"]["type"] == "integer"
+
+    between_schema = _openapi_param_schema(app, "/items", "str_param__between")
+    assert between_schema["type"] == "array"
+    assert between_schema["items"]["type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_joined_filter_uses_related_column_type():
+    """``related.field__op`` should pick up the related model's column type."""
+    app = _router_for(ModelTest, FilterConfig(**{"tier.name__eq": None}))
+
+    schema = _openapi_param_schema(app, "/items", "tier.name__eq")
+    assert schema["type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_custom_filters_still_work_with_typed_params():
+    """Regression: v0.20.0 custom_filters should not be broken by the type wiring."""
+    from sqlalchemy import func
+
+    custom_filters = {
+        "year": lambda col: lambda val: func.strftime("%Y", col) == str(val),
+    }
+
+    app = _router_for(
+        FilterParamTypesModel,
+        FilterConfig(int_param__year=None),
+        crud=FastCRUD(FilterParamTypesModel, custom_filters=custom_filters),
+        custom_filters=custom_filters,
+    )
+
+    # The operator is the suffix, the value type is still the column's (integer).
+    schema = _openapi_param_schema(app, "/items", "int_param__year")
+    assert schema["type"] == "integer"

--- a/tests/sqlalchemy/endpoint/test_filter_param_types.py
+++ b/tests/sqlalchemy/endpoint/test_filter_param_types.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from sqlalchemy import Boolean, Column, Float, Integer, String
 
 from fastcrud import FastCRUD, FilterConfig, crud_router
+from fastcrud.core import FilterProcessor, create_dynamic_filters
 
 from ..conftest import Base, ModelTest
 
@@ -126,3 +127,26 @@ async def test_custom_filters_still_work_with_typed_params():
     # The operator is the suffix, the value type is still the column's (integer).
     schema = _openapi_param_schema(app, "/items", "int_param__year")
     assert schema["type"] == "integer"
+
+
+def test_filter_func_passes_collection_values_through_unchanged():
+    """Collection operators (``__in`` / ``__between`` / ``__not_in``) skip the
+    per-value coercion path — the typed annotation lets FastAPI parse the list."""
+    filter_config = FilterConfig(int_param__in=None, str_param__between=None)
+    filters_func = create_dynamic_filters(filter_config, FilterParamTypesModel)
+
+    result = filters_func(int_param__in=[1, 2, 3], str_param__between=["a", "z"])
+
+    assert result == {
+        "int_param__in": [1, 2, 3],
+        "str_param__between": ["a", "z"],
+    }
+
+
+def test_interpret_filters_rejects_non_relationship_dotted_path():
+    """A dotted filter whose first segment is a column, not a relationship,
+    must raise — otherwise we'd try to join on a non-existent mapper."""
+    processor = FilterProcessor(FilterParamTypesModel)
+
+    with pytest.raises(ValueError, match="Invalid relationship 'int_param'"):
+        processor.interpret_filters(FilterConfig(**{"int_param.something__eq": None}))

--- a/tests/sqlmodel/core/test_uuid.py
+++ b/tests/sqlmodel/core/test_uuid.py
@@ -1,7 +1,7 @@
 import pytest
 from uuid import UUID, uuid4
 
-from sqlalchemy import Column, String
+from sqlalchemy import Boolean, Column, Integer, String
 from sqlalchemy.dialects.postgresql import UUID as PostgresUUID
 from sqlalchemy.types import TypeDecorator
 from pydantic import ConfigDict
@@ -221,18 +221,21 @@ async def test_uuid_list_endpoint(uuid_client):
             pytest.fail("Invalid UUID format in list response")
 
 
+class FilterTypesModel(SQLModel, table=True):
+    __tablename__ = "filter_types_test"
+    id: int = Field(sa_column=Column(Integer, primary_key=True))
+    uuid_field: UUID | None = Field(default=None, sa_column=Column(CustomUUID()))  # type: ignore[misc]
+    int_field: int | None = Field(default=None, sa_column=Column(Integer))
+    str_field: str | None = Field(default=None, sa_column=Column(String(255)))
+    bool_field: bool | None = Field(default=None, sa_column=Column(Boolean))
+
+
 def test_create_dynamic_filters_type_conversion():
     filter_config = FilterConfig(
         uuid_field=None, int_field=None, str_field=None, bool_field=None
     )
-    column_types = {
-        "uuid_field": UUID,
-        "int_field": int,
-        "str_field": str,
-        "bool_field": bool,
-    }
 
-    filters_func = create_dynamic_filters(filter_config, column_types)
+    filters_func = create_dynamic_filters(filter_config, FilterTypesModel)
 
     test_uuid = "123e4567-e89b-12d3-a456-426614174000"
     result = filters_func(uuid_field=test_uuid, int_field="123", str_field=456)
@@ -292,5 +295,5 @@ def test_create_dynamic_filters_type_conversion():
     result = filters_func(bool_field="invalid")
     assert result["bool_field"] == "invalid"
 
-    empty_filters_func = create_dynamic_filters(None, {})
+    empty_filters_func = create_dynamic_filters(None, FilterTypesModel)
     assert empty_filters_func() == {}

--- a/tests/sqlmodel/endpoint/test_filter_param_types.py
+++ b/tests/sqlmodel/endpoint/test_filter_param_types.py
@@ -1,0 +1,139 @@
+"""
+SQLModel parity for :mod:`tests.sqlalchemy.endpoint.test_filter_param_types`.
+
+Verifies that ``crud_router`` exposes correct column types for filter query
+parameters in the generated OpenAPI schema when models are declared with
+SQLModel. See issue #291.
+"""
+
+from typing import Any, cast
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI
+from pydantic import BaseModel
+from sqlmodel import Field, SQLModel
+
+from fastcrud import FastCRUD, FilterConfig, crud_router
+
+from ..conftest import ModelTest
+
+
+class FilterParamTypesModel(SQLModel, table=True):
+    __tablename__ = "filter_param_types_test"
+    id: int = Field(primary_key=True)
+    int_param: int | None = Field(default=None)
+    float_param: float | None = Field(default=None)
+    str_param: str | None = Field(default=None)
+    bool_param: bool | None = Field(default=None)
+    uuid_param: UUID | None = Field(default_factory=uuid4)
+
+
+class NullSchema(BaseModel):
+    pass
+
+
+def _openapi_param_schema(app: FastAPI, path: str, name: str) -> dict[str, Any]:
+    op = app.openapi()["paths"][path]["get"]
+    param = next(p for p in op["parameters"] if p["name"] == name)
+    return cast(dict[str, Any], param["schema"])
+
+
+def _router_for(model: Any, filter_config: FilterConfig, **kwargs: Any) -> FastAPI:
+    app = FastAPI()
+    app.include_router(
+        crud_router(
+            session=lambda: None,  # type: ignore[arg-type, return-value]
+            model=model,
+            create_schema=NullSchema,
+            update_schema=NullSchema,
+            filter_config=filter_config,
+            path="/items",
+            tags=["items"],
+            **kwargs,
+        )
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_simple_column_types_exposed_in_openapi():
+    app = _router_for(
+        FilterParamTypesModel,
+        FilterConfig(int_param=None, float_param=None, str_param=None, bool_param=None),
+    )
+
+    assert _openapi_param_schema(app, "/items", "int_param")["type"] == "integer"
+    assert _openapi_param_schema(app, "/items", "float_param")["type"] == "number"
+    assert _openapi_param_schema(app, "/items", "str_param")["type"] == "string"
+    assert _openapi_param_schema(app, "/items", "bool_param")["type"] == "boolean"
+
+
+@pytest.mark.asyncio
+async def test_sqlmodel_guid_type_resolves_to_string():
+    """SQLModel's GUID column type must resolve to a string-format OpenAPI param.
+
+    Regression for the ``is_uuid_type`` branch that recognises SQLModel's GUID
+    by class name.
+    """
+    app = _router_for(FilterParamTypesModel, FilterConfig(uuid_param=None))
+
+    schema = _openapi_param_schema(app, "/items", "uuid_param")
+    # FastAPI emits UUID as string with a uuid format.
+    assert schema["type"] == "string"
+    assert schema.get("format") == "uuid"
+
+
+@pytest.mark.asyncio
+async def test_operator_filters_keep_column_type():
+    app = _router_for(
+        FilterParamTypesModel,
+        FilterConfig(int_param__gte=None, str_param__ilike=None),
+    )
+
+    assert _openapi_param_schema(app, "/items", "int_param__gte")["type"] == "integer"
+    assert _openapi_param_schema(app, "/items", "str_param__ilike")["type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_collection_operators_render_as_array():
+    app = _router_for(
+        FilterParamTypesModel,
+        FilterConfig(int_param__in=None, str_param__between=None),
+    )
+
+    in_schema = _openapi_param_schema(app, "/items", "int_param__in")
+    assert in_schema["type"] == "array"
+    assert in_schema["items"]["type"] == "integer"
+
+    between_schema = _openapi_param_schema(app, "/items", "str_param__between")
+    assert between_schema["type"] == "array"
+    assert between_schema["items"]["type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_joined_filter_uses_related_column_type():
+    app = _router_for(ModelTest, FilterConfig(**{"tier.name__eq": None}))
+
+    schema = _openapi_param_schema(app, "/items", "tier.name__eq")
+    assert schema["type"] == "string"
+
+
+@pytest.mark.asyncio
+async def test_custom_filters_still_work_with_typed_params():
+    """Regression: v0.20.0 custom_filters should not be broken by the type wiring."""
+    from sqlalchemy import func
+
+    custom_filters = {
+        "year": lambda col: lambda val: func.strftime("%Y", col) == str(val),
+    }
+
+    app = _router_for(
+        FilterParamTypesModel,
+        FilterConfig(int_param__year=None),
+        crud=FastCRUD(FilterParamTypesModel, custom_filters=custom_filters),
+        custom_filters=custom_filters,
+    )
+
+    schema = _openapi_param_schema(app, "/items", "int_param__year")
+    assert schema["type"] == "integer"

--- a/tests/sqlmodel/endpoint/test_filter_param_types.py
+++ b/tests/sqlmodel/endpoint/test_filter_param_types.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from sqlmodel import Field, SQLModel
 
 from fastcrud import FastCRUD, FilterConfig, crud_router
+from fastcrud.core import FilterProcessor, create_dynamic_filters
 
 from ..conftest import ModelTest
 
@@ -137,3 +138,26 @@ async def test_custom_filters_still_work_with_typed_params():
 
     schema = _openapi_param_schema(app, "/items", "int_param__year")
     assert schema["type"] == "integer"
+
+
+def test_filter_func_passes_collection_values_through_unchanged():
+    """Collection operators (``__in`` / ``__between`` / ``__not_in``) skip the
+    per-value coercion path — the typed annotation lets FastAPI parse the list."""
+    filter_config = FilterConfig(int_param__in=None, str_param__between=None)
+    filters_func = create_dynamic_filters(filter_config, FilterParamTypesModel)
+
+    result = filters_func(int_param__in=[1, 2, 3], str_param__between=["a", "z"])
+
+    assert result == {
+        "int_param__in": [1, 2, 3],
+        "str_param__between": ["a", "z"],
+    }
+
+
+def test_interpret_filters_rejects_non_relationship_dotted_path():
+    """A dotted filter whose first segment is a column, not a relationship,
+    must raise — otherwise we'd try to join on a non-existent mapper."""
+    processor = FilterProcessor(FilterParamTypesModel)
+
+    with pytest.raises(ValueError, match="Invalid relationship 'int_param'"):
+        processor.interpret_filters(FilterConfig(**{"int_param.something__eq": None}))


### PR DESCRIPTION
# Expose types of filter parameters

## Description
With a SQLAlchemy model which has
```
title: Mapped[str]
```

when a `crud_router` has:
```python
filter_config={"title": None},
```

then the generated spec says the param type is `any`:
<img width="499" height="94" alt="Screenshot 2025-11-21 at 17 08 53" src="https://github.com/user-attachments/assets/f581d6c6-3c6e-42fb-926d-4a543b7929df" />

## Changes
Look up the param type from `column_types` so that
<img width="500" height="97" alt="Screenshot 2025-11-21 at 17 08 38" src="https://github.com/user-attachments/assets/e7a5d985-5aef-41ec-8adc-c5c4a79793a5" />

## Tests
Added a new test which checks the generated types.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.
