### PR TITLE
Fix joined filter when primary and join target share polymorphic base - #305

### DIFF
--- a/fastcrud/core/field_management.py
+++ b/fastcrud/core/field_management.py
@@ -290,7 +290,7 @@ def auto_detect_join_condition(
     return join_on
 
 
-def _has_table_overlap(primary_model: ModelType, join_model: ModelType) -> bool:
+def has_table_overlap(primary_model: ModelType, join_model: ModelType) -> bool:
     """Check whether primary_model and join_model share any underlying tables.
 
     This occurs with SQLAlchemy joined table inheritance when both models
@@ -435,7 +435,7 @@ def build_relationship_joins_config(
             alias = aliased(related_model, name=rel_name)
         model_counts[related_model] = model_counts.get(related_model, 0) + 1
 
-        if alias is None and _has_table_overlap(model, related_model):
+        if alias is None and has_table_overlap(model, related_model):
             alias = aliased(related_model, flat=True)
 
         try:

--- a/fastcrud/crud/validation.py
+++ b/fastcrud/crud/validation.py
@@ -6,8 +6,11 @@ but generic enough to be reused across different CRUD classes.
 """
 
 from typing import Any, Callable, Awaitable, TYPE_CHECKING
+from sqlalchemy.orm import aliased as sa_aliased
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import NoResultFound, MultipleResultsFound
+
+from ..core.field_management import has_table_overlap
 
 if TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.orm.util import AliasedClass
@@ -127,10 +130,7 @@ def validate_joined_query_params(
     join_definitions = joins_config if joins_config else []
     if join_model:
         if alias is None and join_on is None:
-            from sqlalchemy.orm import aliased as sa_aliased
-            from ..core.field_management import _has_table_overlap
-
-            if _has_table_overlap(primary_model, join_model):
+            if has_table_overlap(primary_model, join_model):
                 alias = sa_aliased(join_model, flat=True)
 
         try:

--- a/fastcrud/crud/validation.py
+++ b/fastcrud/crud/validation.py
@@ -126,13 +126,22 @@ def validate_joined_query_params(
 
     join_definitions = joins_config if joins_config else []
     if join_model:
+        if alias is None and join_on is None:
+            from sqlalchemy.orm import aliased as sa_aliased
+            from ..core.field_management import _has_table_overlap
+
+            if _has_table_overlap(primary_model, join_model):
+                alias = sa_aliased(join_model, flat=True)
+
         try:
             join_definitions.append(
                 JoinConfig(
                     model=join_model,
                     join_on=join_on
                     if join_on is not None
-                    else auto_detect_join_condition(primary_model, join_model),
+                    else auto_detect_join_condition(
+                        primary_model, join_model, join_alias=alias
+                    ),
                     join_prefix=join_prefix,
                     schema_to_select=join_schema_to_select,
                     join_type=join_type,

--- a/tests/sqlalchemy/endpoint/test_joined_filter_polymorphic.py
+++ b/tests/sqlalchemy/endpoint/test_joined_filter_polymorphic.py
@@ -1,0 +1,69 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from fastcrud import FilterConfig
+from fastcrud.crud.fast_crud import FastCRUD
+from fastcrud.endpoint.crud_router import crud_router
+from tests.sqlalchemy.conftest import ProjectPoly, ContractPoly
+
+
+class ProjectPolyCreate(BaseModel):
+    name: str
+    contract_id: int | None = None
+
+
+class ProjectPolyUpdate(BaseModel):
+    name: str | None = None
+    contract_id: int | None = None
+
+
+class ProjectPolyDelete(BaseModel):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_read_multi_joined_filter_with_joined_inheritance(async_session):
+    contract_a = ContractPoly(operator_id=10)
+    contract_b = ContractPoly(operator_id=20)
+
+    project_a = ProjectPoly(name="Project A", contract=contract_a)
+    project_b = ProjectPoly(name="Project B", contract=contract_b)
+
+    async_session.add_all([contract_a, contract_b, project_a, project_b])
+    await async_session.commit()
+
+    app = FastAPI()
+    app.include_router(
+        crud_router(
+            session=lambda: async_session,
+            model=ProjectPoly,
+            crud=FastCRUD(ProjectPoly),
+            create_schema=ProjectPolyCreate,
+            update_schema=ProjectPolyUpdate,
+            delete_schema=ProjectPolyDelete,
+            filter_config=FilterConfig(**{"contract.operator_id__eq": None}),
+            path="/projects_poly",
+            tags=["projects_poly"],
+            endpoint_names={
+                "create": "create",
+                "read": "get",
+                "update": "update",
+                "delete": "delete",
+                "db_delete": "db_delete",
+                "read_multi": "get_multi",
+            },
+        )
+    )
+
+    client = TestClient(app)
+    response = client.get(
+        "/projects_poly/get_multi", params={"contract.operator_id__eq": 10}
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "data" in payload
+    assert len(payload["data"]) == 1
+    assert payload["data"][0]["name"] == "Project A"


### PR DESCRIPTION
# Fix joined filter when primary and join target share polymorphic base

Fixes #305

## Description
Joined filters (e.g. `contract.operator_id__eq=10` on `ProjectPoly`) failed with "no such column: contracts_poly.id" when both the primary model and the related model use joined table inheritance and share a base table. SQLAlchemy auto-aliases the join target, but the join condition was built with the unaliased class, so the ON clause referenced the wrong table.

Fix: when the join target is in the same polymorphic hierarchy as the primary model, use an explicit `aliased(..., flat=True)` and build the join condition against that alias so the compiled SQL is valid.

## Changes
- Detect same-hierarchy join and create an explicit alias; pass it to `auto_detect_join_condition(..., join_alias=alias)` and use it in `JoinConfig` so `prepare_joins` and the ON clause both use the aliased table.
- Test: `test_joined_filter_polymorphic.py` (ProjectPoly + ContractPoly, both inheriting EntityPoly) now passes.

## Tests
- `test_read_multi_joined_filter_with_joined_inheritance` passes.
- Existing joined-filter / get_multi_joined tests unchanged.

## Checklist
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have added tests that cover my changes (if applicable).
- [ ] All new and existing tests passed.

## Why a shared polymorphic base is better (creating Contract and Project)

With a shared base (e.g. `EntityPoly`), creating a contract or project is a single step: the ORM inserts both the entity row and the subclass row and keeps the identity consistent.

**With shared polymorphic base (inheritance):**

```python
# One object → one unit of work; entity row is created automatically
contract_a = ContractPoly(operator_id=10)
project_a = ProjectPoly(name="Project A", contract=contract_a)
session.add_all([contract_a, project_a])
session.commit()
# → 2 rows in entities_poly (id 1=contract, id 2=project)
# → 1 row in contracts_poly (id 1, operator_id=10)
# → 1 row in projects_poly (id 2, name="Project A", contract_id=1)
```

**Without shared base (separate Entity + Contract + Project, no inheritance):**

```python
# You must create the entity row first, then the contract/project
entity_contract = Entity(entity_type="contract")
session.add(entity_contract)
session.flush()  # need entity.id before creating contract

contract_a = Contract(entity_id=entity_contract.id, operator_id=10)
session.add(contract_a)
session.flush()  # need contract.id before creating project

entity_project = Entity(entity_type="project")
session.add(entity_project)
session.flush()

project_a = Project(entity_id=entity_project.id, name="Project A", contract_id=contract_a.id)
session.add(project_a)
session.commit()
# → 4 explicit steps and 3 flush points; easy to forget one or get order wrong
```

So the shared polymorphic base is better for **creating** contract and project instances because: (1) you create one Python object per logical entity and the ORM handles base + subclass rows; (2) no manual entity creation or flush ordering; (3) a single identity (`id`) for each entity across the hierarchy.

## Additional Notes
- Only affects the path where joined filters trigger `get_multi_joined` with auto-detected join (no user-provided `join_on`/`alias`).
- **SQLAlchemy agrees:** The docs recommend using an explicit [`aliased()`](https://sqlalche.me/e/20/xaj2) for this case: *"The better way to write this query is to use the same patterns that apply to any other self-referential relationship, which is to use the `aliased()` construct explicitly. For joined-inheritance and other join-oriented mappings, it is usually desirable to add the use of the `aliased.flat` parameter."* — [An alias is being generated automatically due to overlapping tables](https://sqlalche.me/e/20/xaj2) (Error Messages, SQLAlchemy 2.0).
