### PR TITLE
Library Skill: bundle FastCRUD knowledge for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - ➤ **Cursor-based Pagination**: Implements efficient pagination for large datasets, ideal for infinite scrolling interfaces.
 - 🤸‍♂️ **Modular and Extensible**: Designed for easy extension and customization to fit your requirements.
 - 🛣️ **Auto-generated Endpoints**: Streamlines the process of adding CRUD endpoints with custom dependencies and configurations.
+- 🤖 **Bundled Library Skill**: Ships with a [Library Skill](https://github.com/tiangolo/library-skills) so AI coding tools (Claude Code, Cursor, Copilot, …) know how to use FastCRUD correctly — including N+1 avoidance and when to drop to raw SQLAlchemy.
 
 <h2>Requirements</h2>
 <p>Before installing FastCRUD, ensure you have the following prerequisites:</p>
@@ -71,6 +72,30 @@ Or, if using UV:
 ```sh
 uv add fastcrud
 ```
+
+<h2>For AI Coding Agents</h2>
+
+FastCRUD ships with a bundled [Library Skill](https://github.com/tiangolo/library-skills) at `fastcrud/.agents/skills/fastcrud/SKILL.md`, following the [Agent Skills](https://agentskills.io/) standard.
+
+To make it available to your coding agent, run [`library-skills`](https://github.com/tiangolo/library-skills) from your project directory after `fastcrud` is installed:
+
+```sh
+# In any project that has fastcrud installed
+uvx library-skills              # for Codex, Cursor, Copilot, OpenCode, etc.
+uvx library-skills --claude     # for Claude Code (uses .claude/skills instead)
+```
+
+This symlinks the bundled skill into `.agents/skills/` (or `.claude/skills/` for Claude Code). Re-run after upgrading FastCRUD to pick up skill changes.
+
+The skill teaches agents:
+
+- The canonical setup pattern (model → schemas → `crud_router`)
+- How to pick the right method (and avoid N+1 when fetching related data)
+- The `limit=None` footgun and the three-tier pagination default
+- **When NOT to use FastCRUD** — aggregates, CTEs, `GROUP BY` projections, bulk writes belong to raw SQLAlchemy
+- Return-value semantics, the filter operator syntax (`__gte`, `__in`, `__ilike`, …), soft delete, joined-table inheritance gotchas
+
+Reference deep-dives live under `fastcrud/.agents/skills/fastcrud/references/` for `methods`, `filters`, `joins`, `pagination`, and `endpoints`.
 
 <h2>Usage</h2>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,25 @@
 The Changelog documents all notable changes made to FastCRUD. This includes new features, bug fixes, and improvements. It's organized by version and date, providing a clear history of the library's development.
 ___
 
+## 0.22.3 - Jun 21, 2026
+
+#### Added
+- **Bundled Library Skill for AI Coding Agents** by [@igorbenav](https://github.com/igorbenav)
+  - FastCRUD now ships a [Library Skill](https://github.com/tiangolo/library-skills) inside the wheel at `fastcrud/.agents/skills/fastcrud/`, following the [Agent Skills](https://agentskills.io/) standard
+  - Compatible coding assistants (Claude Code, Cursor, GitHub Copilot, OpenCode, Goose, and [30+ others](https://agentskills.io/clients)) can pick up FastCRUD-specific guidance after the user runs `uvx library-skills` (or `npx library-skills`) from their project root
+  - For Claude Code, run `uvx library-skills --claude` to install into `.claude/skills/` instead of `.agents/skills/`
+  - The skill installs as a symbolic link, so upgrading FastCRUD automatically updates the guidance — no re-run needed
+  - Main `SKILL.md` covers canonical setup, choosing the right CRUD method, N+1 avoidance, the `limit=None` footgun, when NOT to use FastCRUD (aggregates, CTEs, `GROUP BY` projections, bulk writes), return-value semantics, the filter operator syntax, soft delete, and joined-table inheritance gotchas
+  - On-demand reference deep-dives under `references/` for `methods`, `filters`, `joins`, `pagination`, and `endpoints`
+  - New `docs/library-skill.md` page with install instructions, layout, and contributing pointer; new nav entry in `zensical.toml`
+
+#### What's Changed
+* Add bundled Library Skill for AI coding agents by [@igorbenav](https://github.com/igorbenav) in https://github.com/benavlabs/fastcrud/pull/XXX
+
+**Full Changelog**: https://github.com/benavlabs/fastcrud/compare/v0.22.2...v0.22.3
+
+___
+
 ## 0.22.2 - May 27, 2026
 
 #### Fixed

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@
 - **Modular and Extensible**: Designed for easy extension and customization to fit your requirements.
 - **Auto-generated Endpoints**: Streamlines the process of adding CRUD endpoints with custom dependencies and configurations.
 - **Clean Architecture**: Built with a six-level dependency hierarchy that prevents circular dependencies and supports future extensibility.
+- **Bundled AI Agent Skill**: Ships with an [Agent Skill](https://agentskills.io/) so AI coding tools (Claude Code, Cursor, Copilot, …) know how to use FastCRUD correctly. See [AI Agent Skill](agent-skill.md).
 
 ## Quick Start
 

--- a/docs/library-skill.md
+++ b/docs/library-skill.md
@@ -1,0 +1,59 @@
+# Library Skill for AI Coding Agents
+
+FastCRUD ships with a bundled [Library Skill](https://github.com/tiangolo/library-skills) inside the installed package at `fastcrud/.agents/skills/fastcrud/SKILL.md`. Library Skills follow the [Agent Skills](https://agentskills.io/) standard, so any compatible AI coding tool can use it — Codex, Cursor, GitHub Copilot, OpenCode, Claude Code, Pi, Antigravity, and [30+ others](https://agentskills.io/clients).
+
+## Quick install
+
+After `fastcrud` is installed in your project (`uv add fastcrud` / `pip install fastcrud`), run [`library-skills`](https://github.com/tiangolo/library-skills) from the project root:
+
+=== "Python (uvx)"
+
+    ```sh
+    uvx library-skills              # for Codex, Cursor, Copilot, OpenCode, etc.
+    uvx library-skills --claude     # for Claude Code (uses .claude/skills)
+    ```
+
+=== "Node.js (npx)"
+
+    ```sh
+    npx library-skills              # for Codex, Cursor, Copilot, OpenCode, etc.
+    npx library-skills --claude     # for Claude Code (uses .claude/skills)
+    ```
+
+This symlinks the bundled skill into your project's `.agents/skills/` directory (or `.claude/skills/` with `--claude`). Because they're symlinks, **upgrading `fastcrud` automatically updates the skill** — no need to re-run.
+
+Re-run `library-skills` to pick up new or moved skills after upgrades, or to clean up broken symlinks. See the [Library Skills `Use` docs](https://github.com/tiangolo/library-skills) for `--check`, `--yes`, and `--copy` (for systems without symlink support, like some Windows setups).
+
+## What the skill teaches agents
+
+- **Canonical setup** — the minimal model + schemas + `crud_router` pattern
+- **Choosing the right method** — `get` vs `get_joined` vs `get_multi_joined`, and which one avoids N+1
+- **Avoiding N+1** — auto-detection via `include_relationships=True`, manual `JoinConfig`, and `nested_limit` for one-to-many collections
+- **The `limit=None` footgun** — when it's safe (domain-bounded WHERE) and when it isn't, with the three-tier pagination default
+- **When NOT to use FastCRUD** — aggregate roll-ups, CTEs, `GROUP BY` projections, bulk writes, and dialect-specific features that belong to raw SQLAlchemy
+- **Return-value semantics** — `create()` returns `None` by default, `return_as_model=True` requires `schema_to_select`, type narrowing via subclass overrides
+- **Filter syntax** — every `__op` suffix, joined filters with `.`, `Depends(...)` filters, custom operators
+- **Gotchas** — async-session-only, soft delete behavior, joined-table inheritance, SQLModel polymorphism caveat, Python 3.14 PEP 649 compatibility
+
+## Layout
+
+```
+fastcrud/.agents/skills/fastcrud/
+├── SKILL.md              # entry point — loaded when the agent activates the skill
+└── references/
+    ├── methods.md        # every FastCRUD method, return semantics, type narrowing
+    ├── filters.md        # every operator, FilterConfig, dependency filters, custom operators
+    ├── joins.md          # JoinConfig, auto-detection, nested_limit, polymorphism
+    ├── pagination.md     # offset vs cursor, sanity-checking limit=None
+    └── endpoints.md      # crud_router params, EndpointCreator subclassing, soft delete
+```
+
+The agent loads only the skill's name and short description at startup. When a task matches, the full `SKILL.md` body loads into context. Reference files load only on demand — this pattern is called [progressive disclosure](https://agentskills.io/specification#progressive-disclosure).
+
+## Verifying it's loaded
+
+In Claude Code, type `/skills` after installing — the `fastcrud` skill should appear in the list. In other clients, consult their documentation for how to view available skills.
+
+## Contributing improvements
+
+The skill ships from the FastCRUD repository at [`fastcrud/.agents/skills/fastcrud/`](https://github.com/benavlabs/fastcrud/tree/main/fastcrud/.agents/skills/fastcrud). If you notice incorrect behavior, missing gotchas, or anti-patterns the skill should flag, please open an issue or PR with a concrete example.

--- a/fastcrud/.agents/skills/fastcrud/SKILL.md
+++ b/fastcrud/.agents/skills/fastcrud/SKILL.md
@@ -1,0 +1,447 @@
+---
+name: fastcrud
+description: Use when building or modifying CRUD endpoints with FastCRUD (the `fastcrud` PyPI package) in a FastAPI project — covers `FastCRUD`, `crud_router`, `EndpointCreator`, `FilterConfig`, `JoinConfig`, auto-relationship detection, the filter operator syntax (`__gte`, `__in`, `__ilike`, etc.), cursor pagination, soft delete, and how to avoid N+1 queries when fetching related data. Activate when the user mentions FastCRUD, `crud_router`, `FastCRUD()`, `FilterConfig`, `JoinConfig`, or asks how to build CRUD endpoints / generate REST APIs from SQLAlchemy or SQLModel models, even if the user doesn't name the library directly.
+license: MIT
+metadata:
+  author: benav-labs
+  package: fastcrud
+---
+
+# FastCRUD
+
+FastCRUD generates async CRUD methods (and optionally CRUD endpoints) for SQLAlchemy 2.0 models inside a FastAPI app. The two entry points are:
+
+- **`FastCRUD(Model)`** — the data-access class. Use this for per-row CRUD operations (single-record get / create / update / delete, paginated lists, joins with relationships). Real codebases use this in services, workers, and custom endpoints.
+- **`crud_router(...)`** — returns an `APIRouter` with create/read/update/delete endpoints auto-wired. Use this only when you want generated endpoints; many apps skip it and hand-roll FastAPI routes on top of `FastCRUD` instances.
+
+This skill covers the public API across `fastcrud >= 0.22`. SQLAlchemy is the default ORM in examples; SQLModel works the same way except where noted.
+
+**Before reaching for FastCRUD, check the [When NOT to use FastCRUD](#when-not-to-use-fastcrud) section below.** Aggregate roll-ups, CTEs, `GROUP BY` projections, and bulk writes are SQLAlchemy's job — FastCRUD is for per-row CRUD.
+
+---
+
+## Canonical setup
+
+The minimal viable pattern. Always start here, then add filters/joins/relationships as needed.
+
+```python
+# models.py
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import DeclarativeBase, relationship
+
+class Base(DeclarativeBase): pass
+
+class Tier(Base):
+    __tablename__ = "tier"
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True)
+
+class User(Base):
+    __tablename__ = "user"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    email = Column(String, unique=True)
+    tier_id = Column(Integer, ForeignKey("tier.id"))
+    tier = relationship("Tier")
+```
+
+```python
+# schemas.py
+from pydantic import BaseModel, ConfigDict
+
+class UserCreate(BaseModel):
+    name: str
+    email: str
+    tier_id: int
+
+class UserRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: int
+    name: str
+    email: str
+    tier_id: int
+
+class UserUpdate(BaseModel):
+    name: str | None = None
+    email: str | None = None
+```
+
+```python
+# main.py
+from fastapi import FastAPI
+from fastcrud import crud_router
+from .db import get_async_session
+from .models import User
+from .schemas import UserCreate, UserRead, UserUpdate
+
+app = FastAPI()
+
+user_router = crud_router(
+    session=get_async_session,    # callable returning AsyncSession (FastAPI dependency)
+    model=User,
+    create_schema=UserCreate,
+    update_schema=UserUpdate,
+    select_schema=UserRead,        # used for read responses
+    path="/users",
+    tags=["users"],
+)
+app.include_router(user_router)
+```
+
+This produces `POST /users`, `GET /users/{id}`, `PATCH /users/{id}`, `DELETE /users/{id}`, `DELETE /users/db_delete/{id}` (hard delete), and `GET /users` (paginated list).
+
+---
+
+## Choosing the right method
+
+When using `FastCRUD(Model)` directly, pick the method that matches the data shape you actually need. **Do not loop over `get_multi()` and call `get_joined()` per row** — that's the canonical N+1.
+
+| Need                                        | Use                          |
+|---------------------------------------------|------------------------------|
+| Single row, no joins                        | `get(db, id=...)`            |
+| Single row with related data                | `get_joined(db, id=...)`     |
+| Paginated list, no joins                    | `get_multi(db, offset, limit)` |
+| **Paginated list with related data**       | **`get_multi_joined(db, ...)`** |
+| Cursor-paginated list (infinite scroll)     | `get_multi_by_cursor(db, ...)` |
+| Insert                                      | `create(db, schema)`         |
+| Insert-or-update by unique constraint       | `upsert(db, schema)` / `upsert_multi(db, list)` |
+| Patch by filters                            | `update(db, schema, **kwargs)` |
+| Soft delete (if configured)                 | `delete(db, **kwargs)`       |
+| Hard delete (always removes row)            | `db_delete(db, **kwargs)`    |
+| Count                                       | `count(db, **kwargs)`        |
+| Boolean existence check                     | `exists(db, **kwargs)`       |
+
+---
+
+## Avoiding N+1 — the most common mistake
+
+FastCRUD has two mechanisms to prevent N+1 when fetching related data. **Use one of them — never iterate.**
+
+### 1. Auto-detect relationships (zero config, default for v0.21+)
+
+Set `include_relationships=True` on `crud_router` (or `auto_detect_relationships=True` on the FastCRUD method directly). FastCRUD inspects the SQLAlchemy mapper, builds the joins, and threads them through a single query.
+
+```python
+crud_router(
+    session=get_async_session,
+    model=User,
+    create_schema=UserCreate,
+    update_schema=UserUpdate,
+    select_schema=UserWithTier,           # schema includes nested tier field
+    include_relationships=True,           # auto-include all relationships
+    path="/users",
+)
+```
+
+Or pass a list to include only specific relationships:
+
+```python
+include_relationships=["tier", "department"]   # whitelist
+```
+
+**Gotcha:** **One-to-many relationships are excluded by default** because they can return unbounded data. Opt in explicitly:
+
+```python
+include_relationships=True,
+include_one_to_many=True,
+default_nested_limit=10,    # cap nested rows per parent (uses SQL window function)
+```
+
+`default_nested_limit` uses `row_number() OVER (PARTITION BY ...)` at the database level — it does **not** fetch everything and slice in Python.
+
+### 2. Manual `JoinConfig` (when you need explicit control)
+
+For self-joins, aliases, custom join conditions, or per-join schemas:
+
+```python
+from fastcrud import FastCRUD, JoinConfig
+
+orders_with_user = await crud.get_multi_joined(
+    db=session,
+    joins_config=[
+        JoinConfig(
+            model=User,
+            join_on=Order.user_id == User.id,
+            join_prefix="user_",         # avoid column collisions
+            schema_to_select=UserRead,
+        ),
+    ],
+    offset=0,
+    limit=20,
+)
+```
+
+For one-to-many with per-parent capping:
+
+```python
+JoinConfig(
+    model=Article,
+    join_on=Article.author_id == Author.id,
+    relationship_type="one-to-many",
+    sort_columns="created_at",
+    sort_orders="desc",
+    nested_limit=5,         # 5 most recent articles per author, computed in SQL
+)
+```
+
+See `references/joins.md` for the full `JoinConfig` spec, polymorphic inheritance, and the auto-detection rules.
+
+---
+
+## `limit=None` — the second biggest footgun
+
+`get_multi(...)` / `get_multi_joined(...)` accept `limit=None` to fetch **every matching row**. This is the single biggest cause of latency cliffs and OOMs in real-world FastCRUD code.
+
+**Rule:** `limit=None` is only safe when a `WHERE` clause domain-bounds the result to a known-small set. Otherwise, always pass an explicit numeric `limit`.
+
+### Safe — scoped by a WHERE clause
+
+```python
+# OK: scoped to a single project → bounded by N(clips per project)
+clips = await crud_clips.get_multi(db, limit=None, project_id=project.id)
+
+# OK: scoped to a small known set of IDs
+tiers = await crud_tiers.get_multi(db, limit=None, id__in=tier_ids)
+```
+
+### Unsafe — unbounded growth
+
+```python
+# BAD: grows linearly with the user table forever
+users = await crud_users.get_multi(db, limit=None)
+
+# GOOD: HTTP endpoint with a hard ceiling
+limit = min(requested_limit, MAX_PAGE_LIMIT)
+users = await crud_users.get_multi(db, offset=offset, limit=limit)
+```
+
+### Pattern: sanity-check `limit=None` results
+
+When `limit=None` is justified, log when results unexpectedly explode so drift is caught before it becomes an incident:
+
+```python
+def handle_query_sanity(items: list, threshold: int, context: str) -> None:
+    if len(items) > threshold:
+        logger.warning("query growth: %d > %d threshold (%s)",
+                       len(items), threshold, context)
+
+entitlements = await crud_entitlements.get_multi(db, limit=None, user_id=user.id)
+handle_query_sanity(entitlements["data"], threshold=100, context="user_entitlements")
+```
+
+### Three-tier default
+
+| Surface                                       | Default                                |
+|-----------------------------------------------|----------------------------------------|
+| HTTP list endpoint                            | `limit = min(requested, MAX_LIMIT)`    |
+| Worker fetch of bounded child collection      | Explicit cap (`limit=RENDER_MAX_CLIPS`) |
+| Bulk fan-out across a large table             | `get_multi_by_cursor(limit=BATCH)`     |
+
+---
+
+## When NOT to use FastCRUD
+
+FastCRUD is the right tool for **per-row CRUD on a single model**, optionally with relationship joins. Drop to raw SQLAlchemy when the query shape is anything else. In a typical app the split is roughly 80/20 — most data access is FastCRUD's territory, but the 20% that isn't is *firmly* SQLAlchemy's.
+
+| Query shape                                                              | Use instead                                       |
+|--------------------------------------------------------------------------|---------------------------------------------------|
+| Aggregate roll-up (`SUM`, conditional `COUNT FILTER WHERE`, `HAVING`)    | `select(func.sum(...), func.count().filter(...))` |
+| CTEs, correlated subqueries, `EXISTS()` filters                          | `select(...).where(~exists().where(...))`         |
+| `GROUP BY` with derived columns (`Project + count(clips)`)               | `select(Project, func.count(Clip.id)).group_by(Project.id)` |
+| Bulk `UPDATE ... WHERE id IN (...)` with column-expression RHS           | `update(...).values(expires_at=Model.expires_at + interval)` |
+| Bulk `INSERT` (more than ~10 rows)                                       | `db.execute(insert(Model), records)`              |
+| Dialect-specific features (Postgres advisory locks, `array_agg`, JSONB)  | `text("SELECT pg_advisory_xact_lock(...)")` etc.  |
+| Anything you'd reach for `joinedload` / `selectinload` / `contains_eager` for | FastCRUD `JoinConfig` — it covers this           |
+
+**`crud_router` itself is optional.** Production codebases often use FastCRUD instances as the data-access layer behind hand-written FastAPI routes, skipping `crud_router` entirely so they can compose auth, validation, and business logic without subclassing `EndpointCreator`.
+
+### Anti-patterns to refactor on sight
+
+1. **Per-ID loop calling `crud.get()`** — classic N+1.
+   ```python
+   # BAD
+   for tier_id in tier_ids:
+       tier = await crud_tiers.get(db, id=tier_id)
+   # GOOD — one query
+   tiers = await crud_tiers.get_multi(db, id__in=tier_ids, limit=None)
+   ```
+2. **`db.scalar(select(Model).where(...).exists())`** — use `await crud.exists(**filters)`.
+3. **`get_multi(limit=None)` then Python filtering** — push the filter into kwargs so the database does the work.
+4. **`crud.get()` in a hot path without `schema_to_select`** — selects every column. Pass a minimal schema to cut payload size.
+5. **Loop of `crud.create()`** — calls go one-at-a-time. For >10 rows use `crud.upsert_multi(...)` or raw `db.execute(insert(Model), records)`.
+
+---
+
+## Filter syntax
+
+FastCRUD accepts filters as keyword arguments on every read/update/delete method, and via `FilterConfig` for `crud_router`'s `GET /list` endpoint.
+
+### Operator suffix on the field name
+
+The operator goes after a **double underscore**:
+
+```python
+await crud.get_multi(db, price__gte=10, name__ilike="%admin%", id__in=[1, 2, 3])
+```
+
+| Suffix         | SQL                | Notes                                |
+|----------------|--------------------|--------------------------------------|
+| (none)         | `=`                | bare field name is equality          |
+| `__eq`         | `=`                | explicit form                        |
+| `__ne`         | `<>`               |                                      |
+| `__gt` `__gte` | `>` `>=`           |                                      |
+| `__lt` `__lte` | `<` `<=`           |                                      |
+| `__in`         | `IN (...)`         | value must be `list`/`tuple`/`set`   |
+| `__not_in`     | `NOT IN (...)`     | same                                 |
+| `__between`    | `BETWEEN a AND b`  | value must be a 2-element sequence   |
+| `__like`       | `LIKE`             | case-sensitive                       |
+| `__ilike`      | `ILIKE`            | case-insensitive (Postgres)          |
+| `__startswith` `__endswith` `__contains` | substring match (auto-wraps with `%`) | pass the bare substring — do NOT add `%` yourself |
+| `__is` `__is_not` | `IS` `IS NOT`   | for `NULL` checks                    |
+| `__match`      | engine-specific full-text | depends on dialect            |
+
+### Joined filters
+
+Walk relationships with `.`:
+
+```python
+await crud.get_multi_joined(db, **{"tier.name__eq": "premium"})
+```
+
+Or, equivalently, build the kwargs dict literal-style. In `FilterConfig`:
+
+```python
+FilterConfig({
+    "name__ilike": None,           # query string param: ?name__ilike=foo
+    "price__gte": None,
+    "tier.name": None,             # joined filter — auto-includes the tier relationship
+})
+```
+
+### Bool coercion
+
+`?filter=false` is correctly parsed (case-insensitive: `False`, `FALSE`, `0`, `true`, `TRUE`, `1`). No need to pre-coerce.
+
+See `references/filters.md` for `FilterConfig` deep-dive, `Depends(...)` filters (filter by current user automatically), and custom operator registration.
+
+---
+
+## Return semantics — read carefully
+
+The biggest footgun. Several methods have non-obvious defaults that changed in v0.20:
+
+### `create()`
+
+- Without `schema_to_select`: **returns `None`** (since v0.20.0 — was the model in earlier versions).
+- With `schema_to_select`: returns a `dict`.
+- With `schema_to_select` + `return_as_model=True`: returns a Pydantic instance.
+
+```python
+await crud.create(db, UserCreate(...))                                     # → None
+await crud.create(db, UserCreate(...), schema_to_select=UserRead)          # → dict
+await crud.create(db, UserCreate(...), schema_to_select=UserRead,
+                  return_as_model=True)                                    # → UserRead
+```
+
+`return_as_model=True` **requires** `schema_to_select` (else raises `ValueError`).
+
+### `get()` / `get_multi()` / `get_joined()` / etc.
+
+Same pattern: `return_as_model=True` requires `schema_to_select`. Without `schema_to_select`, all columns are returned as a dict.
+
+### `schema_to_select` propagates the subclass type (v0.22+)
+
+If you pass a subclass override per-call, the return type narrows correctly — no manual `cast()` needed:
+
+```python
+class UserAdminRead(UserRead):
+    role: str
+
+result = await crud.get(db, id=1, schema_to_select=UserAdminRead, return_as_model=True)
+# result is typed as UserAdminRead | None, not UserRead | None
+```
+
+### `update(return_columns=...)` must be a list (v0.22+)
+
+`return_columns=True` raises `ValueError`. Pass a list:
+
+```python
+await crud.update(db, schema=UserUpdate(name="X"), return_columns=["id", "name"], id=1)
+```
+
+### `commit=False` for transactions
+
+All write methods take `commit=False`. Use it when chaining multiple operations under a single transaction; commit once at the end with `await db.commit()`.
+
+---
+
+## Soft delete
+
+Configure at the FastCRUD level:
+
+```python
+crud = FastCRUD(User, is_deleted_column="is_deleted", deleted_at_column="deleted_at")
+
+await crud.delete(db, id=1)       # soft: sets is_deleted=True, deleted_at=now
+                                  #       (requires both columns on the model)
+await crud.db_delete(db, id=1)    # hard: actual DELETE — always removes the row
+```
+
+**Reads do NOT auto-filter soft-deleted rows.** This is the most common surprise — you have to filter explicitly:
+
+```python
+active = await crud.get_multi(db, is_deleted=False)
+```
+
+If you want every read to exclude soft-deleted rows automatically, wrap `FastCRUD` in a subclass that overrides `get`/`get_multi`/etc. to add the filter, or pass `is_deleted=False` as a dependency-based default via `FilterConfig` on `crud_router`.
+
+---
+
+## Gotchas (read these before writing code)
+
+1. **`limit=None` fetches every matching row.** Only safe when a `WHERE` clause domain-bounds the result. See [the dedicated section](#limitnone--the-second-biggest-footgun).
+2. **Async session only.** All methods require `AsyncSession`. Sync `Session` support for `count()`/`exists()` is in flight (PR #333) but not merged.
+3. **One-to-many relationships excluded from auto-detect.** Add `include_one_to_many=True` and set `default_nested_limit` (or `nested_limit` per `JoinConfig`).
+4. **Filter operator separator is `__` (two underscores).** `price_gte` is just a column name `price_gte`; `price__gte` is `price >= ...`.
+5. **`create()` returns `None` by default** (no schema_to_select). Don't expect the model back.
+6. **`return_as_model=True` without `schema_to_select` raises.** Always pair them.
+7. **`update(return_columns=True)` raises** since v0.22.0. Use a list of column names.
+8. **Joined filters need `.` not `__` for the relationship part.** `"tier.name__eq"`, not `"tier__name__eq"`.
+9. **`session` parameter on `crud_router` is a callable** (a FastAPI dependency that yields/returns an `AsyncSession`), not a session instance.
+10. **`include_relationships` and `joins_config` are mutually exclusive** on `crud_router`. Pick one.
+11. **Joined-table polymorphic inheritance is supported.** v0.22.0 fixed auto-aliasing when primary and joined share a base table; v0.22.2 fixed inherited columns missing from `create()` responses.
+12. **SQLModel joined-table inheritance is fragile** — redeclaring `id` in a subclass breaks the SQLModel metaclass mapping. Stick to plain SQLAlchemy if you need polymorphism.
+13. **Python 3.10+ required.** Python 3.14 works since v0.22.1 (earlier versions crashed at import under PEP 649).
+
+---
+
+## When to drill into references
+
+Load these on demand:
+
+- `references/methods.md` — full signatures and overloads for every `FastCRUD` method
+- `references/filters.md` — every operator, `FilterConfig`, dependency-based filters, custom operators
+- `references/joins.md` — `JoinConfig` fields, auto-detection rules, `nested_limit` mechanics, polymorphism
+- `references/pagination.md` — offset vs cursor pagination, `paginated_response`, `CursorPaginatedRequestQuery`
+- `references/endpoints.md` — `crud_router` full signature, `EndpointCreator` subclassing, `included_methods`, per-method dependencies, soft delete, custom endpoint names
+
+---
+
+## SQLModel notes (when the project uses SQLModel instead)
+
+The library works the same way; substitute the model definition:
+
+```python
+from sqlmodel import SQLModel, Field
+
+class User(SQLModel, table=True):
+    __tablename__ = "user"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    email: str = Field(unique=True)
+    tier_id: int | None = Field(default=None, foreign_key="tier.id")
+```
+
+Schemas can also be `SQLModel` (without `table=True`) instead of `BaseModel`. The CRUD layer is identical because SQLModel inherits from SQLAlchemy. One caveat:
+
+- **Joined-table inheritance is unreliable** — see gotcha #11. For polymorphic models, drop to plain SQLAlchemy.

--- a/fastcrud/.agents/skills/fastcrud/references/endpoints.md
+++ b/fastcrud/.agents/skills/fastcrud/references/endpoints.md
@@ -1,0 +1,238 @@
+# Endpoints — `crud_router` and `EndpointCreator`
+
+How to customize the auto-generated FastAPI router.
+
+---
+
+## `crud_router` full parameter reference
+
+```python
+crud_router(
+    session,                          # callable[..., AsyncSession] — FastAPI dependency
+    model,                            # SQLAlchemy / SQLModel model class
+    create_schema,                    # Pydantic schema for POST body
+    update_schema,                    # Pydantic schema for PATCH body
+    *,
+    crud=None,                        # pre-built FastCRUD instance (else FastCRUD(model))
+    delete_schema=None,               # rarely needed — delete is by path param
+    select_schema=None,               # response schema for read endpoints
+    path="",                          # base path prefix (e.g. "/users")
+    tags=None,                        # OpenAPI tags
+    include_in_schema=True,
+
+    # Per-method dependencies (auth, rate limit, etc.)
+    create_deps=[],
+    read_deps=[],
+    read_multi_deps=[],
+    update_deps=[],
+    delete_deps=[],
+    db_delete_deps=[],
+
+    # Method selection
+    included_methods=None,            # whitelist: ["create", "read", "read_multi", ...]
+    deleted_methods=None,             # blacklist (cannot use with included_methods)
+
+    # Endpoint name customization
+    endpoint_names=None,              # {"create": "make", "read": "fetch", ...}
+
+    # Filters on the list endpoint
+    filter_config=None,               # FilterConfig | dict
+    custom_filters=None,              # {"year": year_eq, ...}
+
+    # Soft delete
+    is_deleted_column="is_deleted",
+    deleted_at_column="deleted_at",
+    updated_at_column="updated_at",
+
+    # Joins / relationships
+    include_relationships=False,      # True | False | ["rel1", "rel2"]
+    joins_config=None,                # explicit JoinConfig list (mutually exclusive with above)
+    nest_joins=True,
+    default_nested_limit=None,
+    include_one_to_many=False,
+
+    # Advanced configs
+    create_config=None,               # CreateConfig — auto-inject fields, exclusions
+    update_config=None,               # UpdateConfig — same
+    delete_config=None,               # DeleteConfig
+
+    # For deep customization
+    endpoint_creator=None,            # subclass of EndpointCreator
+)
+```
+
+---
+
+## Selecting which methods to expose
+
+```python
+crud_router(..., included_methods=["read", "read_multi"])   # read-only API
+crud_router(..., deleted_methods=["db_delete"])              # all but hard-delete
+```
+
+Method names (the strings accepted by `included_methods` / `deleted_methods` / `endpoint_names`):
+- `"create"` → `POST {path}`
+- `"read"` → `GET {path}/{pk}`
+- `"read_multi"` → `GET {path}`
+- `"update"` → `PATCH {path}/{pk}`
+- `"delete"` → `DELETE {path}/{pk}` (soft if configured, see [Soft delete](#soft-delete))
+- `"db_delete"` → `DELETE {path}/db_delete/{pk}` (always hard delete)
+
+`{pk}` is the actual primary-key column name (usually `id`). The `db_delete` endpoint is suffixed with `/db_delete/` to keep it distinct from the soft-delete endpoint — override via `endpoint_names={"db_delete": "hard"}` to change to `/hard/{pk}` etc.
+
+Cannot pass both `included_methods` and `deleted_methods` — raises `ValueError`.
+
+---
+
+## Per-method dependencies
+
+For auth, rate limiting, audit logging, etc.:
+
+```python
+from fastapi import Depends
+from .auth import require_admin, require_authenticated
+
+crud_router(
+    ...,
+    read_deps=[Depends(require_authenticated)],
+    read_multi_deps=[Depends(require_authenticated)],
+    create_deps=[Depends(require_admin)],
+    update_deps=[Depends(require_admin)],
+    delete_deps=[Depends(require_admin)],
+)
+```
+
+Each `*_deps` is a list of `Depends(...)` injected into that endpoint's signature. FastAPI evaluates them as usual.
+
+---
+
+## Auto-inject fields on create/update
+
+Use `CreateConfig` / `UpdateConfig` to derive fields from the request automatically (timestamps, user IDs, audit fields). This keeps them out of the user-facing schema:
+
+```python
+from datetime import datetime, UTC
+from fastapi import Depends
+from fastcrud import CreateConfig, UpdateConfig
+
+def now_utc() -> datetime:
+    return datetime.now(UTC)
+
+def current_user_id(user = Depends(get_current_user)) -> int:
+    return user.id
+
+crud_router(
+    ...,
+    create_schema=UserCreate,          # doesn't include created_by, created_at
+    create_config=CreateConfig(
+        auto_fields={
+            "created_by": current_user_id,
+            "created_at": now_utc,
+        },
+        exclude_from_schema=[],
+    ),
+    update_config=UpdateConfig(
+        auto_fields={"updated_by": current_user_id},
+    ),
+)
+```
+
+`auto_fields` values are FastAPI dependencies — they can take `Depends(...)` args, request headers, etc.
+
+---
+
+## Customizing endpoint names
+
+By default endpoints are mounted at `/`, `/{id}`, etc. To rename:
+
+```python
+crud_router(
+    ...,
+    path="/users",
+    endpoint_names={
+        "read": "fetch",          # GET /users/fetch/{id}
+        "read_multi": "list",     # GET /users/list
+        "create": "register",     # POST /users/register
+    },
+)
+```
+
+---
+
+## Soft delete
+
+Configure via the column-name parameters (defaults shown):
+
+```python
+crud_router(
+    ...,
+    is_deleted_column="is_deleted",
+    deleted_at_column="deleted_at",
+)
+```
+
+When **both** columns exist on the model:
+- `DELETE /{id}` sets `is_deleted=True`, `deleted_at=now()`.
+- All read queries auto-filter `is_deleted=False`.
+- `DELETE /db/{id}` always hard-deletes.
+
+To temporarily query soft-deleted rows, pass `is_deleted=True` as a kwarg on the underlying `FastCRUD` method (not exposed via `crud_router` by default).
+
+---
+
+## `EndpointCreator` — for advanced customization
+
+Subclass `EndpointCreator` to add new endpoints or override existing ones. The override entry point is the **public** method `add_routes_to_router(...)`:
+
+```python
+from fastapi import Depends
+from fastcrud import EndpointCreator, crud_router
+
+class MyEndpointCreator(EndpointCreator):
+    def add_routes_to_router(self, **kwargs):
+        super().add_routes_to_router(**kwargs)    # keep the defaults
+        self.router.add_api_route(
+            "/me",
+            self._me_endpoint(),
+            methods=["GET"],
+        )
+
+    def _me_endpoint(self):
+        async def endpoint(user = Depends(get_current_user)):
+            async for db in self.session():
+                return await self.crud.get(db, id=user.id)
+        return endpoint
+
+router = crud_router(
+    ...,
+    endpoint_creator=MyEndpointCreator,   # pass the CLASS, not an instance
+)
+```
+
+The built-in endpoint-builder methods are private (single underscore prefix) and return the FastAPI handler callable — override them to change behavior of an existing endpoint:
+
+| Method                | Builds                          |
+|-----------------------|---------------------------------|
+| `_create_item()`      | `POST {path}`                   |
+| `_read_item()`        | `GET {path}/{pk}`               |
+| `_read_items()`       | `GET {path}` (paginated list)   |
+| `_update_item()`      | `PATCH {path}/{pk}`             |
+| `_delete_item()`      | `DELETE {path}/{pk}`            |
+| `_db_delete()`        | `DELETE {path}/db_delete/{pk}`  |
+| `_create_cursor_validator()` | cursor query-param validator dependency used by custom cursor endpoints |
+
+The route-registration loop is `add_routes_to_router(...)` — that's the public seam you override to add new routes or skip default ones.
+
+---
+
+## Response wrapper key
+
+Multi-item endpoints wrap results in `{"data": [...], "total_count": N}` by default. To change the wrapper key:
+
+```python
+crud = FastCRUD(User, multi_response_key="items")
+crud_router(..., crud=crud)
+# now: {"items": [...], "total_count": N}
+```
+
+Pass the pre-built `FastCRUD` instance via `crud=` to apply.

--- a/fastcrud/.agents/skills/fastcrud/references/filters.md
+++ b/fastcrud/.agents/skills/fastcrud/references/filters.md
@@ -1,0 +1,145 @@
+# Filters
+
+Complete reference for filtering — operator syntax, `FilterConfig` (the `crud_router` query-param surface), dependency-based filters, custom operators.
+
+---
+
+## Operator reference
+
+Every operator is registered as a suffix after `__` on a field name.
+
+| Suffix         | SQL / behaviour                                | Value shape          |
+|----------------|------------------------------------------------|----------------------|
+| (none)         | `=` (equality is the default)                  | scalar               |
+| `__eq`         | `=`                                            | scalar               |
+| `__ne`         | `<>`                                           | scalar               |
+| `__gt` `__gte` | `>` `>=`                                       | scalar               |
+| `__lt` `__lte` | `<` `<=`                                       | scalar               |
+| `__is`         | `IS` (use for `None`/`True`/`False`)           | scalar               |
+| `__is_not`     | `IS NOT`                                       | scalar               |
+| `__in`         | `IN (...)`                                     | list / tuple / set   |
+| `__not_in`     | `NOT IN (...)`                                 | list / tuple / set   |
+| `__between`    | `BETWEEN a AND b`                              | 2-element sequence   |
+| `__like`       | `LIKE` (case-sensitive)                        | string w/ `%`        |
+| `__notlike`    | `NOT LIKE`                                     | string w/ `%`        |
+| `__ilike`      | `ILIKE` (case-insensitive, Postgres)           | string w/ `%`        |
+| `__notilike`   | `NOT ILIKE`                                    | string w/ `%`        |
+| `__startswith` | `LIKE 'value%'` (auto-wrapped)                 | bare substring — do NOT add `%` yourself |
+| `__endswith`   | `LIKE '%value'` (auto-wrapped)                 | bare substring                           |
+| `__contains`   | `LIKE '%value%'` (auto-wrapped)                | bare substring                           |
+| `__match`      | engine-specific full-text match                | depends              |
+| `__or`         | OR group (see below)                           | dict                 |
+| `__not`        | NOT wrapper                                    | scalar               |
+
+### OR groups
+
+To express `(col >= 10 OR col <= 0)`:
+
+```python
+await crud.get_multi(db, price__or={"gte": 100, "lte": 0})
+```
+
+The keys inside the dict are operator names (without the `__` prefix).
+
+### Joined filters
+
+For `crud_router` filter configs and the joined CRUD methods, use a **dot** to walk relationships:
+
+```python
+await crud.get_multi_joined(db, **{"tier.name__eq": "premium"})
+
+FilterConfig({
+    "tier.name__eq": None,          # query param: ?tier.name__eq=premium
+    "tier.tier_score__gte": None,
+})
+```
+
+Joined filters auto-include the join — you don't need to also list the relationship in `include_relationships`. They walk one level of relationship per `.`.
+
+---
+
+## `FilterConfig` — the `crud_router` filter surface
+
+Defines which query parameters are exposed on the auto-generated `GET /list` endpoint, plus their default values and types.
+
+```python
+from fastcrud import FilterConfig, crud_router
+
+filters = FilterConfig({
+    "name__ilike": None,           # ?name__ilike=%admin%
+    "price__gte": 0,               # default 0
+    "active": True,                # default True; query param: ?active=false to override
+    "tag__in": None,               # ?tag__in=a&tag__in=b
+    "tier.name": None,             # joined filter; auto-joins tier
+    "created_at__between": None,
+})
+
+router = crud_router(..., filter_config=filters)
+```
+
+### Types are exposed correctly in OpenAPI (v0.22+)
+
+FastCRUD now reads the column type and renders proper `integer`/`string`/`boolean`/`array<X>` schemas instead of falling back to `any`. The FastAPI `/docs` page shows real input controls and OpenAPI codegen produces typed clients.
+
+You don't need to do anything to opt in — it Just Works™ as long as you're on v0.22 or later.
+
+### Bool coercion
+
+`?active=false` (and `False`, `FALSE`, `0`) is correctly parsed as `False`. Case-insensitive. Don't pre-coerce.
+
+---
+
+## Dependency-based filters
+
+Pass a FastAPI `Depends(...)` callable as the default value to filter by something extracted from the request (current user, tenant, header, etc.):
+
+```python
+from fastapi import Depends
+from fastcrud import FilterConfig, crud_router
+
+def current_tenant_id(user = Depends(get_current_user)) -> int:
+    return user.tenant_id
+
+router = crud_router(
+    ...,
+    filter_config=FilterConfig({
+        "tenant_id": Depends(current_tenant_id),    # every list query is scoped to caller's tenant
+        "name__ilike": None,
+    }),
+)
+```
+
+The dependency runs per request, before the query. This is the right way to enforce row-level access control.
+
+---
+
+## Custom operators
+
+Register your own operator with `custom_filters` on `crud_router`:
+
+```python
+def year_eq(column):
+    """Match rows where column's YEAR(...) equals the value."""
+    from sqlalchemy import extract
+    def make_filter(value):
+        return extract("year", column) == value
+    return make_filter
+
+router = crud_router(
+    ...,
+    custom_filters={"year": year_eq},
+    filter_config=FilterConfig({"created_at__year": None}),
+)
+```
+
+Then `?created_at__year=2025` works.
+
+For the full registration protocol see `fastcrud.core.filtering.operators.FilterCallable`. The callable signature is `(column) -> (value) -> SQLAlchemy expression`.
+
+---
+
+## When the filter syntax fails open
+
+If a filter key doesn't match any column and isn't a registered operator, FastCRUD raises `ValueError`. There's no silent fall-through, so a typo in `"price__gtee"` will be caught — but only at query time, not at startup.
+
+For startup-time validation, instantiate the `FilterConfig` early in your app and call `validate_joined_filter_path` (from `fastcrud.core.config`) against each joined key if you want to fail fast.

--- a/fastcrud/.agents/skills/fastcrud/references/joins.md
+++ b/fastcrud/.agents/skills/fastcrud/references/joins.md
@@ -1,0 +1,193 @@
+# Joins
+
+Everything about loading related data — auto-detection, `JoinConfig`, `nested_limit`, polymorphic inheritance.
+
+---
+
+## Two ways to join
+
+Pick one. They cannot be combined on the same `crud_router` call.
+
+### Auto-detect (default, recommended)
+
+```python
+crud_router(
+    ...,
+    include_relationships=True,            # all relationships
+    # or:
+    include_relationships=["tier", "dept"], # whitelist
+)
+```
+
+FastCRUD inspects the SQLAlchemy mapper, discovers all `relationship(...)` definitions, walks foreign keys bidirectionally, generates `JoinConfig` objects, and applies left joins.
+
+**Defaults:**
+- All `*-to-one` relationships are included.
+- **One-to-many is excluded** unless you explicitly opt in.
+- Multiple relationships to the same table get distinct aliases automatically.
+
+### Manual `JoinConfig`
+
+```python
+from fastcrud import JoinConfig
+
+joins = [
+    JoinConfig(
+        model=Tier,
+        join_on=User.tier_id == Tier.id,
+        join_prefix="tier_",
+        schema_to_select=TierRead,
+        join_type="left",          # or "inner"
+    ),
+]
+
+crud_router(..., joins_config=joins)
+```
+
+Use this for: self-joins, custom join conditions, per-join schemas, per-join filters, explicit aliasing.
+
+---
+
+## `JoinConfig` fields
+
+| Field               | Required | Default        | Notes                                                            |
+|---------------------|----------|----------------|------------------------------------------------------------------|
+| `model`             | yes      | —              | SQLAlchemy model to join                                         |
+| `join_on`           | yes      | —              | SQLAlchemy expression (`A.id == B.a_id`)                         |
+| `join_prefix`       | no       | `None`         | Column prefix in flat results (no effect when `nest_joins=True`) |
+| `schema_to_select`  | no       | `None`         | Limit columns selected from this join                            |
+| `join_type`         | no       | `"left"`       | `"left"` or `"inner"`                                            |
+| `alias`             | no       | `None`         | Pass an `aliased(Model, flat=True)` for self-joins / polymorphic |
+| `filters`           | no       | `None`         | Dict of filters applied to this join's table                     |
+| `relationship_type` | no       | `"one-to-one"` | Set `"one-to-many"` for collections                              |
+| `sort_columns`      | no       | `None`         | Sort nested items (one-to-many only)                             |
+| `sort_orders`       | no       | `None`         | `"asc"` / `"desc"` matching `sort_columns`                       |
+| `nested_limit`      | no       | `None`         | Cap nested items per parent (uses SQL window function)           |
+
+---
+
+## One-to-many and `nested_limit`
+
+The N+1 trap for collections: naïve code fetches the parent, then loops to fetch children. **Don't.** Use `nested_limit` on `JoinConfig` (or `default_nested_limit` on `crud_router`):
+
+```python
+JoinConfig(
+    model=Article,
+    join_on=Article.author_id == Author.id,
+    relationship_type="one-to-many",
+    sort_columns="created_at",
+    sort_orders="desc",
+    nested_limit=10,                       # 10 most recent articles per author
+)
+```
+
+FastCRUD rewrites this as a `ROW_NUMBER() OVER (PARTITION BY author_id ORDER BY created_at DESC)` subquery and filters `rn <= 10`. **The capping happens at the database level**, not in Python — even with 10,000 authors, only 100,000 rows transit the wire (10 per author), not the unbounded collection.
+
+For `crud_router`:
+
+```python
+crud_router(
+    ...,
+    include_relationships=True,
+    include_one_to_many=True,
+    default_nested_limit=10,
+)
+```
+
+---
+
+## Self-joins and aliases
+
+Use an explicit alias:
+
+```python
+from sqlalchemy.orm import aliased
+
+manager_alias = aliased(User, flat=True)
+
+joins = [
+    JoinConfig(
+        model=User,
+        alias=manager_alias,
+        join_on=Employee.manager_id == manager_alias.id,
+        join_prefix="manager_",
+        schema_to_select=UserRead,
+    ),
+]
+```
+
+`flat=True` is important for SQL correctness when the alias is used in nested joins.
+
+---
+
+## Polymorphic / joined-table inheritance
+
+SQLAlchemy joined-table inheritance works with FastCRUD. v0.22.0 fixed a long-standing bug where the join target wasn't aliased when the primary and joined models shared a base table — that's now automatic.
+
+```python
+class Entity(Base):
+    __tablename__ = "entity"
+    id = Column(Integer, primary_key=True)
+    type = Column(String(50))
+    __mapper_args__ = {"polymorphic_on": "type", "polymorphic_identity": "entity"}
+
+class Project(Entity):
+    __tablename__ = "project"
+    id = Column(Integer, ForeignKey("entity.id"), primary_key=True)
+    name = Column(String)
+    contract_id = Column(Integer, ForeignKey("contract.id"))
+    __mapper_args__ = {"polymorphic_identity": "project"}
+
+# This Just Works since v0.22.0
+crud = FastCRUD(Project)
+await crud.get_joined(db, auto_detect_relationships=True, id=1)
+```
+
+**v0.22.2 also fixed inherited columns missing from `create()` responses** — earlier versions returned only the child table's columns, silently dropping anything from the parent (including the polymorphic discriminator).
+
+### SQLModel + polymorphism = avoid
+
+SQLModel's metaclass treats redeclared `id` fields in subclasses as shadowing the parent attribute, breaking the SQLAlchemy mapping. The model loads, but `inspect(cls)` fails with `NoInspectionAvailable`. **Use plain SQLAlchemy if you need polymorphic inheritance.**
+
+---
+
+## `CountConfig` — counts without joining the rows
+
+When you want `users` plus a count of their `posts` but don't want to actually join and nest the posts:
+
+```python
+from fastcrud import CountConfig
+
+result = await crud.get_multi_joined(
+    db,
+    joins_config=[],
+    count_configs=[
+        CountConfig(
+            model=Post,
+            join_on=Post.user_id == User.id,
+            alias="post_count",
+        ),
+    ],
+)
+# each user dict has a "post_count" field
+```
+
+Implemented as a scalar subquery, so every primary row is returned (with `0` for parents with no children).
+
+---
+
+## `nest_joins` — nested dicts vs flat columns
+
+- `nest_joins=True`: joined data is nested under the relationship name: `{"id": 1, "tier": {"name": "premium"}}`
+- `nest_joins=False`: joined columns are flattened with `join_prefix`: `{"id": 1, "tier_name": "premium"}`
+
+**The default differs depending on the entry point:**
+
+| Entry point                                              | Default       |
+|----------------------------------------------------------|---------------|
+| `crud_router(...)` / `EndpointCreator.__init__(...)`     | `True` (nest) |
+| `FastCRUD(Model).get_joined(...)` / `get_multi_joined(...)` (direct call) | `False` (flat) |
+
+When calling FastCRUD methods directly, pass `nest_joins=True` explicitly if you want the nested shape — clients usually expect it. The router defaults to nesting because that's the typical API response shape; the direct method defaults to flat because it's the cheaper structure when you're consuming the rows in Python.
+
+**One-to-many always requires `nest_joins=True`** — `nest_joins=False` with a one-to-many `JoinConfig` raises `ValueError`.

--- a/fastcrud/.agents/skills/fastcrud/references/methods.md
+++ b/fastcrud/.agents/skills/fastcrud/references/methods.md
@@ -1,0 +1,176 @@
+# FastCRUD method reference
+
+Every method on `FastCRUD(Model)`, with signature shape, return type, and the one or two non-obvious things to know about each.
+
+All methods are `async` and take an `AsyncSession` as `db`. Filter kwargs use the `field__op` syntax (see `filters.md`).
+
+---
+
+## Reads
+
+### `get(db, schema_to_select=None, return_as_model=False, **kwargs) -> dict | Model | None`
+
+Single row by filters. Returns `None` if not found (does not raise).
+
+```python
+user = await crud.get(db, id=1)                                    # dict
+user = await crud.get(db, id=1, schema_to_select=UserRead,
+                       return_as_model=True)                        # UserRead | None
+```
+
+### `get_joined(db, joins_config=None, auto_detect_relationships=False, schema_to_select=None, return_as_model=False, nest_joins=False, **kwargs)`
+
+Single row plus joined data. Set `auto_detect_relationships=True` (or pass `joins_config=[...]`) to control which related models are joined.
+
+```python
+user = await crud.get_joined(db, auto_detect_relationships=True, nest_joins=True, id=1)
+# {"id": 1, "name": "...", "tier": {"id": 2, "name": "premium"}}
+```
+
+**Default `nest_joins=False`** on the direct method — joined columns are flattened with `join_prefix`. Pass `nest_joins=True` for the nested-dict shape shown above. Note this is the opposite of `crud_router`'s default (`nest_joins=True`).
+
+### `get_multi(db, offset=0, limit=100, schema_to_select=None, return_as_model=False, sort_columns=None, sort_orders=None, **kwargs)`
+
+Offset-paginated list. Returns `{"data": [...], "total_count": N}` by default; the wrapper key is configurable via `multi_response_key`.
+
+```python
+result = await crud.get_multi(db, offset=0, limit=20, tier_id=1,
+                              sort_columns=["created_at"], sort_orders=["desc"])
+# {"data": [...], "total_count": 42}
+```
+
+**`limit=None` fetches every matching row.** Only safe when a `WHERE` clause domain-bounds the result (e.g., `project_id=...`, `id__in=[...]`). Otherwise pass an explicit numeric limit. For tables that grow unboundedly, use `get_multi_by_cursor` for batched processing. See `pagination.md` for the sanity-check pattern.
+
+### `get_multi_joined(db, joins_config=None, auto_detect_relationships=False, ...)`
+
+Same as `get_multi` but with joins. **This is what you use to avoid N+1.** Per-join filters live inside each `JoinConfig.filters`.
+
+```python
+result = await crud.get_multi_joined(
+    db,
+    auto_detect_relationships=["tier", "articles"],
+    nested_limit=5,           # cap one-to-many at 5 nested rows per parent (SQL window function)
+    offset=0, limit=20,
+    tier_id=1,
+)
+```
+
+### `get_multi_by_cursor(db, cursor=None, limit=100, sort_column="id", sort_order="asc", schema_to_select=None, ...)`
+
+Cursor pagination — efficient for infinite-scroll. Returns `{"data": [...], "next_cursor": <value-or-null>}`.
+
+```python
+page1 = await crud.get_multi_by_cursor(db, limit=20, sort_column="created_at", sort_order="desc")
+page2 = await crud.get_multi_by_cursor(db, cursor=page1["next_cursor"], limit=20,
+                                       sort_column="created_at", sort_order="desc")
+```
+
+Cursor values are validated against the column type **only when the method is exposed through a router-generated endpoint** (the cursor validator is set up in `EndpointCreator`, not in `FastCRUD.get_multi_by_cursor` itself). When you build your own endpoint around the direct method, validate the incoming cursor yourself or surface the database-level error to the caller. Validation recognises plain integers, UUIDs (including SQLModel's `GUID` type), and ISO datetimes.
+
+### `count(db, joins_config=None, **kwargs) -> int`
+
+Row count, with optional joins. `joins_config` can include `CountConfig` for subquery-based related counts.
+
+### `exists(db, **kwargs) -> bool`
+
+Cheap existence check (`SELECT ... LIMIT 1`). Returns `True` if any row matches the filters, `False` otherwise.
+
+### `select(...) -> Select`
+
+Returns the SQLAlchemy `Select` statement without executing. Use when you need to compose further (raw `.execute()`, custom CTE, etc.).
+
+---
+
+## Writes
+
+### `create(db, object, commit=True, schema_to_select=None, return_as_model=False)`
+
+Insert one row. Returns `None` by default (since v0.20.0) — pass `schema_to_select` to get back data.
+
+```python
+await crud.create(db, UserCreate(name="X"))                                # None
+created = await crud.create(db, UserCreate(name="X"),
+                             schema_to_select=UserRead,
+                             return_as_model=True)                          # UserRead
+```
+
+**Inherited columns:** v0.22.2 fixed a bug where columns from parent tables in joined-table inheritance were missing from the response dict. If you hit a `KeyError` on an inherited column, upgrade.
+
+### `upsert(db, instance, schema_to_select=None, return_as_model=False)`
+
+Insert-or-update by primary key. **Implementation is two round-trips** — issues a `get` first, then `create` or `update` depending on whether a row matched. There is no `commit` parameter and no dialect-specific `ON CONFLICT` clause — that's `upsert_multi`. Use this only for single instances where simplicity outweighs the extra round-trip.
+
+### `upsert_multi(db, instances: list, commit=False, return_columns=None, schema_to_select=None, return_as_model=False, update_override=None, **kwargs)`
+
+Batch upsert via dialect-specific `ON CONFLICT` (Postgres / SQLite) or `ON DUPLICATE KEY UPDATE` (MySQL). Single round-trip.
+
+- **`commit=False` default** (different from `create`/`update`) — caller is responsible for committing.
+- **`update_override={...}`** overrides the values applied on conflict (otherwise the conflicting row is updated to the values in the corresponding `instance`).
+- **`return_columns=["id", "name"]`** captures the listed columns via `RETURNING`. Returns a dict shaped `{"created": [...], "updated": [...]}` keyed by which path each row took.
+- **MySQL caveat:** doesn't support `RETURNING`, so passing `return_columns` / `schema_to_select` / `return_as_model` / filter kwargs raises `ValueError` on MySQL.
+- Unsupported dialects raise `NotImplementedError`.
+
+### `update(db, object, commit=True, return_columns=None, schema_to_select=None, return_as_model=False, allow_multiple=False, **kwargs)`
+
+Patch by filters. `kwargs` select the row(s); `object` (Pydantic model or dict) carries the new values.
+
+```python
+await crud.update(db, UserUpdate(name="Y"), id=1)
+```
+
+- **`return_columns` must be a list** (`return_columns=True` raises since v0.22.0). Pass `["id", "name"]` to get those columns back as a dict.
+- **`allow_multiple=False` (default)** — if the filter matches more than one row, raises. Set `True` to bulk-update.
+- **`updated_at` auto-update**: if your model has an `updated_at` column (configurable name), it's set to `datetime.now(UTC)` automatically on every update.
+
+### `delete(db, db_row=None, filters=None, allow_multiple=False, commit=True, **kwargs)`
+
+Soft delete if the configured soft-delete columns exist on the model; otherwise hard delete. Same `allow_multiple` semantics as `update`.
+
+Two execution paths with slightly different rules:
+
+- **Filter path** (no `db_row` passed) — sets whichever of `is_deleted_column` / `deleted_at_column` actually exists in `model_col_names`; falls back to hard `DELETE` only when neither exists.
+- **`db_row` path** (preloaded instance passed) — requires **both** columns to be present on the instance for soft delete; otherwise hard-deletes via `session.delete(db_row)`.
+
+You almost always want the filter path. The `db_row` path exists for cases where you've already loaded the row for another reason.
+
+### `db_delete(db, allow_multiple=False, commit=True, **kwargs)`
+
+Always hard delete (`DELETE FROM ...`), regardless of soft-delete configuration.
+
+---
+
+## Schema-controlled column selection
+
+`schema_to_select` does **column selection**, not type coercion. The query selects only the columns listed in the schema, which is faster than `SELECT *`. Combined with `return_as_model=True`, you also get validated Pydantic instances back.
+
+```python
+class UserSummary(BaseModel):
+    id: int
+    name: str
+
+# Only SELECTs id, name — not email, tier_id, etc.
+summary = await crud.get(db, id=1, schema_to_select=UserSummary)
+# {"id": 1, "name": "..."}
+```
+
+This is the main lever for reducing payload size on read endpoints.
+
+---
+
+## Type-narrowing pattern (v0.22+)
+
+If you want per-call type narrowing (e.g., admin endpoint that returns a superset schema), pass a subclass of the class-level `select_schema`. The TypeVar on the method propagates the subclass through to the return type:
+
+```python
+crud = FastCRUD(User)  # default SelectSchemaType is unset
+
+class UserRead(BaseModel): ...
+class UserAdminRead(UserRead):
+    role: str
+    last_login: datetime
+
+result = await crud.get(db, id=1, schema_to_select=UserAdminRead, return_as_model=True)
+# typed as UserAdminRead | None
+```
+
+No `cast()` needed — the previous version required it.

--- a/fastcrud/.agents/skills/fastcrud/references/pagination.md
+++ b/fastcrud/.agents/skills/fastcrud/references/pagination.md
@@ -1,0 +1,200 @@
+# Pagination
+
+Two strategies. Pick by access pattern. Then pick your `limit` carefully — `limit=None` is the most common source of latency cliffs in real FastCRUD code.
+
+---
+
+## Offset pagination — `get_multi(...)`
+
+Best for: numbered pages, "page 5 of 17"-style UIs, admin panels.
+
+```python
+result = await crud.get_multi(db, offset=0, limit=20)
+# {"data": [...], "total_count": 142}
+```
+
+For the next page:
+
+```python
+result = await crud.get_multi(db, offset=20, limit=20)
+```
+
+### Helpers
+
+```python
+from fastcrud import compute_offset, paginated_response, PaginatedListResponse
+
+offset = compute_offset(page=3, items_per_page=20)   # → 40
+
+result = await crud.get_multi(db, offset=offset, limit=20)
+return paginated_response(crud_data=result, page=3, items_per_page=20)
+# {"data": [...], "total_count": 142, "has_more": true, "page": 3, "items_per_page": 20}
+```
+
+### When `crud_router` exposes this
+
+`GET /your-path` is paginated by default. Query params: `?page=N&itemsPerPage=M` (the `itemsPerPage` alias is camelCase, matching the OpenAPI/JSON convention — the snake_case `items_per_page` form is also accepted via `populate_by_name=True`).
+
+---
+
+## Cursor pagination — `get_multi_by_cursor(...)`
+
+Best for: infinite scroll, activity feeds, anywhere "page N+1" doesn't make sense, and any list where rows are inserted/deleted frequently (offset paginates wrongly under concurrent writes).
+
+```python
+page1 = await crud.get_multi_by_cursor(
+    db,
+    limit=20,
+    sort_column="created_at",
+    sort_order="desc",
+)
+# {"data": [...], "next_cursor": "2026-05-20T10:30:00"}
+
+page2 = await crud.get_multi_by_cursor(
+    db,
+    cursor=page1["next_cursor"],
+    limit=20,
+    sort_column="created_at",
+    sort_order="desc",
+)
+```
+
+`next_cursor` is `None` on the last page.
+
+### Cursor validation (v0.22+, router-side only)
+
+When the cursor endpoint is exposed by `EndpointCreator` (i.e. a custom endpoint built via subclass — `get_multi_by_cursor` isn't in the default `crud_router` endpoints), the router wraps the cursor parameter with a validator that:
+
+- Rejects out-of-range integers (int32/int64 overflow) → HTTP 400
+- Rejects malformed UUIDs → HTTP 400
+- Rejects unparseable datetimes → HTTP 400
+- Recognises SQLModel's `GUID` type for UUID columns
+
+The direct `FastCRUD.get_multi_by_cursor(...)` method does **not** do this validation — it just builds the filter and runs the query, so a bad cursor surfaces as a database error. If you call the method directly from your own endpoint, validate the cursor yourself (or wire it through `EndpointCreator._create_cursor_validator`).
+
+### When `crud_router` exposes this
+
+Cursor pagination is **not** in the default `crud_router` endpoints. Add it via `EndpointCreator` subclass or as a custom endpoint:
+
+```python
+from fastapi import APIRouter, Depends
+from fastcrud import CursorPaginatedRequestQuery, FastCRUD
+
+router = APIRouter()
+crud = FastCRUD(User)
+
+@router.get("/users/feed")
+async def feed(
+    query: CursorPaginatedRequestQuery = Depends(),
+    db: AsyncSession = Depends(get_async_session),
+):
+    return await crud.get_multi_by_cursor(
+        db,
+        cursor=query.cursor,
+        limit=query.limit,
+        sort_column=query.sort_column,
+        sort_order=query.sort_order,
+    )
+```
+
+`CursorPaginatedRequestQuery` is a pre-built Pydantic model with `cursor`, `limit`, `sort_column`, `sort_order` fields and FastAPI-friendly defaults.
+
+---
+
+## Don't mix strategies
+
+A single endpoint should be one or the other. Switching strategies mid-list (e.g., starting with offset and then switching to cursor) requires holding two queries' worth of state on the client and rarely justifies the complexity.
+
+---
+
+## Picking `limit`
+
+`get_multi(...)` / `get_multi_joined(...)` accept any positive integer or `None`. `None` means "fetch everything matching the WHERE clause." This is occasionally what you want and frequently what you don't.
+
+### Default by surface
+
+| Surface                                       | Default                                |
+|-----------------------------------------------|----------------------------------------|
+| HTTP list endpoint                            | `limit = min(requested, MAX_PAGE_LIMIT)` |
+| Worker fetch of bounded child collection      | Explicit cap (`limit=RENDER_MAX_CLIPS`) |
+| Bulk fan-out across a large table             | `get_multi_by_cursor(limit=BATCH_SIZE)` |
+| Lookup by domain-bounded WHERE clause         | `limit=None` is OK (with sanity check) |
+
+### When `limit=None` is safe
+
+When a WHERE clause guarantees a bounded number of rows. Examples:
+
+```python
+# OK: bounded by clips-per-project (a few hundred at most)
+await crud_clips.get_multi(db, limit=None, project_id=project.id)
+
+# OK: bounded by len(tier_ids) which is small
+await crud_tiers.get_multi(db, limit=None, id__in=tier_ids)
+
+# OK: bounded by entitlements-per-user
+await crud_entitlements.get_multi(db, limit=None, user_id=user.id)
+```
+
+### When `limit=None` is unsafe
+
+When the WHERE clause doesn't bound the result, or when "bounded" today might not be tomorrow.
+
+```python
+# BAD: unbounded; grows with the user table forever
+await crud_users.get_multi(db, limit=None)
+
+# BAD: unbounded; grows with traffic
+await crud_events.get_multi(db, limit=None, event_type="page_view")
+
+# BAD: "bounded" by status, but pending tasks pile up
+await crud_tasks.get_multi(db, limit=None, status="pending")
+```
+
+### The sanity-check pattern
+
+When `limit=None` is justified, log when results unexpectedly explode. Catches drift before it becomes an incident:
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+def handle_query_sanity(items: list, threshold: int, context: str) -> None:
+    """Used on domain-bounded queries (limit=None with a WHERE clause)
+    to surface unexpected growth without breaking the request."""
+    if len(items) > threshold:
+        logger.warning(
+            "query growth: %d items > %d threshold (%s)",
+            len(items), threshold, context,
+        )
+
+result = await crud_entitlements.get_multi(db, limit=None, user_id=user.id)
+handle_query_sanity(result["data"], threshold=100, context="user_entitlements")
+```
+
+Pick a threshold ~5x the expected steady-state count. Don't raise — log and continue.
+
+### Putting it all together — HTTP list endpoint
+
+```python
+DEFAULT_PAGE_LIMIT = 20
+MAX_PAGE_LIMIT = 100
+
+async def list_users(
+    offset: int = 0,
+    limit: int = DEFAULT_PAGE_LIMIT,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    limit = min(limit, MAX_PAGE_LIMIT)   # never trust client
+    return await crud_users.get_multi(db, offset=offset, limit=limit)
+```
+
+---
+
+## Total count is not free
+
+`get_multi(...)` runs a `SELECT COUNT(*)` in addition to the data query. On large tables behind heavy filters, this can dominate the response time. Two options:
+
+1. **Skip the count:** call `get_multi_by_cursor` (no count returned).
+2. **Pass `return_total_count=False`** to `get_multi(...)` if you don't need it.
+
+Per [PR #146](https://github.com/benavlabs/fastcrud/issues/146), an exact `total_count` is sometimes a foot-gun on tables with billions of rows. If your dataset is that large, drop the count.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastcrud"
-version = "0.22.2"
+version = "0.22.3"
 description = "FastCRUD is a Python package for FastAPI, offering robust async CRUD operations and flexible endpoint creation utilities."
 authors = [{ name = "Igor Benav", email = "igor@benav.io" }]
 requires-python = ">=3.10,<4"

--- a/zensical.toml
+++ b/zensical.toml
@@ -63,6 +63,9 @@ edit_uri = "edit/main/docs/"
 "Why FastCRUD?" = "why-fastcrud.md"
 
 [[project.nav]]
+"Library Skill" = "library-skill.md"
+
+[[project.nav]]
 "Usage" = [
     { "Overview" = "usage/overview.md" },
     { "Automatic Endpoints" = "usage/endpoint.md" },


### PR DESCRIPTION
# Library Skill: bundle FastCRUD knowledge for AI coding agents

FastCRUD now ships an [Agent Skill](https://agentskills.io/) inside the wheel, following the [Library Skills](https://github.com/tiangolo/library-skills) convention. After installing FastCRUD into a project, users run `uvx library-skills` once and any compatible coding assistant — Claude Code, Cursor, GitHub Copilot, OpenCode, Codex, Goose, and [30+ others](https://agentskills.io/clients) — picks up project-specific guidance about how to use FastCRUD correctly. The skill is grounded in the real public API of `fastcrud 0.22` and includes the production patterns we've learned from using FastCRUD in Sapari, particularly around N+1 avoidance and when to drop to raw SQLAlchemy. Released as v0.22.3.

---

## Bundled Library Skill

Until now, an LLM coding assistant working with FastCRUD had two options: read the docs site at build time, or guess from the imported symbols. Neither produces correct code reliably. The docs cover the API but not the failure modes; the imports cover the symbols but not the semantics. Agents got `return_as_model=True` without `schema_to_select` wrong, iterated `crud.get()` per ID instead of using `id__in`, and called `crud.get_multi(limit=None)` on tables that grow with traffic.

This change bundles an Agent Skill inside the published wheel at `fastcrud/.agents/skills/fastcrud/`. The Library Skills CLI symlinks it into the user's `.agents/skills/` (or `.claude/skills/` for Claude Code) so any compatible coding assistant discovers it automatically. Because the install is a symbolic link by default, upgrading FastCRUD updates the skill — there's no per-project copy to drift.

```
fastcrud/.agents/skills/fastcrud/
├── SKILL.md              # entry point — loaded when the agent activates the skill
└── references/
    ├── methods.md        # every FastCRUD method, return semantics, type narrowing
    ├── filters.md        # every operator, FilterConfig, dependency filters, custom operators
    ├── joins.md          # JoinConfig, auto-detection, nested_limit, polymorphism
    ├── pagination.md     # offset vs cursor, sanity-checking limit=None
    └── endpoints.md      # crud_router params, EndpointCreator subclassing, soft delete
```

**Why:** Generic LLM knowledge produces plausible-but-wrong FastCRUD code. Project-specific best practices have to live next to the library, in a format agents can load on demand. The Agent Skills standard (progressive disclosure — name + description load at startup, full body loads only when the task matches) is the right shape for this: many libraries can ship skills without bloating the agent's context.

---

## What the skill teaches

The main `SKILL.md` opens with what `FastCRUD` is and isn't — explicitly: it's for per-row CRUD on a single model, not for aggregate roll-ups, CTEs, `GROUP BY` projections, or bulk writes. Those belong to raw SQLAlchemy and the skill names that boundary up front so agents don't try to wedge FastCRUD into the wrong shape.

The decision table that follows ("Choosing the right method") maps each data shape — single row, single row with joins, paginated list, paginated list with joins, cursor pagination, insert, upsert, patch by filters, soft delete, hard delete, count, exists — to the right `FastCRUD` method. It deliberately highlights `get_multi_joined` because looping `get_multi() + get_joined()` per row is the canonical N+1 trap.

Two full sections cover the most common production footguns. **Avoiding N+1** walks the agent through both mechanisms: `include_relationships=True` for auto-detection (with the important gotcha that one-to-many is excluded by default), and manual `JoinConfig` for explicit control. The `nested_limit` field is called out as a SQL `ROW_NUMBER() OVER (PARTITION BY ...)` window function — capping happens database-side, not in Python. **`limit=None` — the second biggest footgun** explains when it's safe (domain-bounded `WHERE` clause), when it isn't (unbounded growth tables), and includes the three-tier pagination default we use in Sapari: `min(limit, MAX_PAGE_LIMIT)` for HTTP endpoints, explicit caps for worker child collections, `get_multi_by_cursor` for bulk fan-out. The `handle_query_sanity` helper from Sapari is shown verbatim as the pattern for logging unexpected result growth.

A "When NOT to use FastCRUD" section follows with a 7-row table mapping query shapes to raw SQLAlchemy alternatives — multi-aggregate `COUNT FILTER WHERE`, CTEs, `EXISTS()` filters, `GROUP BY` with derived columns, bulk `UPDATE ... WHERE id IN (...)`, bulk `INSERT`, dialect-specific features. It explicitly notes that `crud_router` itself is optional and many production codebases use FastCRUD instances as a data-access layer behind hand-written FastAPI routes. Anti-patterns to refactor on sight close the section: per-ID `crud.get()` loops, `db.scalar(select(...).exists())`, `get_multi(limit=None) + Python filtering`, `crud.get()` without `schema_to_select`, loops of `crud.create()`.

The remaining sections cover filter syntax (every `__op` suffix, joined filters with `.`, `Depends(...)` filters, `?filter=false` bool coercion), return-value semantics (the `create() → None` default that surprises everyone, `return_as_model=True` requiring `schema_to_select`, v0.22+ type narrowing through subclass `schema_to_select` overrides), soft delete configuration with the explicit "reads do NOT auto-filter" callout, and a 13-item gotchas list ranked by how often we've seen them bite.

Reference files (`methods.md`, `filters.md`, `joins.md`, `pagination.md`, `endpoints.md`) each cover their domain in depth — every method signature with defaults, every operator with value-shape constraints, every `JoinConfig` field, the full `crud_router` parameter reference, and the `EndpointCreator` subclassing pattern with correct private method names.

---

## Accuracy audit

After drafting the skill, we ran a parallel six-agent verification pass against the source. Each agent took a section of the skill and verified every claim — operator names, method signatures, default values, exception conditions, response shapes — against `fastcrud/` source with file:line citations and PASS / FAIL / UNCERTAIN labels.

That pass found 11 substantive inaccuracies, all corrected in the same commit. The biggest were a false "reads automatically filter out soft-deleted rows" claim (no such auto-filter exists in `fastcrud/`), seven wrong `EndpointCreator` method names (the agent had been told `_create_endpoint` etc. but the actual private methods are `_create_item` / `_read_item` / `_read_items` / `_update_item` / `_delete_item` / `_db_delete`, with the override entry point being the **public** `add_routes_to_router`), a wrong `db_delete` URL path (`/db_delete/{id}`, not `/db/{id}`), and several incorrect signatures: `upsert` has no `commit` parameter and does get + create/update (two round-trips, not `ON CONFLICT` — that's `upsert_multi`); `upsert_multi`'s default `commit=False` and has no `ignore_duplicates` parameter; cursor validation is router-side only, not on the direct method; the pagination query param is `?itemsPerPage` (camelCase), not `items_per_page`. Subtler issues — `startswith`/`endswith`/`contains` auto-wrap with `%`, `nest_joins` defaults differ between `crud_router` (`True`) and direct `FastCRUD` methods (`False`), `delete()` filter-path vs `db_row`-path soft-delete column requirements — were also corrected.

**Why:** A skill that ships in the wheel is loaded by every agent using FastCRUD. Wrong information in it is multiplied across every user. The cost of the audit (a few minutes of parallel agent runs) is trivial compared to the cost of agents confidently writing broken code.

---

## Documentation and discoverability

The README gets a Features bullet ("🤖 **Bundled Library Skill**") and a new `## For AI Coding Agents` section between Installing and Usage. The section leads with the install command — `uvx library-skills` for most agents, `uvx library-skills --claude` for Claude Code — because the skill is not auto-discovered without that step. The README explicitly does not claim auto-discovery; the install is required.

A new docs page lives at `docs/library-skill.md`, registered in the zensical nav as a top-level entry between Why FastCRUD and Usage. It covers the install command (tabbed Python/Node.js), what the skill teaches, the file layout, how to verify the install with `/skills` in Claude Code, and a contributing pointer. The `docs/index.md` page mirrors the Features bullet so the docs site landing page calls it out alongside the existing features.

---

## FastroAI marketing block in README

A previous commit on this branch (`35004c8 mention fastroai`) adds a card-style cross-promotion to the README pointing at [FastroAI](https://fastro.ai), the FastAPI SaaS template that uses FastCRUD as its data layer. Two card images (light/dark) live under `docs/assets/`. This is a marketing addition and doesn't affect any code.

---

## Release 0.22.3

Version bumped from 0.22.2 to 0.22.3 in `pyproject.toml`. Changelog entry added with the full feature description, install commands, and what the skill covers. Versioning is a patch because the change is purely additive — the skill files ship inside the wheel but nothing in the import path or public API has changed.

---

## Documentation Updates

**`README.md`:**
- Added Features bullet for the bundled Library Skill
- New `## For AI Coding Agents` section between Installing and Usage with `uvx library-skills` / `uvx library-skills --claude` install commands

**`docs/index.md`:**
- Added Features bullet linking to the new Library Skill page

**`docs/library-skill.md`** *(new)*:
- Dedicated page covering install commands, what the skill teaches, file layout, verification, and contributing

**`zensical.toml`:**
- New nav entry `"Library Skill" = "library-skill.md"` between Why FastCRUD and Usage

**`docs/changelog.md`:**
- v0.22.3 entry

---

## Test Plan

### Automated
- [x] `uv build --wheel` succeeds; all six skill files ship inside `fastcrud-0.22.3-py3-none-any.whl` under `fastcrud/.agents/skills/fastcrud/`
- [x] `uv run mypy . --config-file mypy.ini` clean
- [x] `uv run ruff check .` clean
- [x] `uv run pytest tests/sqlalchemy/ tests/sqlmodel/` clean (no code changes; running for safety)

### Accuracy audit
- [x] 6 parallel verification agents covered SKILL.md gotchas, methods.md, filters.md, joins.md, pagination.md, endpoints.md
- [x] 11 substantive inaccuracies found and corrected (soft-delete auto-filter claim, EndpointCreator method names, `db_delete` path, `upsert`/`upsert_multi` signatures, cursor validation scope, `itemsPerPage` query param, `nest_joins` defaults, `startswith`/`endswith`/`contains` auto-wrap, `delete()` soft-delete path nuance, `exists()` SQL, signature omissions)
- [x] Each fix re-verified directly against `fastcrud/crud/fast_crud.py` and `fastcrud/endpoint/endpoint_creator.py` with grep/Read before committing

### Skill content coverage
- [x] N+1 avoidance covered both ways (auto-detect + manual `JoinConfig`) with the `nested_limit` window-function explanation
- [x] `limit=None` footgun has safe/unsafe examples, three-tier default table, and the Sapari `handle_query_sanity` pattern
- [x] "When NOT to use FastCRUD" maps 7 query shapes to raw SQLAlchemy alternatives
- [x] Anti-patterns list covers the 5 most common refactor-on-sight patterns
- [x] All 20+ filter operators verified against `fastcrud/core/filtering/operators.py`
- [x] `JoinConfig` 11-field table verified against `fastcrud/core/config/join_configs.py`
- [x] `crud_router` 30+ parameter reference verified against `fastcrud/endpoint/crud_router.py`

### Documentation
- [x] `docs/library-skill.md` renders correctly under zensical
- [x] Nav entry shows under "Library Skill" between "Why FastCRUD?" and "Usage"
- [x] README cross-links resolve

### Manual
- [ ] After merge: run `uvx library-skills` in a fresh project with `fastcrud==0.22.3` installed and verify the skill symlink appears under `.agents/skills/fastcrud/`
- [ ] After merge: run `uvx library-skills --claude` in a Claude Code project and verify the skill appears under `/skills` in the chat panel

---

## Dependencies

None new. The Library Skill is consumed by an external CLI (`library-skills`) that users install on demand via `uvx` — FastCRUD itself doesn't depend on it.

## Breaking Changes

None. All changes are additive:

- New directory under `fastcrud/.agents/` that doesn't conflict with any Python import path
- New README section and Features bullet
- New `docs/library-skill.md` page and nav entry
- Patch version bump (0.22.2 → 0.22.3)

No public API changes, no signature changes, no deprecations.
