### PR TITLE
Fix Python 3.14 PEP 649 startup crash: qualify Filter `type` annotations as `builtins.type`

### DIFF
--- a/fastcrud/core/filtering/filter_model.py
+++ b/fastcrud/core/filtering/filter_model.py
@@ -10,6 +10,7 @@ It sits between :class:`~fastcrud.core.config.crud_configs.FilterConfig`
 clauses produced by :class:`~fastcrud.core.filtering.processor.FilterProcessor`.
 """
 
+import builtins
 from typing import Any, cast
 
 from pydantic import BaseModel, ConfigDict, SkipValidation, computed_field
@@ -46,13 +47,13 @@ class Filter(BaseModel):
     param_name: str
     default_value: Any
     operator: str | None
-    wrap_type: type | None
-    joined_model: type | None
+    wrap_type: builtins.type | None
+    joined_model: builtins.type | None
     column: SkipValidation[Column[Any]]
-    value_type: type
+    value_type: builtins.type
 
     @computed_field
-    def type(self) -> type:
+    def type(self) -> builtins.type:
         """
         Final Python type for OpenAPI / FastAPI signature generation.
 
@@ -60,5 +61,5 @@ class Filter(BaseModel):
         (e.g. ``list[int]``) for collection operators.
         """
         if self.wrap_type:
-            return cast(type, self.wrap_type[self.value_type])  # type: ignore[index]
+            return cast(builtins.type, self.wrap_type[self.value_type])  # type: ignore[index]
         return self.value_type

--- a/tests/sqlalchemy/core/test_filter_model_pep649.py
+++ b/tests/sqlalchemy/core/test_filter_model_pep649.py
@@ -1,0 +1,70 @@
+"""Regression test for PEP 649 / Python 3.14 type-annotation collision.
+
+The Filter Pydantic model declares fields annotated `wrap_type: type | None`
+etc., and also has a `@computed_field def type(self)` method. Under Python
+3.14's deferred annotation evaluation, the string form `"type | None"`
+resolves the bare `type` against the class namespace, which now contains
+the property -- producing `TypeError: unsupported operand type(s) for |:
+'property' and 'NoneType'`.
+
+This test ensures the model can be constructed (which triggers the
+schema build that exercises annotation resolution) on every supported
+Python version.
+"""
+
+import builtins
+
+from sqlalchemy import Column, Integer
+
+from fastcrud.core.filtering.filter_model import Filter
+
+
+def test_filter_constructs_without_pep649_type_collision():
+    """Constructing Filter forces Pydantic to resolve all field annotations,
+    which historically failed under Python 3.14 with a TypeError when
+    ``type | None`` evaluated against the class namespace and resolved
+    ``type`` to the property instead of the builtin."""
+    # Re-resolve all annotations explicitly. Under Python 3.14 (PEP 649)
+    # this is the path that crashed with::
+    #     TypeError: unsupported operand type(s) for |:
+    #         'property' and 'NoneType'
+    # because the bare ``type`` in ``wrap_type: type | None`` resolved to
+    # the ``@computed_field def type`` property instead of the builtin.
+    Filter.model_rebuild(force=True)
+
+    col = Column("id", Integer)
+    filter_obj = Filter(
+        definition="id",
+        param_name="id",
+        default_value=None,
+        operator=None,
+        wrap_type=None,
+        joined_model=None,
+        column=col,
+        value_type=int,
+    )
+
+    # Sanity: annotation resolution succeeded and the computed field
+    # still returns the scalar value_type for non-collection filters.
+    assert filter_obj.type is int
+
+    # The model's stored field annotations should reference the builtin
+    # ``type``, not the @computed_field property.
+    assert Filter.model_fields["wrap_type"].annotation == (builtins.type | None)
+    assert Filter.model_fields["value_type"].annotation is builtins.type
+
+
+def test_filter_with_wrap_type_collection():
+    """``type`` computed_field returns ``wrap_type[value_type]`` for collections."""
+    col = Column("id", Integer)
+    filter_obj = Filter(
+        definition="id__in",
+        param_name="id__in",
+        default_value=None,
+        operator="in",
+        wrap_type=list,
+        joined_model=None,
+        column=col,
+        value_type=int,
+    )
+    assert filter_obj.type == builtins.list[int]


### PR DESCRIPTION
## Bug

Under Python 3.14 (PEP 649), importing fastcrud crashes any FastAPI app at module load with:

```
TypeError: unsupported operand type(s) for |: 'property' and 'NoneType'
Unable to evaluate type annotation 'type | None'.
```

## Root cause

`fastcrud/core/filtering/filter_model.py`'s `Filter` model declares both:

- Field annotations `wrap_type: type | None`, `joined_model: type | None`, `value_type: type`
- A `@computed_field def type(self) -> type:` method

On Python <= 3.13, annotations are evaluated at class definition time — before `def type(self)` is processed — so `type` resolves to the builtin and the model builds fine.

On Python 3.14+, [PEP 649](https://peps.python.org/pep-0649/) defers annotation evaluation. When Pydantic later resolves the string-form `"type | None"` against the class namespace, `type` now resolves to the `property` descriptor installed by `@computed_field`, not the builtin. `<property> | <NoneType>` raises the TypeError above.

## Fix

`import builtins` and qualify the four `type` references in `Filter` as `builtins.type`. No public API change, no rename of the `type` computed field.

## Test

New regression test constructs `Filter` and forces `model_rebuild(force=True)` — this is the path that exercises annotation resolution and triggers the crash on 3.14 before the fix. Verifies `.type` still returns the expected Python type for scalar and collection (`wrap_type=list`) filters, and that the stored field annotations resolve to the builtin `type`.

## Compat

- Python 3.10/3.11/3.12/3.13: behavior unchanged (still resolves to the builtin via the qualified path).
- Python 3.14: import + model rebuild succeed instead of crashing.

## Verification

Locally on Python 3.11.4: full suite passes (894 tests excluding the postgres/mysql dialect tests that hit a pre-existing Windows `ProactorEventLoop` psycopg incompatibility unrelated to this change — those same 5 errors reproduce on unmodified `main`). `mypy fastcrud` and `ruff check` both clean.

## Reported by

Affected my downstream project (Python 3.14 on CI). Happy to add the failing-on-3.14 case to the CI matrix in a follow-up if the maintainers want — the regression test passes on every version since the fix sidesteps the eager-eval path entirely.
