### PR TITLE
fix: raise ValueError when update() receives non-list return_columns

### DIFF
--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -2881,6 +2881,11 @@ class FastCRUD(
             )
             ```
         """
+        if return_columns is not None and not isinstance(return_columns, list):
+            raise ValueError(
+                "return_columns must be a list of column name strings or None."
+            )
+
         await validate_update_delete_operation(
             self.count, db, allow_multiple, "update", **kwargs
         )
@@ -2890,11 +2895,6 @@ class FastCRUD(
 
         filters = self._filter_processor.parse_filters(**kwargs)
         stmt = update(self.model).filter(*filters).values(update_data)
-
-        if return_columns is not None and not isinstance(return_columns, list):
-            raise ValueError(
-                "return_columns must be a list of column name strings or None."
-            )
 
         if return_as_model:
             return_columns = self.model_col_names

--- a/fastcrud/crud/fast_crud.py
+++ b/fastcrud/crud/fast_crud.py
@@ -2891,6 +2891,11 @@ class FastCRUD(
         filters = self._filter_processor.parse_filters(**kwargs)
         stmt = update(self.model).filter(*filters).values(update_data)
 
+        if return_columns is not None and not isinstance(return_columns, list):
+            raise ValueError(
+                "return_columns must be a list of column name strings or None."
+            )
+
         if return_as_model:
             return_columns = self.model_col_names
 

--- a/tests/sqlalchemy/crud/test_update.py
+++ b/tests/sqlalchemy/crud/test_update.py
@@ -183,9 +183,9 @@ async def test_update_with_schema_object(async_session, test_data):
         select(ModelTest).where(ModelTest.id == target_id)
     )
     updated = updated_record.scalar_one()
-    assert (
-        updated.name == "Updated Via Schema Object"
-    ), "Record should be updated with the name from the schema object."
+    assert updated.name == "Updated Via Schema Object", (
+        "Record should be updated with the name from the schema object."
+    )
 
 
 @pytest.mark.asyncio
@@ -207,9 +207,9 @@ async def test_update_auto_updates_updated_at(async_session, test_data):
     )
     updated = updated_record.scalar_one()
     assert updated.name == "UpdatedName", "Record should be updated with the new name."
-    assert (
-        updated.updated_at > initial_time
-    ), "updated_at should be later than the initial timestamp."
+    assert updated.updated_at > initial_time, (
+        "updated_at should be later than the initial timestamp."
+    )
 
 
 @pytest.mark.parametrize(
@@ -275,3 +275,19 @@ async def test_update_with_returning(
     # Rollback the current transaction to see if the record was actually committed
     await async_session.rollback()
     assert await crud.count(async_session, name="Updated Name") == 1
+
+
+@pytest.mark.asyncio
+async def test_update_return_columns_bool_raises_value_error(async_session, test_data):
+    for item in test_data:
+        async_session.add(ModelTest(**item))
+    await async_session.commit()
+
+    crud = FastCRUD(ModelTest)
+    with pytest.raises(ValueError, match="return_columns must be a list"):
+        await crud.update(
+            db=async_session,
+            object={"name": "Updated"},
+            return_columns=True,
+            id=test_data[0]["id"],
+        )

--- a/tests/sqlalchemy/crud/test_update.py
+++ b/tests/sqlalchemy/crud/test_update.py
@@ -183,9 +183,9 @@ async def test_update_with_schema_object(async_session, test_data):
         select(ModelTest).where(ModelTest.id == target_id)
     )
     updated = updated_record.scalar_one()
-    assert updated.name == "Updated Via Schema Object", (
-        "Record should be updated with the name from the schema object."
-    )
+    assert (
+        updated.name == "Updated Via Schema Object"
+    ), "Record should be updated with the name from the schema object."
 
 
 @pytest.mark.asyncio
@@ -207,9 +207,9 @@ async def test_update_auto_updates_updated_at(async_session, test_data):
     )
     updated = updated_record.scalar_one()
     assert updated.name == "UpdatedName", "Record should be updated with the new name."
-    assert updated.updated_at > initial_time, (
-        "updated_at should be later than the initial timestamp."
-    )
+    assert (
+        updated.updated_at > initial_time
+    ), "updated_at should be later than the initial timestamp."
 
 
 @pytest.mark.parametrize(

--- a/tests/sqlalchemy/endpoint/test_cursor_validation.py
+++ b/tests/sqlalchemy/endpoint/test_cursor_validation.py
@@ -9,6 +9,7 @@ import pytest
 from typing import Annotated
 from fastapi import FastAPI, Depends
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
 from sqlalchemy import Column, Integer, BigInteger, SmallInteger, String, DateTime
 from sqlalchemy.dialects.postgresql import UUID as PostgresUUID
 from sqlalchemy.orm import declarative_base
@@ -32,18 +33,18 @@ class TestCursorModel(Base):
     uuid_field = Column(PostgresUUID(as_uuid=True))
 
 
+class CreateSchema(BaseModel):
+    name: str
+
+
+class UpdateSchema(BaseModel):
+    name: str
+
+
 @pytest.fixture
 def app_with_cursor_validation(async_session):
     """Create a FastAPI app with cursor validation."""
     app = FastAPI()
-
-    from pydantic import BaseModel
-
-    class CreateSchema(BaseModel):
-        name: str
-
-    class UpdateSchema(BaseModel):
-        name: str
 
     endpoint_creator = EndpointCreator(
         session=lambda: async_session,


### PR DESCRIPTION
## Description

Calling `FastCRUD.update(..., return_columns=True)` raises an unhelpful `TypeError: 'bool' object is not iterable` from inside `execute_update_and_return_response`. The docstring documents `return_columns` as `list[str] | None`, so passing a bool is a misuse, but the error message gives no indication of the expected type.

This fix adds an explicit `ValueError` in `update()` when `return_columns` is not `None` and not a `list`, matching the pattern used for similar param validation elsewhere in the codebase.

Closes #316.

## Changes

- `fastcrud/crud/fast_crud.py`: guard before delegating to `execute_update_and_return_response` raises `ValueError` when `return_columns` is not `list | None`.
- `tests/sqlalchemy/crud/test_update.py`: regression test that asserts `ValueError` is raised with `return_columns=True`.

## Tests

Added `test_update_return_columns_bool_raises_value_error`. Verified:
- Test fails on unpatched code (TypeError propagates from SQLAlchemy layer).
- Test passes with the fix.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added necessary documentation (if appropriate).
- [x] I have added tests that cover my changes (if applicable).
- [x] All new and existing tests passed.